### PR TITLE
use on_sale_date more in advanced search

### DIFF
--- a/apps/gcd/forms/search.py
+++ b/apps/gcd/forms/search.py
@@ -282,22 +282,24 @@ class AdvancedSearch(forms.Form):
         if self.is_valid():
             if cleaned_data['cover_needed']:
                 # use of in since after distinction stuff is cleared add series
-                if cleaned_data['target'] not in ['issue','series']:
+                if cleaned_data['target'] not in ['issue', 'series']:
                     raise forms.ValidationError(
                       "Searching for covers which are missing or need to be"
                       " replaced is valid only for issue or series searches.")
             if cleaned_data['target'] == 'cover' and cleaned_data['type']:
                 if len(cleaned_data['type']) > 1 or StoryType.objects\
                   .get(name='cover') not in cleaned_data['type']:
-                    raise forms.ValidationError("When searching for covers"
-                          " only type cover can be selected.")
+                    raise forms.ValidationError(
+                      "When searching for covers only type cover can be "
+                      "selected.")
             if cleaned_data['use_on_sale_date']:
-                if cleaned_data['target'] not in ['issue','sequence']:
+                if cleaned_data['target'] not in ['issue', 'sequence',
+                                                  'issue_cover']:
                     raise forms.ValidationError(
                       "The on-sale date can only be used in issue or story "
                       "searches.")
             if cleaned_data['keywords']:
-                if cleaned_data['target'] in ['cover','issue_cover']:
+                if cleaned_data['target'] in ['cover', 'issue_cover']:
                     raise forms.ValidationError(
                       "For technical reasons keywords cannot be used for "
                       "searches for covers and covers for issues.")

--- a/apps/gcd/views/search.py
+++ b/apps/gcd/views/search.py
@@ -1470,7 +1470,10 @@ def compute_order(data):
 
         elif target == 'issue':
             if order == 'date':
-                terms.append('key_date')
+                if data['use_on_sale_date']:
+                    terms.append('on_sale_date')
+                else:
+                    terms.append('key_date')
             elif order == 'series':
                 terms.append('series')
             elif order == 'indicia_publisher':
@@ -1494,7 +1497,10 @@ def compute_order(data):
             elif order == 'series':
                 terms.append('issue__series')
             elif order == 'date':
-                terms.append('issue__key_date')
+                if data['use_on_sale_date']:
+                    terms.append('issue__on_sale_date')
+                else:
+                    terms.append('issue__key_date')
             elif order == 'country':
                 terms.append('issue__series__country__name')
             elif order == 'language':


### PR DESCRIPTION
As mentioned on main, it would be nice if we could show covers based the on-sale-date. 

Also observed on main, If using on-sale-date for filtering, we should also use it for sorting, and not the keydate.