### PR TITLE
add advanced search filter for sequences not being a reprint

### DIFF
--- a/apps/gcd/forms/search.py
+++ b/apps/gcd/forms/search.py
@@ -156,8 +156,8 @@ class AdvancedSearch(forms.Form):
                                         required=False)
     issue_reprinted = forms.NullBooleanField(label="Reprinted", required=False,
       widget=forms.Select(choices=((None, ""),
-                                   (True, "From"),
-                                   (False, "In"))))
+                                   (True, "has issue level sources"),
+                                   (False, "has issue level targets"))))
 
     cover_needed = forms.BooleanField(label="Cover is Needed",
                                        required=False)
@@ -203,10 +203,11 @@ class AdvancedSearch(forms.Form):
     characters = forms.CharField(required=False)
     synopsis = forms.CharField(required=False)
     reprint_notes = forms.CharField(label='Reprint Notes', required=False)
-    story_reprinted = forms.NullBooleanField(label="Reprinted", required=False,
-      widget=forms.Select(choices=((None, ""),
-                                   (True, "From"),
-                                   (False, "In"))))
+    story_reprinted = forms.ChoiceField(label="Reprinted", required=False,
+      choices=[('', ""),
+               ('from', "is a linked reprint"),
+               ('in', "has linked reprints"),
+               ('not', "is not a linked reprint")])
 
     notes = forms.CharField(label='Notes', required=False)
 

--- a/apps/gcd/views/search.py
+++ b/apps/gcd/views/search.py
@@ -1263,14 +1263,16 @@ def search_stories(data, op):
         q_objs.append(Q(**{ '%sediting__%s' % (prefix, op):
                             data['story_editing'] }))
 
-    if data['story_reprinted'] is not None:
-        if data['story_reprinted'] == True:
+    if data['story_reprinted'] != '':
+        if data['story_reprinted'] == 'from':
             q_objs.append(Q(**{ '%sfrom_reprints__isnull' % prefix: False }) | \
                    Q(**{ '%sfrom_issue_reprints__isnull' % prefix: False }))
-        else:
+        elif data['story_reprinted'] == 'in':
             q_objs.append(Q(**{ '%sto_reprints__isnull' % prefix: False }) | \
                    Q(**{ '%sto_issue_reprints__isnull' % prefix: False }))
-
+        elif data['story_reprinted'] == 'not':
+            q_objs.append(Q(**{ '%sfrom_reprints__isnull' % prefix: True }) & \
+                   Q(**{ '%sfrom_issue_reprints__isnull' % prefix: True }))
     try:
         if data['pages'] is not None and data['pages'] != '':
             range_match = match(PAGE_RANGE_REGEXP, data['pages'])


### PR DESCRIPTION
as tested on beta with short feedback on main

filter for issue level reprints fills a different role, so not adding this there to avoid confusion (no existing issue level reprint links can still mean issue is a linked reprint via the stories)