### PR TITLE
shorter and more legible checklist urls

### DIFF
--- a/apps/gcd/urls.py
+++ b/apps/gcd/urls.py
@@ -183,13 +183,13 @@ urlpatterns = patterns('',
      'apps.gcd.views.search.story_by_credit'),
 
     # Special display pages
-    url(r'^checklist/(?P<creator>.+)/country/(?P<country>.+)/$',
-     'apps.gcd.views.search.checklist', name='checklist'),
-    url(r'^checklist/(?P<creator>.+)/language/(?P<language>.+)/$',
-     'apps.gcd.views.search.checklist', name='checklist'),
-    url(r'^checklist/(?P<creator>.+)/$',
-     'apps.gcd.views.search.checklist', name='checklist'),
-    
+    url(r'^checklist/name/(?P<creator>.+)/country/(?P<country>.+)/$',
+     'apps.gcd.views.search.checklist', name='checklist_for_name'),
+    url(r'^checklist/name/(?P<creator>.+)/language/(?P<language>.+)/$',
+     'apps.gcd.views.search.checklist', name='checklist_for_name'),
+    url(r'^checklist/name/(?P<creator>.+)/$',
+     'apps.gcd.views.search.checklist', name='checklist_for_name'),
+
     # Note that Jobs don't have 'name' in the path, but otherwise work the same.
     (r'^job_number/name/(?P<number>.+)/sort/(?P<sort>.+)/$',
      'apps.gcd.views.search.story_by_job_number_name'),
@@ -269,9 +269,9 @@ urlpatterns += patterns('django.views.generic.simple',
     (r'^graphics/covers/', 'redirect_to', {'url' : None}),
     ('^coversubmit/index.lasso/$', 'redirect_to', {'url' : None}),
     (r'^creator_checklist/name/(?P<creator>.+)/country/(?P<country>.+)/$',
-      'redirect_to', {'url': r'^checklist/%(creator)s/country/%(country)s/$'}),
+      'redirect_to', {'url': r'^checklist/name/%(creator)s/country/%(country)s/$'}),
     (r'^creator_checklist/name/(?P<creator>.+)/language/(?P<language>.+)/$',
-      'redirect_to', {'url': r'^checklist/%(creator)s/language/%(language)s/$'}),
+      'redirect_to', {'url': r'^checklist/name/%(creator)s/language/%(language)s/$'}),
     (r'^creator_checklist/name/(?P<creator>.+)/$',
-      'redirect_to', {'url': r'^checklist/%(creator)s/$'})
+      'redirect_to', {'url': r'^checklist/name/%(creator)s/$'})
 )

--- a/apps/gcd/views/search.py
+++ b/apps/gcd/views/search.py
@@ -411,7 +411,7 @@ def search(request):
                                       'sort': sort }))
 
 
-def checklist(request, creator, country=None, language=None):
+def checklist_for_name(request, creator, country=None, language=None):
     creator = creator.replace('_', ' ').title()
     get = request.GET.copy()
     get[u'target'] = u'issue'


### PR DESCRIPTION
In a conversation with Daniel, the checklist urls came up and since they seemed a bit cumbersome this could make them more memorable and/or human-readable. So people can just use "comics.org/checklist/Arthur_Adams" instead of "comics.org/creator_checklist/name/Arthur%20Adams".
