### PR TITLE
handle pre-fill search for existing reprint note

### DIFF
--- a/apps/oi/urls.py
+++ b/apps/oi/urls.py
@@ -193,7 +193,7 @@ urlpatterns = patterns('',
     url(r'^reprint/revision/(?P<id>\d+)/$',
       oi_views.edit_reprint, name='edit_reprint'),
 
-    url(r'^story/revision/(?P<story_id>\d+)/add_reprint/(?P<changeset_id>\d+)/reprint_note/(?P<reprint_note>.+)/$',
+    url(r'^story/revision/(?P<story_id>\d+)/add_reprint/(?P<changeset_id>\d+)/reprint_note/(?P<reprint_note>.+|)/$',
       oi_views.add_reprint, name='add_story_reprint'),
     url(r'^story/revision/(?P<story_id>\d+)/add_reprint/(?P<changeset_id>\d+)/$',
       oi_views.add_reprint, name='add_story_reprint'),

--- a/apps/oi/views.py
+++ b/apps/oi/views.py
@@ -5,6 +5,7 @@ import re
 import sys
 import glob
 import PIL.Image as pyImage
+from urllib import unquote
 
 from django.core import urlresolvers
 from django.conf import settings
@@ -2945,7 +2946,7 @@ def add_reprint(request, changeset_id,
                                   changeset__id=changeset_id)
     if reprint_note:
         publisher, series, year, number, volume = \
-            parse_reprint(reprint_note)
+            parse_reprint(unquote(reprint_note).split(';')[0])
         initial = { 'series': series, 'publisher': publisher,
                     'year': year, 'number': number }
     else:

--- a/templates/oi/edit/issue_changeset.html
+++ b/templates/oi/edit/issue_changeset.html
@@ -150,7 +150,7 @@
       </form>
         {% if changeset.change_type == CTYPES.issue %}
       <form class="story_button" method="GET"
-            action="{% url "add_story_reprint" story_id=story.id changeset_id=changeset.id %}">
+            action="{% url "add_story_reprint" story_id=story.id changeset_id=changeset.id reprint_note=story.reprint_notes|urlencode %}">
         <input type="submit" id="reprint_{{ story.id }}" name="reprint_{{ story.id }}"
                value="Add reprint">
       </form>

--- a/templates/oi/edit/list_issue_reprints.html
+++ b/templates/oi/edit/list_issue_reprints.html
@@ -103,7 +103,7 @@
   <li>{{ reprint }}
       {% if not story_revision.deleted %}
     <form class="story_button" method="GET"
-            action="{% url "add_story_reprint" story_id=story_revision.id changeset_id=changeset.id reprint_note=reprint %}">
+            action="{% url "add_story_reprint" story_id=story_revision.id changeset_id=changeset.id reprint_note=reprint|urlencode %}">
         <input type="submit" id="reprint_{{ story_revision.id }}" name="reprint_{{ story_re.id }}"
                value="Add reprint">
     </form>


### PR DESCRIPTION
undo a small recent change, and do it correctly.

It was surprisingly difficult to find the routine unquote, at least with search involving django one always finds the other way... And also surprisingly, we seemingly so far didn't need unquote at all.

also pre-full search from for existing notes under the normal issue changeset page, only using the first (of several) notes.