### PR TITLE
add native name for languages

### DIFF
--- a/apps/stddata/migrations/0003_language_native_name.py
+++ b/apps/stddata/migrations/0003_language_native_name.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('stddata', '0002_initial_data'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='language',
+            name='native_name',
+            field=models.CharField(max_length=255, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/apps/stddata/models.py
+++ b/apps/stddata/models.py
@@ -108,6 +108,7 @@ class Language(models.Model):
 
     code = models.CharField(max_length=10, unique=True)
     name = models.CharField(max_length=255, db_index=True)
+    native_name = models.CharField(max_length=255, blank=True)
 
     def natural_key(self):
         """

--- a/static/css/gcd/default.css
+++ b/static/css/gcd/default.css
@@ -130,6 +130,11 @@ div.stats_content {
     padding-left: 8px;
 }
 
+div.stats_header {
+    padding-left: 8px;
+    line-height: 1.5em;
+}
+
 /* Item ID stuff */
 
 .item_id {

--- a/templates/gcd/status/international_stats.html
+++ b/templates/gcd/status/international_stats.html
@@ -1,6 +1,6 @@
 {% extends "gcd/base_view.html" %}
 
-{% load url from future %}
+{% load cycle from future %}
 {% load staticfiles %}
 {% load humanize %}
 {% load i18n %}
@@ -24,8 +24,8 @@ Statistics by {{ type }}, ordered by number of
 {% for object, stats_for_object in stats %}
 <div class="{% cycle 'stats_left' 'stats_right'%}">
         <h3 class="item_id">
-        <div class='stats_content'>
-            Statistics for Comics {% if type == 'country' %} published in <img style="vertical-align:middle" src="{{ STATIC_URL }}/img/gcd/flags/{{ object.code|lower }}.png" alt="{{ object }}">{% else %} in {% endif %} <a href="{% url "process_advanced_search" %}?target=series&method=icontains&logic=False&order1=series&order2=date&order3=&{{ type }}={{ object.code }}">{{ object }}</a>
+        <div class='stats_header'>
+            Statistics for Comics {% if type == 'country' %} published in <img style="vertical-align:middle" src="{{ STATIC_URL }}/img/gcd/flags/{{ object.code|lower }}.png" alt="{{ object }}">{% else %} in {% endif %} <a href="{% url "process_advanced_search" %}?target=series&method=icontains&logic=False&order1=series&order2=date&order3=&{{ type }}={{ object.code }}">{{ object }}{% if object.native_name %} ({{ object.native_name }}) {% endif %}</a>
         </div>
         </h3>
         <div class='stats_content'>


### PR DESCRIPTION
Also use it on the language stats page, where we also import cycle from future to avoid a deprecation warning.
