### PR TITLE
mycomics: remember last added-to collection

### DIFF
--- a/apps/mycomics/views.py
+++ b/apps/mycomics/views.py
@@ -522,6 +522,7 @@ def add_issues_to_collection(request, collection_id, issues, redirect,
         collected = create_collection_item(issue, collection)
         if post_process_selection:
             post_process_selection(collected)
+    request.session['collection_id'] = collection_id
     return HttpResponseRedirect(redirect)
 
 
@@ -537,6 +538,7 @@ def add_single_issue_to_collection(request, issue_id):
                                "'%s' collection." % \
                               (collected.get_absolute_url(collection),
                                esc(issue), esc(collection.name)))
+    request.session['collection_id'] = collection.id
     return HttpResponseRedirect(urlresolvers.reverse('show_issue',
                                   kwargs={'issue_id': issue_id}))
 

--- a/templates/404.html
+++ b/templates/404.html
@@ -17,7 +17,7 @@ Page not found
 </h1>
 <div class="item_id">
 <div class="left">
-Looks like you followed a bad link. If you think it's our fault, please <a href="https://github.com/GrandComicsDatabase/gcd-django/issues/new?body=Occurred+at+{{ request.build_absolute_uri }}">let us know.</a>
+Looks like you followed a bad link. If you think it's our fault, please <a href="https://github.com/GrandComicsDatabase/gcd-django/issues/new?body=Occurred+at+{{ request.build_absolute_uri|urlencode }}">let us know.</a>
 </div>
 </div>
 &nbsp;

--- a/templates/404.html
+++ b/templates/404.html
@@ -17,7 +17,7 @@ Page not found
 </h1>
 <div class="item_id">
 <div class="left">
-Looks like you followed a bad link. If you think it's our fault, please <a href="http://dev.comics.org/bugs/enter_bug.cgi?product=GCD Online&bug_file_loc={{ request.build_absolute_uri }}">let us know.</a>
+Looks like you followed a bad link. If you think it's our fault, please <a href="https://github.com/GrandComicsDatabase/gcd-django/issues/new?body=Occurred+at+{{ request.build_absolute_uri }}">let us know.</a>
 </div>
 </div>
 &nbsp;

--- a/templates/500.html
+++ b/templates/500.html
@@ -6,7 +6,7 @@
   <link rel="shortcut icon" href="{% static "img/favicon.ico" %}">
 </head>
 <h2>Internal Server Error</h2>
-Something is wrong. We don't really know what.<br/> If the problem persists please <a href="https://github.com/GrandComicsDatabase/gcd-django/issues/new?body=Occurred+at+{{ request.build_absolute_uri }}">let us know.</a>
+Something is wrong. We don't really know what.<br/> If the problem persists please <a href="https://github.com/GrandComicsDatabase/gcd-django/issues/new?body=Occurred+at+{{ request.build_absolute_uri|urlencode }}">let us know.</a>
 <body>
 </body>
 </html>

--- a/templates/500.html
+++ b/templates/500.html
@@ -6,7 +6,7 @@
   <link rel="shortcut icon" href="{% static "img/favicon.ico" %}">
 </head>
 <h2>Internal Server Error</h2>
-Something is wrong. We don't really know what.<br/> If the problem persists please <a href="http://dev.comics.org/bugs/enter_bug.cgi?product=GCD Online&bug_file_loc={{ request.build_absolute_uri }}">let us know.</a>
+Something is wrong. We don't really know what.<br/> If the problem persists please <a href="https://github.com/GrandComicsDatabase/gcd-django/issues/new?body=Occurred+at+{{ request.build_absolute_uri }}">let us know.</a>
 <body>
 </body>
 </html>

--- a/templates/mycomics/bits/issue_control.html
+++ b/templates/mycomics/bits/issue_control.html
@@ -21,7 +21,7 @@
     this issue to your 
     <select name="collection_id">
     {% for col_item in request.user.collector.ordered_collections %}
-      <option value="{{ col_item.id }}">{{ col_item.name }}
+      <option value="{{ col_item.id }}" {% if request.session.collection_id == col_item.id %}selected{% endif %}>{{ col_item.name }}
     {% endfor %}
     </select>
   </div>

--- a/templates/mycomics/bits/series_control.html
+++ b/templates/mycomics/bits/series_control.html
@@ -52,7 +52,7 @@ to add to a collection.
     <br> (without variants) to your 
     <select name="collection_id">
   {% for col_item in request.user.collector.ordered_collections %}
-      <option value="{{ col_item.id }}">{{ col_item.name }}</option>
+      <option value="{{ col_item.id }}" {% if request.session.collection_id == col_item.id %}selected{% endif %}>{{ col_item.name }}</option>
   {% endfor %}
     </select>
   </div>


### PR DESCRIPTION
When adding issues in my.comics.org, one often adds several different ones to one collection in a row. If it is not the first one, one always needs to re-select it. We now remember it and pre-select it on the issue and series pages. Maybe later also add this to selecting issues via the searches ?

Also: Point the link on 404/500 pages to github #277 