### PR TITLE
add country filter to search

### DIFF
--- a/apps/gcd/search_indexes.py
+++ b/apps/gcd/search_indexes.py
@@ -45,7 +45,7 @@ class IssueIndex(ObjectIndex, indexes.SearchIndex, indexes.Indexable):
     sort_code = indexes.IntegerField(model_attr='sort_code', indexed=False)
     year = indexes.IntegerField()
     country = indexes.CharField(model_attr='series__country__code',
-                                indexed=False)
+                                faceted=True, indexed=False)
     language = indexes.CharField(model_attr='series__language__code',
                                  indexed=False)
 
@@ -78,7 +78,8 @@ class SeriesIndex(ObjectIndex, indexes.SearchIndex, indexes.Indexable):
 
     sort_name = indexes.CharField(model_attr='sort_name', indexed=False)
     year = indexes.IntegerField()
-    country = indexes.CharField(model_attr='country__code', indexed=False)
+    country = indexes.CharField(model_attr='country__code',  faceted=True,
+                                indexed=False)
     language = indexes.CharField(model_attr='language__code', indexed=False)
     title_search = indexes.CharField()
 
@@ -112,7 +113,7 @@ class StoryIndex(ObjectIndex, indexes.SearchIndex, indexes.Indexable):
     type = indexes.CharField(model_attr='type__name', indexed=False)
     year = indexes.IntegerField()
     country = indexes.CharField(model_attr='issue__series__country__code',
-                                indexed=False)
+                                faceted=True, indexed=False)
     language = indexes.CharField(model_attr='issue__series__language__code',
                                  indexed=False)
 
@@ -150,7 +151,8 @@ class PublisherIndex(ObjectIndex, indexes.SearchIndex, indexes.Indexable):
 
     sort_name = indexes.CharField(model_attr='name', indexed=False)
     year = indexes.IntegerField()
-    country = indexes.CharField(model_attr='country__code', indexed=False)
+    country = indexes.CharField(model_attr='country__code', faceted=True,
+                                indexed=False)
 
     def get_model(self):
         return Publisher
@@ -170,7 +172,8 @@ class IndiciaPublisherIndex(ObjectIndex, indexes.SearchIndex,
 
     sort_name = indexes.CharField(model_attr='name', indexed=False)
     year = indexes.IntegerField()
-    country = indexes.CharField(model_attr='country__code', indexed=False)
+    country = indexes.CharField(model_attr='country__code', faceted=True,
+                                indexed=False)
 
     def get_model(self):
         return IndiciaPublisher
@@ -208,7 +211,7 @@ class BrandGroupIndex(ObjectIndex, indexes.SearchIndex, indexes.Indexable):
     sort_name = indexes.CharField(model_attr='name', indexed=False)
     year = indexes.IntegerField()
     country = indexes.CharField(model_attr='parent__country__code',
-                                indexed=False)
+                                faceted=True, indexed=False)
 
     def get_model(self):
         return BrandGroup

--- a/apps/gcd/templatetags/credits.py
+++ b/apps/gcd/templatetags/credits.py
@@ -286,7 +286,9 @@ def show_country_info(country, name=None):
     title = u'title="%s"' % esc(name)
     return mark_safe(u'%s %s %s' % (src, alt, title))
 
-def get_country_flag(country):
+def get_country_flag(country, given_code=False):
+    if given_code:
+        country = Country.objects.get(code=country)
     return mark_safe(u'<img %s '\
            'class="embedded_flag">' \
            % show_country_info(country))

--- a/apps/gcd/urls.py
+++ b/apps/gcd/urls.py
@@ -259,7 +259,7 @@ urlpatterns = patterns('',
 )
 
 # haystack search
-sqs = GcdSearchQuerySet().facet('facet_model_name')
+sqs = GcdSearchQuerySet().facet('facet_model_name').facet('country')
 
 urlpatterns += patterns('haystack.views',
                         url(r'^searchNew/', search_view_factory(

--- a/apps/gcd/views/search_haystack.py
+++ b/apps/gcd/views/search_haystack.py
@@ -127,14 +127,18 @@ class PaginatedFacetedSearchView(FacetedSearchView):
         elif self.sort == 'year':
             self.results = self.results.order_by('year',
                                                  '-_score')
-        elif len(self.form.selected_facets) == 1:
+        elif len(self.form.selected_facets) >= 1:
             if self.sort:
-                if self.form.selected_facets[0] in \
-                  [u'facet_model_name_exact:publisher',
-                   u'facet_model_name_exact:indicia publisher',
-                   u'facet_model_name_exact:brand group',
-                   u'facet_model_name_exact:brand emblem',
-                   u'facet_model_name_exact:series']:
+                if (u'facet_model_name_exact:publisher' \
+                  in self.form.selected_facets) or \
+                  (u'facet_model_name_exact:indicia publisher'
+                  in self.form.selected_facets) or \
+                  (u'facet_model_name_exact:brand group'
+                  in self.form.selected_facets) or \
+                  (u'facet_model_name_exact:brand emblem'
+                  in self.form.selected_facets) or \
+                  (u'facet_model_name_exact:series'
+                  in self.form.selected_facets):
                     if request.GET['sort'] == 'alpha':
                         self.results = self.results.order_by('sort_name',
                                                              'year')
@@ -176,11 +180,19 @@ class PaginatedFacetedSearchView(FacetedSearchView):
         if suggestion == self.get_query().lower():
             suggestion = u''
         facet_page = ''
+        is_model_selected = False
+        is_country_selected = False
         if self.form.selected_facets:
             for facet in self.form.selected_facets:
                 facet_page += '&selected_facets=%s' % facet
+                if u'facet_model_name_exact:' in facet:
+                    is_model_selected = True
+                elif u'country_exact:' in facet:
+                    is_country_selected = True
         extra.update({'suggestion': suggestion,
-                     'facet_page': facet_page})
+                     'facet_page': facet_page,
+                     'is_model_selected': is_model_selected,
+                     'is_country_selected': is_country_selected})
         if self.sort:
             extra.update({'sort': '&sort=%s' % self.sort})
         else:

--- a/static/css/gcd/default.css
+++ b/static/css/gcd/default.css
@@ -15,6 +15,15 @@ body {
     float: right;
 }
 
+#RightSearchColumn {
+    margin-left : 100px;
+}
+
+#LeftSearchColumn {
+    float : left;
+    width : 95px;
+}
+
 /*
  * This is intended to be so horribly, jarringly unatractive that
  * you can't possibly fail to notice it.

--- a/templates/search/search.html
+++ b/templates/search/search.html
@@ -10,8 +10,6 @@
         href="{% static "css/gcd/default.css" %}"/>
 {% endblock %}
 {% block view_body %}
-  <h2>Search</h2>
-
   <form method="get" action=".">
       <p>
         <label for="id_q">Search for:</label>
@@ -35,15 +33,15 @@
     {% if query and paginator.count > 0 %}
       <h1 class="item_id search_id">Search Results:
         <div class="right">Order:
-        {% if form.selected_facets|length == 1 %}
+        {% if is_model_selected %}
           {% if sort %}<a href="?{{ query }}{{ facet_page }}">Relevance</a>{% else %}Relevance{% endif %} |
           {% if 'alpha' not in sort %}<a href="?{{ query }}{{ facet_page }}&sort=alpha">Alpha</a>{% else %}Alpha{%endif %} |
           {% if 'chrono' not in sort %}<a href="?{{ query }}{{ facet_page }}&sort=chrono">Chrono</a>{% else %}Chrono{%endif %} |
           {% if 'country' not in sort %}<a href="?{{ query }}{{ facet_page }}&sort=country">Country</a>{% else %}Country{%endif %}
         {% else %}
-          {% if sort %}<a href="?{{ query }}">Relevance</a>{% else %} Relevance{% endif %} |
-          {% if 'year' not in sort %}<a href="?{{ query }}&sort=year">Year</a>{% else %}Year{% endif %} |
-          {% if 'country' not in sort %}<a href="?{{ query }}&sort=country">Country</a>{% else %}Country{%endif %}
+          {% if sort %}<a href="?{{ query }}{{ facet_page }}">Relevance</a>{% else %} Relevance{% endif %} |
+          {% if 'year' not in sort %}<a href="?{{ query }}{{ facet_page }}&sort=year">Year</a>{% else %}Year{% endif %} |
+          {% if 'country' not in sort %}<a href="?{{ query }}{{ facet_page }}&sort=country">Country</a>{% else %}Country{%endif %}
         {% endif %}
         </div>
       </h1>
@@ -62,7 +60,7 @@
       {% if facets.fields.facet_model_name %}
         <ul>
           {% for model in facets.fields.facet_model_name %}
-            <li><a href="?{{ query }}{% if request.GET.models %}&amp;models={{ request.GET.models }}{% endif %}&amp;selected_facets=facet_model_name_exact:{{ model.0|urlencode }}">{{ model.0 }}</a> ({{ model.1 }})</li>
+            <li><a href="?{{ query }}{{ facet_page }}{% if not is_model_selected %}&amp;selected_facets=facet_model_name_exact:{{ model.0|urlencode }}{% endif %}">{{ model.0 }}</a> ({{ model.1 }})</li>
           {% endfor %}
         </ul>
       {% endif %}
@@ -80,6 +78,20 @@
       issue number.
       </div>
       {% endif %}
+      <div id="Container">
+      <div id="LeftSearchColumn">
+        <table class="listing left">
+          <tr>
+            <th>Country</th>
+          </tr>
+      {% for country in facets.fields.country %}
+            <tr class="{% cycle 'listing_even' 'listing_odd' %}">
+          <td><a href="?{{ query }}{{ facet_page }}{% if not is_country_selected %}&amp;selected_facets=country_exact:{{ country.0|urlencode }}{% endif %}">{{ country.0|get_country_flag:1 }} ({{ country.1}})</a>
+          </td></tr>
+      {% endfor %}
+        </table>
+      </div>
+      <div id="RightSearchColumn">
       <div class="left">
         <table class="listing left">
           <tr>
@@ -104,7 +116,7 @@
                 </form>
                 {% endif %}
               {% endif %}
-              </td>
+              </td></tr>
             {% endif %}
             {% if result.model_name == 'series' %}
                 <td>[SERIES]</td>
@@ -154,9 +166,11 @@
         </table>
       </div>
       <div class="right">
-        {% if ADVERTISING and not BETA %}
+        {% if ADVERTISING and not BETA and USE_TEMPLATESADMIN %}
           {% include "managed_content/gcd/ads/ad_skyscraper.html" %}
         {% endif %}
+      </div>
+      </div> <!-- #RightSearchColumn -->
       </div>
       {% if select_key and multiple_selects %}
       <div style="clear: both;"></div>


### PR DESCRIPTION
We can use facets to add further filters to search results without too much effort, it seems.

Add these step-by-step, need to check and see if further filters nicely interact and if our bit of django- and template-code is fine with it.

Start with country, which would be the most important one. Make sure it behaves nice on the production environment.

Then language (wikipedia-style), then maybe others (year ?).