### PR TITLE
Adding a column means moving the data.

### DIFF
--- a/apps/indexer/migrations/0001_initial.py
+++ b/apps/indexer/migrations/0001_initial.py
@@ -8,7 +8,7 @@ from django.conf import settings
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('stddata', '0002_initial_data'),
+        ('stddata', '0004_initial_data'),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]
 

--- a/apps/stats/migrations/0001_initial.py
+++ b/apps/stats/migrations/0001_initial.py
@@ -8,7 +8,7 @@ from django.conf import settings
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('stddata', '0002_initial_data'),
+        ('stddata', '0004_initial_data'),
         ('gcd', '0002_initial_data'),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]

--- a/apps/stddata/migrations/0003_language_native_name.py
+++ b/apps/stddata/migrations/0003_language_native_name.py
@@ -7,7 +7,7 @@ from django.db import models, migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('stddata', '0002_initial_data'),
+        ('stddata', '0001_initial'),
     ]
 
     operations = [

--- a/apps/stddata/migrations/0004_initial_data.py
+++ b/apps/stddata/migrations/0004_initial_data.py
@@ -16,7 +16,7 @@ def load_initial_data(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('stddata', '0001_initial'),
+        ('stddata', '0003_language_native_name'),
     ]
 
     operations = [


### PR DESCRIPTION
Since the native_name column is used in the natural key, when
the initial data migration loads the fixtures before that
column is present, the migration fails.

This moves it out past the addition of native_name, and
adjusts the dependencies accordingly.