### PR TITLE
check for existing revision from first migration round

### DIFF
--- a/apps/legacy/tools/history/issue.py
+++ b/apps/legacy/tools/history/issue.py
@@ -163,8 +163,8 @@ UPDATE log_issue SET key_date = REPLACE(key_date, '.', '-');
                     # do this once per issue
                     story_existed = OldStory.objects.using('earliest_old_site').filter(\
                         issue_id=i.IssueID).exists()
-                    #revision_exists = StoryRevision.objects.filter(issue_id=i.IssueID, created__lt=EARLIEST_DATA_DATE).exists()
-                if not story_existed and story_set.exists():
+                    revision_exists = IssueRevision.objects.filter(issue_id=i.IssueID, created__lt=EARLIEST_DATA_DATE).exists()
+                if not story_existed and story_set.exists() and not revision_exists:
                     # stories created after 2004-08, make assumption on indexer
                     # i.e. assume anon-stories with no time belong to 
                     # first actual indexer, determined from the issue-logs
@@ -176,7 +176,8 @@ UPDATE log_issue SET key_date = REPLACE(key_date, '.', '-');
                     if objects.exists():
                         adding_user = objects[0].UserID
                     story_set = story_set.exclude(UserID=anon.id, Modified__lt=datetime.date(2002,1,2))
-
+                else:
+                    adding_user = None
             for s in story_set.order_by('dt').select_related(*story_related):
                 if scounter % 5000 == 1:
                     logging.info("Story set loop %d" % scounter)

--- a/apps/legacy/tools/history/prepare.py
+++ b/apps/legacy/tools/history/prepare.py
@@ -54,7 +54,7 @@ def main(database):
 
     for old_table, log_class in (#('LogPublishers', LogPublisher),
                                  #('LogSeries', LogSeries),
-                   #              ('LogIssues', LogIssue),
+                                 ('LogIssues', LogIssue),
                                  ('LogStories', LogStory),
                                 ):
         table_name = log_class._meta.db_table


### PR DESCRIPTION
Need this check in the end, otherwise content which existed in 2004-X-X (the oldest dump used in the first migration run) will be assigned to the first indexer in the logs after that date, which is often wrong. 