### PR TITLE
fix a view forms

### DIFF
--- a/apps/oi/forms/image.py
+++ b/apps/oi/forms/image.py
@@ -16,9 +16,14 @@ def get_cover_revision_form(revision=None, user=None):
         'compare',
         kwargs={'id': revision.changeset.id}) + '">Compare Change</a>'
 
+    # TODO Revisit this. Does it need to be a ModelForm to be consistent
+    # to other forms which get returned by get_revision_form, or can
+    # this be a normal Form and avoid the slight hackish way of not
+    # really using the ModelForm before in the actual cover upload.
     class UploadScanCommentForm(forms.ModelForm):
         class Meta:
             model = CoverRevision
+            fields = []
 
         comments = forms.CharField(
             widget=forms.Textarea,

--- a/apps/oi/views.py
+++ b/apps/oi/views.py
@@ -405,10 +405,6 @@ def edit(request, id):
     form = None
     revision = None
 
-    # TODO workaround for ImageRevision, which do hang in render_to_response
-    if changeset.change_type == CTYPES['image']:
-        return compare(request, id)
-
     if changeset.inline():
         revision = changeset.inline_revision()
         form_class = get_revision_form(revision, user=request.user)

--- a/templates/oi/edit/list_issue_reprints.html
+++ b/templates/oi/edit/list_issue_reprints.html
@@ -103,7 +103,7 @@
   <li>{{ reprint }}
       {% if not story_revision.deleted %}
     <form class="story_button" method="GET"
-            action="{% url "add_story_reprint" story_id=story_revision.id changeset_id=changeset.id reprint_note=reprint|urlencode %}">
+            action="{% url "add_story_reprint" story_id=story_revision.id changeset_id=changeset.id reprint_note=reprint %}">
         <input type="submit" id="reprint_{{ story_revision.id }}" name="reprint_{{ story_re.id }}"
                value="Add reprint">
     </form>


### PR DESCRIPTION
fixes hanged edit-views for sent back image/cover uploads

fixes editing existing reprint notes, they now get pre-filled again in the search box, currently they are twice urlencoded