### PR TITLE
migration using two histories

### DIFF
--- a/apps/legacy/tools/history/__init__.py
+++ b/apps/legacy/tools/history/__init__.py
@@ -7,12 +7,22 @@ from apps.gcd.models.publisher import Publisher
 from apps.indexer.models import Indexer
 from apps.oi.models import *
 
+LATEST_OLD_SITE = 'latest_old_site'
+EARLIEST_OLD_SITE = 'earliest_old_site'
+
+EARLIEST_DATA_DATE = datetime.datetime(2004,9,1,0,0)
+
 COMMENT_TEXT = """This change history was migrated from the old site."""
 COMMENT_TEXT_FOR_ADD = """
 This is the oldest change we have for this object, so it shows as the addition.
 However, it may just be the state of the object at the time when the data was
 first imported into the old site circa %s.
 """ % settings.OLD_SITE_CREATION_DATE
+COMMENT_TEXT_FOR_ADD_LATER = """
+This is the oldest change we have for this object, so it shows as the addition.
+If was added sometime after %s, and is likely close in time to the next change
+with an actual date. 
+"""  % EARLIEST_DATA_DATE
 
 class MigratoryTable(models.Model):
     class Meta:
@@ -35,7 +45,7 @@ class LogRecord(models.Model):
     Modified = models.DateField(db_column='modified_new', db_index=True)
     ModTime = models.TimeField(db_column='modtime_new', db_index=True)
     UserID = models.IntegerField(db_column='userid_new')
-    User = models.ForeignKey('gcd.Indexer', db_column='userid_new')
+    User = models.ForeignKey('indexer.Indexer', db_column='userid_new')
     is_add = models.BooleanField(default=False, db_index=True)
     is_duplicate = models.BooleanField(default=False, db_index=True)
     old_user_id = models.IntegerField(db_column='UserID')
@@ -149,7 +159,7 @@ class LogRecord(models.Model):
         return None
 
     @classmethod
-    def migrate(klass, anon):
+    def migrate(klass, anon, use_earlier_data=False):
         table_name = klass._meta.db_table
 
         # Migrate in order so that IMPs can be calculated- for any change,
@@ -182,9 +192,12 @@ class LogRecord(models.Model):
                 #changeset = change.create_changeset(anon)
                 #change.create_revision(changeset, anon)
 
-    def create_changeset(self, anon):
+    def create_changeset(self, anon, user=None):
         # create changeset
-        indexer_user=self.User.user
+        if user:
+            indexer_user=Indexer.objects.get(id=user).user
+        else:
+            indexer_user=self.User.user
         ctype = self.ctype
 
         # self.dt_inferred may be None so we can't just assign it as is.
@@ -200,6 +213,12 @@ class LogRecord(models.Model):
         # Circumvent automatic field behavior.
         # all dates and times guaranteed to be valid
         mc = MigratoryChangeset.objects.get(id=changeset.id)
+#        if user: # use_earlier_data
+#            if self.dt < EARLIEST_DATA_DATE:
+#                mc.created = EARLIEST_DATA_DATE
+#            else:
+#                mc.created = self.dt
+#        else:
         mc.created = self.dt
         mc.modified = mc.created
         mc.save()
@@ -207,7 +226,10 @@ class LogRecord(models.Model):
 
         comment_text = COMMENT_TEXT
         if self.is_add:
-            comment_text += COMMENT_TEXT_FOR_ADD
+            if user:
+                comment_text += COMMENT_TEXT_FOR_ADD_LATER
+            else:
+                comment_text += COMMENT_TEXT_FOR_ADD
 
         changeset.comments.create(commenter=indexer_user,
                                   text=comment_text,

--- a/apps/legacy/tools/history/issue.py
+++ b/apps/legacy/tools/history/issue.py
@@ -7,7 +7,8 @@ from django.contrib.auth.models import User
 from apps.gcd.models.publisher import Publisher
 from apps.indexer.models import Indexer
 from apps.oi.models import *
-from apps.legacy.tools.history import MigratoryTable, LogRecord
+from apps.legacy.tools.history import MigratoryTable, LogRecord, \
+                       EARLIEST_OLD_SITE, LATEST_OLD_SITE, EARLIEST_DATA_DATE
 from apps.legacy.tools.history.story import MigratoryStoryRevision, LogStory
 
 EPSILON = timedelta(5, 0, 0) # Five days
@@ -55,9 +56,17 @@ class LogIssue(LogRecord):
                 'Price collate utf8_bin, Key_Date, Issue collate utf8_bin, IssueID')
 
     @classmethod
-    def alter_table(klass, anon):
-        cursor = connection.cursor()
-        cursor.execute("""
+    def alter_table(klass, anon, database):
+        if database == EARLIEST_OLD_SITE:
+            cursor = connection.cursor()
+            cursor.execute("""
+ALTER TABLE log_issue
+    %s,
+    ADD INDEX (IssueID);
+""" % klass._common_alter_clauses())
+        else:
+            cursor = connection.cursor()
+            cursor.execute("""
 ALTER TABLE log_issue
     DROP COLUMN IP,
     %s,
@@ -70,8 +79,8 @@ INSERT INTO log_issue
         (VolumeNum, SeriesID, Pub_Date, Price, Key_Date, Issue, IssueID, UserID)
     SELECT
         VolumeNum, SeriesID, Pub_Date, Price, Key_Date, Issue, ID, %d
-    FROM GCDOnline.issues;
-""" % anon.id)
+    FROM %s.issues;
+""" % (anon.id, database))
 
     @classmethod
     def fix_values(klass, anon, unknown_country, undetermined_language):
@@ -85,6 +94,7 @@ DELETE li.* FROM log_issue li LEFT OUTER JOIN gcd_series gs ON li.SeriesID = gs.
     WHERE gs.id IS NULL;
 UPDATE log_issue SET key_date = REPLACE(key_date, '.', '-');
 """)
+        cursor.close()
         klass.objects.filter(Pub_Date__isnull=True).update(Pub_Date='')
         klass.objects.filter(Key_Date__isnull=True).update(Key_Date='')
         klass.objects.filter(Price__isnull=True).update(Price='')
@@ -109,9 +119,12 @@ UPDATE log_issue SET key_date = REPLACE(key_date, '.', '-');
                              dt_inferred=True)
 
     @classmethod
-    def migrate(klass, anon):
+    def migrate(klass, anon, use_earlier_data=False):
+        from apps.legacy.tools.history.old_models import OldIssue, OldStory
         issue_history = klass.objects.order_by('IssueID', 'dt')
         related = klass.get_related()
+
+        #issue_history = issue_history.filter(IssueID=174591)#541088)#205)
 
         if related is not None:
             issue_history = issue_history.filter(is_duplicate=False)\
@@ -123,13 +136,13 @@ UPDATE log_issue SET key_date = REPLACE(key_date, '.', '-');
         attached_stories = {}
         last_user = None
         last_dt = None
+        adding_user = None
         icounter = 1
         scounter = 1
         for i in issue_history.iterator():
             if icounter % 1000 == 1:
                 logging.info("Issue record %d" % icounter)
             icounter += 1
-
 
             # Find the stories, if any, that precede this issue.  We will
             # process them first, then the issue.  This allows us to properly
@@ -139,8 +152,30 @@ UPDATE log_issue SET key_date = REPLACE(key_date, '.', '-');
             story_set = LogStory.objects.filter(is_duplicate=False)\
                                         .filter(DisplayIssue=i.DisplayIssue)\
                                         .filter(dt__lt=i.dt)
-            if last_i is not None and last_i.IssueID == i.IssueID:
-                story_set = story_set.filter(dt__gte=last_i.dt)
+            if not use_earlier_data:
+                if last_i is not None and last_i.IssueID == i.IssueID:
+                    story_set = story_set.filter(dt__gte=last_i.dt)
+            else:
+                if last_i is not None and last_i.IssueID == i.IssueID:
+                    story_set = story_set.filter(dt__gte=last_i.dt)
+                else:
+                    # issue with stories exists in dump from 2004-08
+                    # do this once per issue
+                    story_existed = OldStory.objects.using('earliest_old_site').filter(\
+                        issue_id=i.IssueID).exists()
+                    #revision_exists = StoryRevision.objects.filter(issue_id=i.IssueID, created__lt=EARLIEST_DATA_DATE).exists()
+                if not story_existed and story_set.exists():
+                    # stories created after 2004-08, make assumption on indexer
+                    # i.e. assume anon-stories with no time belong to 
+                    # first actual indexer, determined from the issue-logs
+                    anon_story_set = story_set.filter(UserID=anon.id, Modified__lt=datetime.date(2002,1,2))
+                    for s in anon_story_set.order_by('dt').select_related(*story_related):
+                        attached_stories[s.StoryID] = s
+                        last_dt = s.dt
+                    objects = klass.objects.order_by('IssueID', 'dt').filter(IssueID=i.IssueID).exclude(UserID=anon.id)
+                    if objects.exists():
+                        adding_user = objects[0].UserID
+                    story_set = story_set.exclude(UserID=anon.id, Modified__lt=datetime.date(2002,1,2))
 
             for s in story_set.order_by('dt').select_related(*story_related):
                 if scounter % 5000 == 1:
@@ -152,12 +187,21 @@ UPDATE log_issue SET key_date = REPLACE(key_date, '.', '-');
                     # Same story, but a different user, and at least one of
                     # the current objects needs saving.  So save under the old
                     # user and mark all stories as clean.
-                    klass.gather_changeset(last_i, attached_stories, anon)
-
+                    if not use_earlier_data:
+                        klass.gather_changeset(last_i, attached_stories, anon)
+                    else:
+                        klass.gather_changeset(last_i, attached_stories, anon, 
+                                               adding_user)
+                        adding_user = None
                 elif last_dt is not None and s.dt > last_dt + EPSILON:
                     # Same story, same user, but there's a large gap, so treat
                     # it as a new change.
-                    klass.gather_changeset(last_i, attached_stories, anon)
+                    if not use_earlier_data:
+                        klass.gather_changeset(last_i, attached_stories, anon)
+                    else:
+                        klass.gather_changeset(last_i, attached_stories, anon, 
+                                               adding_user)
+                        adding_user = None
 
                 # Either there was no old story, or we saved it, or
                 # we determined that it can be supplanted by this one
@@ -185,12 +229,22 @@ UPDATE log_issue SET key_date = REPLACE(key_date, '.', '-');
                         # Same story, but a different user, and at least one of
                         # the current objects needs saving.  So save under the old
                         # user and mark all stories as clean.
-                        klass.gather_changeset(last_i, attached_stories, anon)
+                        if not use_earlier_data:
+                            klass.gather_changeset(last_i, attached_stories, anon)
+                        else:
+                            klass.gather_changeset(last_i, attached_stories, anon, 
+                                                   adding_user)
+                            adding_user = None
 
                     elif last_dt is not None and s.dt > last_dt + EPSILON:
                         # Same story, same user, but there's a large gap, so treat
                         # it as a new change.
-                        klass.gather_changeset(last_i, attached_stories, anon)
+                        if not use_earlier_data:
+                            klass.gather_changeset(last_i, attached_stories, anon)
+                        else:
+                            klass.gather_changeset(last_i, attached_stories, anon, 
+                                                   adding_user)
+                            adding_user = None
 
                     # Either there was no old story, or we saved it, or
                     # we determined that it can be supplanted by this one
@@ -199,16 +253,31 @@ UPDATE log_issue SET key_date = REPLACE(key_date, '.', '-');
                     last_user = s.UserID
                     last_dt = s.dt
 
-                klass.gather_changeset(last_i, attached_stories, anon)
+                if not use_earlier_data:
+                    klass.gather_changeset(last_i, attached_stories, anon)
+                else:
+                    klass.gather_changeset(last_i, attached_stories, anon, 
+                                           adding_user)
+                    adding_user = None
                 attached_stories = {}
 
             elif last_user is not None and i.UserID != last_user:
                 # Same issue, but a different user.
-                klass.gather_changeset(last_i, attached_stories, anon)
+                if not use_earlier_data:
+                    klass.gather_changeset(last_i, attached_stories, anon)
+                else:
+                    klass.gather_changeset(last_i, attached_stories, anon, 
+                                           adding_user)
+                    adding_user = None
 
             elif last_dt is not None and i.dt > last_dt + EPSILON:
                 # Same issue, same user, but there's a large gap.
-                klass.gather_changeset(last_i, attached_stories, anon)
+                if not use_earlier_data:
+                    klass.gather_changeset(last_i, attached_stories, anon)
+                else:
+                    klass.gather_changeset(last_i, attached_stories, anon, 
+                                           adding_user)
+                    adding_user = None
 
             last_i = i
             last_user = i.UserID
@@ -232,12 +301,22 @@ UPDATE log_issue SET key_date = REPLACE(key_date, '.', '-');
                 # Same story, but a different user, and at least one of
                 # the current objects needs saving.  So save under the old
                 # user and mark all stories as clean.
-                klass.gather_changeset(last_i, attached_stories, anon)
+                if not use_earlier_data:
+                    klass.gather_changeset(last_i, attached_stories, anon)
+                else:
+                    klass.gather_changeset(last_i, attached_stories, anon, 
+                                           adding_user)
+                    adding_user = None
 
             elif last_dt is not None and s.dt > last_dt + EPSILON:
                 # Same story, same user, but there's a large gap, so treat
                 # it as a new change.
-                klass.gather_changeset(last_i, attached_stories, anon)
+                if not use_earlier_data:
+                    klass.gather_changeset(last_i, attached_stories, anon)
+                else:
+                    klass.gather_changeset(last_i, attached_stories, anon, 
+                                           adding_user)
+                    adding_user = None
 
             # Either there was no old story, or we saved it, or
             # we determined that it can be supplanted by this one
@@ -246,17 +325,22 @@ UPDATE log_issue SET key_date = REPLACE(key_date, '.', '-');
             last_user = s.UserID
             last_dt = s.dt
 
-        klass.gather_changeset(last_i, attached_stories, anon)
+        if not use_earlier_data:
+            klass.gather_changeset(last_i, attached_stories, anon)
+        else:
+            klass.gather_changeset(last_i, attached_stories, anon, 
+                                   adding_user)
+            adding_user = None
 
     @classmethod
-    def gather_changeset(klass, issue_record, attached_stories, anon):
+    def gather_changeset(klass, issue_record, attached_stories, anon, user=None):
         records = attached_stories.values()
         if issue_record is not None:
             records.append(issue_record)
         # We want to use the most recent revision for the changeset date+time.
         use_for_changeset = reduce(lambda a, b: a if a.dt >= b.dt else b, records)
 
-        changeset = use_for_changeset.create_changeset(anon)
+        changeset = use_for_changeset.create_changeset(anon, user)
         if issue_record is None:
             # If there was no issue then there will always be at least one story.
             example_story = records[0]

--- a/apps/legacy/tools/history/migrate.py
+++ b/apps/legacy/tools/history/migrate.py
@@ -8,12 +8,14 @@ from apps.gcd.models.publisher import Publisher
 from apps.indexer.models import Indexer
 from apps.oi.models import *
 
-from apps.gcd.migration.history.publisher import MigratoryPublisherRevision, \
+django.setup()
+from apps.legacy.tools.history.publisher import MigratoryPublisherRevision, \
                                                  LogPublisher
-from apps.gcd.migration.history.series import MigratorySeriesRevision, LogSeries
-from apps.gcd.migration.history.issue import MigratoryIssueRevision, LogIssue
+from apps.legacy.tools.history.series import MigratorySeriesRevision, LogSeries
+#from apps.gcd.migration.history.issue_use_earliest import MigratoryIssueRevision, LogIssue
+from apps.legacy.tools.history.issue import MigratoryIssueRevision, LogIssue
 
-def main():
+def main(use_earlier_data=False):
     logging.basicConfig(level=logging.NOTSET,
                         stream=sys.stdout,
                         format='%(asctime)s %(levelname)s: %(message)s')
@@ -23,11 +25,19 @@ def main():
                       #LogSeries,
                       LogIssue,
                      ):
-        log_class.migrate(anon)
+        log_class.migrate(anon, use_earlier_data)
 
         # Commit the changes to the InnoDB tables for each object type.
         transaction.commit_unless_managed()
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     django.setup()
-    main()
+    if len(sys.argv) != 2:
+        print "give 1 (earliest) / 2 latest"
+        sys.exit()
+    if sys.argv[1] == '1':
+        main(use_earlier_data=False)
+    elif sys.argv[1] == '2':
+        main(use_earlier_data=True)
+    else:
+        print "not valid: %s" % sys.argv[1]

--- a/apps/legacy/tools/history/old_models.py
+++ b/apps/legacy/tools/history/old_models.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+from decimal import Decimal
+
+from django.db import models
+
+from series import Series
+from issue import Issue
+from story import Story
+from apps.oi.models import IssueRevision, StoryRevision, StoryType
+from apps.legacy.tools.history.story import MigratoryStoryRevision
+from apps.legacy.tools.history.issue import MigratoryIssueRevision
+
+class OldIssue(models.Model):
+    class Meta:
+        app_label = 'old_gcd_data'
+        #ordering = ['series', 'sort_code']
+        db_table='issues'
+
+    # Issue identification
+    number = models.CharField(db_column='Issue', max_length=50, db_index=True)
+    volume = models.IntegerField(db_column='VolumeNum', db_index=True)
+    book_name = models.CharField(db_column='Bk_Name', max_length=50)
+    pub_name = models.CharField(db_column='Pub_Name', max_length=50)
+
+    story_count = models.IntegerField(db_column='storycount')
+    is_updated = models.IntegerField(db_column='isUpdated')
+    # Dates and sorting
+    publication_date = models.CharField(db_column='Pub_Date', max_length=255)
+    key_date = models.CharField(db_column='Key_Date', max_length=10, db_index=True)
+
+    # Price, page count and format fields
+    price = models.CharField(db_column='Price', max_length=255)
+    page_count = models.DecimalField(db_column='Pg_Cnt', max_digits=10, decimal_places=3, null=True)
+
+    editing = models.TextField(db_column='Editing', )
+    notes = models.TextField(db_column='Notes', )
+
+    series_id = models.IntegerField(db_column='SeriesID')
+
+    modified = models.DateField(db_column='Modified')
+    last_change = models.DateField(db_column='LstChang')
+    modified_time = models.TimeField(db_column='ModTime')
+    created = models.DateField(db_column='created')
+
+    migratory_class = MigratoryIssueRevision
+
+    def convert(self, changeset):
+        if self.volume is None:
+            volume = ''
+        else:
+            volume = '%s' % self.volume
+
+        display_series = Series.objects.get(id=self.series_id)
+
+        if display_series.year_ended and display_series.year_ended < 1970:
+            no_isbn = True
+        else:
+            no_isbn = False
+
+        if display_series.year_ended and display_series.year_ended < 1974:
+            no_barcode = True
+        else:
+            no_barcode = False
+
+        issue = Issue.objects.get(id=self.id)
+
+        if not self.publication_date:
+            self.publication_date = ''
+
+        if not self.key_date:
+            self.key_date = ''
+
+        if not self.price:
+            self.price = ''
+
+        revision = IssueRevision(changeset=changeset,
+                                 issue=issue,
+                                 number=self.number,
+                                 volume=volume,
+                                 series=display_series,
+                                 publication_date=self.publication_date,
+                                 key_date=self.key_date.replace('.', '-'),
+                                 price=self.price,
+                                 no_barcode=no_barcode,
+                                 no_isbn=no_isbn,
+                                 date_inferred=changeset.date_inferred)
+        revision.save()
+        return revision
+
+class OldStory(models.Model):
+    class Meta:
+        app_label = 'old_gcd_data'
+        db_table='stories'
+
+    title = models.CharField(db_column='Title', max_length=255)
+    feature = models.CharField(db_column='Feature', max_length=255)
+    type = models.CharField(db_column='Type')
+    sequence_number = models.IntegerField(db_column='Seq_No')
+
+    page_count = models.DecimalField(db_column='Pg_Cnt', max_digits=10, decimal_places=3, null=True)
+#models.IntegerField(db_column='Pg_Cnt')
+    script = models.TextField(db_column='Script')
+    pencils = models.TextField(db_column='Pencils')
+    inks = models.TextField(db_column='Inks')
+    colors = models.TextField(db_column='Colors')
+    letters = models.TextField(db_column='Letters')
+    editing = models.TextField(db_column='Editing')
+
+    job_number = models.CharField(db_column='JobNo')
+    genre = models.CharField(db_column='Genre')
+    characters = models.TextField(db_column='Char_App')
+    synopsis = models.TextField(db_column='Synopsis')
+    reprint_notes = models.TextField(db_column='Reprints')
+    notes = models.TextField(db_column='Notes')
+
+    # Fields from issue.
+    issue = models.ForeignKey(OldIssue, db_column='IssueId')
+
+    # Fields related to change management.
+    created = models.DateField(db_column='Created')
+    modified = models.DateField(db_column='Modified')
+    modified_time = models.TimeField(db_column='Modtime')
+    migratory_class = MigratoryStoryRevision
+
+    def convert(self, changeset):
+        from apps.gcd.migration.history.migrate_status import convert_story_type
+        # Fix types
+        story_type = convert_story_type(self)
+
+        if Story.objects.filter(id=self.id).exists():
+            story_id = self.id
+        else:
+            story_id = None
+
+        try:
+            page_count = float(self.page_count)
+        except:
+            page_count = None
+
+        revision = StoryRevision(changeset=changeset,
+                                 story_id=story_id,
+                                 issue_id=self.issue_id,
+                                 sequence_number=self.sequence_number,
+                                 title=self.title,
+                                 feature=self.feature,
+                                 type=story_type,
+                                 page_count=page_count,
+                                 script=self.script,
+                                 pencils=self.pencils,
+                                 inks=self.inks,
+                                 colors=self.colors,
+                                 letters=self.letters,
+                                 editing=self.editing,
+                                 genre=self.genre,
+                                 characters=self.characters,
+                                 synopsis=self.synopsis,
+                                 reprint_notes=self.reprint_notes,
+                                 job_number=self.job_number,
+                                 notes=self.notes)
+        revision.save()
+        return revision
+

--- a/apps/legacy/tools/history/prepare.py
+++ b/apps/legacy/tools/history/prepare.py
@@ -7,7 +7,7 @@ from django.contrib.auth.models import User
 from apps.gcd.models.publisher import Publisher
 from apps.indexer.models import Indexer
 from apps.oi.models import *
-
+django.setup()
 #from apps.legacy.tools.history.publisher import MigratoryPublisherRevision, \
 #                                                 LogPublisher
 #from apps.legacy.tools.history.series import MigratorySeriesRevision, LogSeries
@@ -17,8 +17,9 @@ from apps.legacy.tools.history.publisher import LogPublisher
 from apps.legacy.tools.history.series import LogSeries
 from apps.legacy.tools.history.issue import LogIssue
 from apps.legacy.tools.history.story import LogStory
+from apps.legacy.tools.history import EARLIEST_OLD_SITE, LATEST_OLD_SITE
 
-def main():
+def main(database):
     logging.basicConfig(level=logging.NOTSET,
                         stream=sys.stdout,
                         format='%(asctime)s %(levelname)s: %(message)s')
@@ -41,16 +42,19 @@ def main():
     cursor = connection.cursor()
 
     # Ray had two accounts which were merged in the original migration.
-    fetch_indexer = "SELECT ID FROM GCDOnline.Indexers WHERE username='%s'"
-    cursor.execute(fetch_indexer % 'rayb')
-    ray1 = cursor.fetchone()[0]
-    cursor.execute(fetch_indexer % 'RaySB')
-    ray2 = cursor.fetchone()[0]
-    cursor.close()
+    # Only for LASTEST_OLD_SITE, but not for EARLIEST_OLD_SITE
+    if database == LATEST_OLD_SITE:
+        fetch_indexer = "SELECT ID FROM %s.Indexers WHERE username='%s'"
+        cursor.execute(fetch_indexer % (LATEST_OLD_SITE, 'rayb'))
+        ray1 = cursor.fetchone()[0]
+        cursor.execute(fetch_indexer % (LATEST_OLD_SITE, 'RaySB'))
+        ray2 = cursor.fetchone()[0]
+        cursor.close()
+
 
     for old_table, log_class in (#('LogPublishers', LogPublisher),
                                  #('LogSeries', LogSeries),
-                                 ('LogIssues', LogIssue),
+                   #              ('LogIssues', LogIssue),
                                  ('LogStories', LogStory),
                                 ):
         table_name = log_class._meta.db_table
@@ -59,12 +63,15 @@ def main():
         cursor = connection.cursor()
         cursor.execute("""
 CREATE TABLE %s (PRIMARY KEY (id)) ENGINE=MyISAM
-  SELECT * FROM GCDOnline.%s;
-""" % (table_name, log_class.original_table()));
+  SELECT * FROM %s.%s;
+""" % (table_name, database, log_class.original_table()));
 
         logging.info("Altering table %s and loading data" % table_name)
-        log_class.alter_table(anon)
+        log_class.alter_table(anon, database)
+        logging.info("Fixing data for table %s" % table_name)
         log_class.fix_values(anon, unknown_country, undetermined_language)
+        cursor.close()
+        cursor = connection.cursor()
 
         logging.info("Deleting rows that don't match %s" %
                      log_class.display_table())
@@ -73,12 +80,14 @@ DELETE l FROM %s l LEFT OUTER JOIN %s d
                ON l.%s = d.id
     WHERE d.id IS NULL %s;
 """ % (table_name, log_class.display_table(),
-       log_class.source_id(), log_class.extra_delete_where()))
+        log_class.source_id(), log_class.extra_delete_where()))
 
         # Set Ray's 2nd login to his first login, and set NULL users to anonymous.
-        log_class.objects.filter(old_user_id=ray2).update(old_user_id=ray1)
-        log_class.objects.filter(old_user_id__isnull=True)\
-                         .update(old_user_id=anon.id)
+        # only for LATEST not EARLIEST 
+        if database == LATEST_OLD_SITE:
+            log_class.objects.filter(old_user_id=ray2).update(old_user_id=ray1)
+            log_class.objects.filter(old_user_id__isnull=True)\
+                             .update(old_user_id=anon.id)
 
         logging.info("Setting up sort codes for %s" % table_name)
         cursor.execute("""
@@ -148,4 +157,12 @@ UPDATE %s l LEFT OUTER JOIN %s_helper h ON l.ID=h.id
 
 if __name__ == '__main__':
     django.setup()
-    main()
+    if len(sys.argv) != 2:
+        print "give 1 (earliest) / 2 latest"
+        sys.exit()
+    if sys.argv[1] == '1':
+        main(EARLIEST_OLD_SITE)
+    elif sys.argv[1] == '2':
+        main(LATEST_OLD_SITE)
+    else:
+        print "not valid: %s" % sys.argv[1]


### PR DESCRIPTION
The older pull request disappeared during cleanup in my repo.

Changed migration of old logs by using two log files, one very early one and the latest before the switch to the new site.

Problem with using only the latest log is that many edits for new issues will be given to anonymous, instead of the user. The idea is now to treat all 'newer' log entries different and give much more credit to indexers than before.

The current result (running the local migrations) can be seen on beta. Another test will run on beta before even considering making one on production.

There is code on there, which is not used any more (at some point the idea was to do two runs based on two dumps, but that is not really working). Cleaning up for this once running code is not needed, and maybe someone gets a better idea later.