### PR TITLE
changes due to upcoming deprecations

### DIFF
--- a/apps/gcd/urls.py
+++ b/apps/gcd/urls.py
@@ -24,7 +24,7 @@ urlpatterns = patterns('',
     ###########################################################################
 
     url(r'^$', 'apps.gcd.views.index', name='home'),
-    (r'^search/$', 'apps.gcd.views.search.search'),
+    url(r'^search/$', 'apps.gcd.views.search.search', name='basic_search'),
     url(r'^search/advanced/$', 'apps.gcd.views.search.advanced_search',
       name='advanced_search'),
     url(r'^search/advanced/process/$',

--- a/apps/gcd/urls.py
+++ b/apps/gcd/urls.py
@@ -160,14 +160,14 @@ urlpatterns = patterns('',
      'apps.gcd.views.search.series_by_name', name='series_by_name'),
 
     # Series index and cover status / gallery
-    (r'^series/(?P<series_id>\d+)/status/$',
-     'apps.gcd.views.details.status'),
+    url(r'^series/(?P<series_id>\d+)/status/$',
+     'apps.gcd.views.details.status', name='series_status'),
 
-    (r'^series/(?P<series_id>\d+)/covers/$',
-     'apps.gcd.views.details.covers'),
+    url(r'^series/(?P<series_id>\d+)/covers/$',
+     'apps.gcd.views.details.covers', name='series_covers'),
 
-    (r'^series/(?P<series_id>\d+)/scans/$',
-     'apps.gcd.views.details.scans'),
+    url(r'^series/(?P<series_id>\d+)/scans/$',
+     'apps.gcd.views.details.scans', name='series_scan_table'),
 
     # Issue
     url(r'^issue/(?P<issue_id>\d+)/$',

--- a/templates/gcd/bits/front_page_search_box.html
+++ b/templates/gcd/bits/front_page_search_box.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 
 <div id="search_box">
-  <form action="{% url "apps.gcd.views.search.search" %}" method="get">
+  <form action="{% url "basic_search" %}" method="get">
     <div class="first_line">
         {% trans 'Search' %} {% include "gcd/bits/search_for.html" %}
         <input type="text" name="query" id="query" size="15" {% if flavour != 'mobile' %}autofocus{% endif %}>
@@ -17,7 +17,7 @@
         {% trans 'Sort by' %}
         {% include "gcd/bits/search_order.html" %}
         <input type="submit" name="submit" id="submit" value="{% trans 'Search' %}">
-        |&nbsp;<span class="advanced_link"><a href="{% url "apps.gcd.views.search.advanced_search" %}">{% trans 'Advanced&nbsp;Search' %}</a></span>
+        |&nbsp;<span class="advanced_link"><a href="{% url "advanced_search" %}">{% trans 'Advanced&nbsp;Search' %}</a></span>
     </div>
   </form> 
 </div>

--- a/templates/gcd/bits/publisher_header.html
+++ b/templates/gcd/bits/publisher_header.html
@@ -26,7 +26,7 @@
     {% endif %}
     {% if description %}
       {% ifnotequal description 'Publisher' %}
-        {% if description = 'Brand Emblem' %}
+        {% if description == 'Brand Emblem' %}
       ({{ description }})
         {% else %}
       (<a href="{{ publisher.parent.get_absolute_url }}{{ url_suffix }}/">{{ description }}</a>)

--- a/templates/gcd/bits/search_bar.html
+++ b/templates/gcd/bits/search_bar.html
@@ -5,9 +5,9 @@
 {% else %}
 <div class="search_bar">
 {% endif %}
-  <form action="{% url "apps.gcd.views.search.search" %}" method="get">
-    <a href="{% url "apps.gcd.views.index" %}"><img src="{% static "img/gcd_logo_icon.png" %}" alt="GCD" style="border:0;"></a>
-    | <a href="{% url "apps.gcd.views.index" %}">Home</a> |
+  <form action="{% url "basic_search" %}" method="get">
+    <a href="{% url "home" %}"><img src="{% static "img/gcd_logo_icon.png" %}" alt="GCD" style="border:0;"></a>
+    | <a href="{% url "home" %}">Home</a> |
     <span class="search_message">Search</span>
     {% include "gcd/bits/search_for.html" %}
     <input type="text" name="query" size="15" value="{{ search_term|default:"" }}">
@@ -16,7 +16,7 @@
     &nbsp;
     <input type="submit" name="submit" value="Go">
   </form>
-  | <a href="{% url "apps.gcd.views.search.advanced_search" %}">Advanced Search</a> |
+  | <a href="{% url "advanced_search" %}">Advanced Search</a> |
 {% if user.is_authenticated %}
   {% if MYCOMICS %}
   <a href="{% url "collections_list" %}">Collections</a> |

--- a/templates/gcd/bits/series_issue_header.html
+++ b/templates/gcd/bits/series_issue_header.html
@@ -58,7 +58,7 @@
       <select name="id" id="id">
     {% for other_issue in series.active_base_issues_variant_count %}
         <option value="{{ other_issue.id }}"
-      {% if issue = other_issue or issue.variant_of = other_issue %}
+      {% if issue == other_issue or issue.variant_of == other_issue %}
                 selected
       {% endif %}>{{ other_issue.issue_descriptor }}
       {% if other_issue.variant_count %}*{{ other_issue.variant_count|add:1 }}{% endif %}

--- a/templates/gcd/bits/status_banner.html
+++ b/templates/gcd/bits/status_banner.html
@@ -22,7 +22,7 @@
     (<a href="{% url "compare" id=changeset.id %}">view the edits</a>)
       {% endif %}
     {% endifequal %}
-    {% if changeset.state = states.REVIEWING or changeset.state = states.DISCUSSED %}
+    {% if changeset.state == states.REVIEWING or changeset.state == states.DISCUSSED %}
     Edits to this {{ object_name }}
     are being reviewed by GCD Editor {{ changeset.approver.indexer }}
       {% if request.user.is_authenticated %}

--- a/templates/gcd/details/change_history.html
+++ b/templates/gcd/details/change_history.html
@@ -101,7 +101,7 @@ should include a comment explaining the deletion.
 </table>
 </div>
 
-{% if description = "Issue" and object.series.is_singleton %}
+{% if description == "Issue" and object.series.is_singleton %}
 <div>
 <table class="listing">
   <tr>
@@ -115,7 +115,7 @@ should include a comment explaining the deletion.
 </div>
 {% endif %}
 
-{% if description = "Issue" and perms.indexer.can_vote %}
+{% if description == "Issue" and perms.indexer.can_vote %}
 <div>
 <table class="listing">
   <tr>
@@ -131,7 +131,7 @@ should include a comment explaining the deletion.
 </div>
 {% endif %}
 
-{% if description = "Issue" and object.indicia_image or object.soo_image %}
+{% if description == "Issue" and object.indicia_image or object.soo_image %}
 <div>
   {% if object.indicia_image %}
   <table class="listing">
@@ -156,7 +156,7 @@ should include a comment explaining the deletion.
 </div>
 {% endif %}
 
-{% if description = "Series" and object.has_series_bonds %}
+{% if description == "Series" and object.has_series_bonds %}
 <div>
   <table class="listing">
     <tr>
@@ -176,7 +176,7 @@ should include a comment explaining the deletion.
 </div>
 {% endif %}
 
-{% if description = "Brand" and object.emblem %}
+{% if description == "Brand" and object.emblem %}
 <div>
   <table class="listing">
     <tr>
@@ -189,7 +189,7 @@ should include a comment explaining the deletion.
 </div>
 {% endif %}
 
-{% if description = "Creators" and object.portrait %}
+{% if description == "Creators" and object.portrait %}
 <div>
   <table class="listing">
     <tr>
@@ -202,7 +202,7 @@ should include a comment explaining the deletion.
 </div>
 {% endif %}
 
-{% if description = "Creators" and object.samplescan %}
+{% if description == "Creators" and object.samplescan %}
 <div>
   <table class="listing">
     <tr>

--- a/templates/gcd/details/publisher.html
+++ b/templates/gcd/details/publisher.html
@@ -66,7 +66,7 @@
           <dt> Web Site:
           <dd> <a href="{{ publisher.get_official_url }}">{{ publisher.url }}</a>
   {% endif %}
-  {% if publisher.notes and page_number = 1 %}
+  {% if publisher.notes and page_number == 1 %}
           <dt> Notes:
           <dd> {{ publisher.notes|urlizetrunc:75|linebreaksbr }}
   {% endif %}

--- a/templates/gcd/details/publisher.html
+++ b/templates/gcd/details/publisher.html
@@ -144,15 +144,15 @@
       No Covers
     {% else %}
       {% if not series.scan_needed_count %}
-    <a href="{% url "apps.gcd.views.details.covers" series_id=series.id %}">Gallery</a>
+    <a href="{% url "series_covers" series_id=series.id %}">Gallery</a>
       {% else %}
         {% if series.has_gallery %}
-        <a href="{% url "apps.gcd.views.details.covers" series_id=series.id %}">Have
+        <a href="{% url "series_covers" series_id=series.id %}">Have
           {{ series.scan_count}}</a>
-        (<a href="{% url "apps.gcd.views.details.scans" series_id=series.id %}">Need 
+        (<a href="{% url "series_scan_table" series_id=series.id %}">Need
           {{ series.scan_needed_count }}</a>)
         {% else %}
-        <a href="{% url "apps.gcd.views.details.scans" series_id=series.id %}">Add</a>
+        <a href="{% url "series_scan_table" series_id=series.id %}">Add</a>
         {% endif %}
       {% endif %}
     {% endif %}

--- a/templates/gcd/details/series.html
+++ b/templates/gcd/details/series.html
@@ -114,16 +114,15 @@
           <ul class="series_detail_info">
   {% for brand in brands %}
             <li> {{ brand|absolute_url }}
-                 (<a href="{% url "apps.gcd.views.search.process_advanced" %}?target=issue&amp;method=iexact&amp;logic=False&amp;order1=series&amp;order2=date&amp;order3=&amp;pub_name={{ series.publisher.name|urlencode }}&amp;series={{ series.name|urlencode }}&amp;brand_emblem={{ brand|urlencode }}&amp;issue_count={{ series.issue_count }}&amp;series_year_began={{ series.year_began }}">{{ brand.used_issue_count }} issue{{ brand.used_issue_count|pluralize }}</a>)
+                 (<a href="{% url "process_advanced_search" %}?target=issue&amp;method=iexact&amp;logic=False&amp;order1=series&amp;order2=date&amp;order3=&amp;pub_name={{ series.publisher.name|urlencode }}&amp;series={{ series.name|urlencode }}&amp;brand_emblem={{ brand|urlencode }}&amp;issue_count={{ series.issue_count }}&amp;series_year_began={{ series.year_began }}">{{ brand.used_issue_count }} issue{{ brand.used_issue_count|pluralize }}</a>)
   {% endfor %}
   {% if brand_counts.no_brand %}
             <li> no publisher's brand 
-                 (<a href="{% url "apps.gcd.views.search.process_advanced" %}?target=issue&amp;method=iexact&amp;logic=False&amp;order1=series&amp;order2=date&amp;order3=&amp;pub_name={{ series.publisher.name|urlencode }}&amp;series={{ series.name|urlencode }}&amp;brand_emblem={{ is_none }}&amp;issue_count={{ series.issue_count }}&amp;series_year_began={{ series.year_began }}">{{ brand_counts.no_brand }} issue{{ brand_counts.no_brand|pluralize }}</a>)                 
-                 
+                 (<a href="{% url "process_advanced_search" %}?target=issue&amp;method=iexact&amp;logic=False&amp;order1=series&amp;order2=date&amp;order3=&amp;pub_name={{ series.publisher.name|urlencode }}&amp;series={{ series.name|urlencode }}&amp;brand_emblem={{ is_none }}&amp;issue_count={{ series.issue_count }}&amp;series_year_began={{ series.year_began }}">{{ brand_counts.no_brand }} issue{{ brand_counts.no_brand|pluralize }}</a>)
   {% endif %}
   {% if brand_counts.unknown %}
             <li> without publisher's brand information
-                 (<a href="{% url "apps.gcd.views.search.process_advanced" %}?target=issue&amp;method=iexact&amp;logic=False&amp;order1=series&amp;order2=date&amp;order3=&amp;pub_name={{ series.publisher.name|urlencode }}&amp;series={{ series.name|urlencode }}&amp;brand_emblem={{ is_empty }}&amp;issue_count={{ series.issue_count }}&amp;series_year_began={{ series.year_began }}">{{ brand_counts.unknown }} issue{{ brand_counts.unknown|pluralize }}</a>)                 
+                 (<a href="{% url "process_advanced_search" %}?target=issue&amp;method=iexact&amp;logic=False&amp;order1=series&amp;order2=date&amp;order3=&amp;pub_name={{ series.publisher.name|urlencode }}&amp;series={{ series.name|urlencode }}&amp;brand_emblem={{ is_empty }}&amp;issue_count={{ series.issue_count }}&amp;series_year_began={{ series.year_began }}">{{ brand_counts.unknown }} issue{{ brand_counts.unknown|pluralize }}</a>)
   {% endif %}
           </ul>
 {% endif %}
@@ -133,11 +132,11 @@
           <ul class="series_detail_info">
   {% for ip in series.ordered_indicia_publishers %}
             <li> {{ ip|absolute_url }}
-                 (<a href="{% url "apps.gcd.views.search.process_advanced" %}?target=issue&amp;method=iexact&amp;logic=False&amp;order1=series&amp;order2=date&amp;order3=&amp;pub_name={{ series.publisher.name|urlencode }}&amp;series={{ series.name|urlencode }}&amp;indicia_publisher={{ ip|urlencode }}&amp;issue_count={{ series.issue_count }}&amp;series_year_began={{ series.year_began }}">{{ ip.used_issue_count }} issue{{ ip.used_issue_count|pluralize }}</a>)
+                 (<a href="{% url "process_advanced_search" %}?target=issue&amp;method=iexact&amp;logic=False&amp;order1=series&amp;order2=date&amp;order3=&amp;pub_name={{ series.publisher.name|urlencode }}&amp;series={{ series.name|urlencode }}&amp;indicia_publisher={{ ip|urlencode }}&amp;issue_count={{ series.issue_count }}&amp;series_year_began={{ series.year_began }}">{{ ip.used_issue_count }} issue{{ ip.used_issue_count|pluralize }}</a>)
   {% endfor %}
   {% if indicia_publisher_counts.unknown %}
             <li> without indicia publisher information
-                 (<a href="{% url "apps.gcd.views.search.process_advanced" %}?target=issue&amp;method=iexact&amp;logic=False&amp;order1=series&amp;order2=date&amp;order3=&amp;pub_name={{ series.publisher.name|urlencode }}&amp;series={{ series.name|urlencode }}&amp;indicia_publisher={{ is_empty }}&amp;issue_count={{ series.issue_count }}&amp;series_year_began={{ series.year_began }}">{{ indicia_publisher_counts.unknown }} issue{{ indicia_publisher_counts.unknown|pluralize }}</a>)                 
+                 (<a href="{% url "process_advanced_search" %}?target=issue&amp;method=iexact&amp;logic=False&amp;order1=series&amp;order2=date&amp;order3=&amp;pub_name={{ series.publisher.name|urlencode }}&amp;series={{ series.name|urlencode }}&amp;indicia_publisher={{ is_empty }}&amp;issue_count={{ series.issue_count }}&amp;series_year_began={{ series.year_began }}">{{ indicia_publisher_counts.unknown }} issue{{ indicia_publisher_counts.unknown|pluralize }}</a>)
   {% endif %}
         </ul>
 {% endif %}

--- a/templates/gcd/index.html
+++ b/templates/gcd/index.html
@@ -148,16 +148,16 @@ http://matthewjamestaylor.com/blog/ultimate-3-column-holy-grail-ems.htm -->
               <li><a href="{% url "international_stats_country" %}">{% trans "by Country" %}</a>
               </ul>
               {% if language and language.code != 'en' %}
-              <li><a href="{% url "apps.gcd.views.index" %}">English start page</a></li>
+              <li><a href="{% url "home" %}">English start page</a></li>
               {% endif %}
               {% ifnotequal language.code 'de' %}
-              <li><a href="{% url "apps.gcd.views.index" %}?lang=de">Deutsche Startseite</a></li>
+              <li><a href="{% url "home" %}?lang=de">Deutsche Startseite</a></li>
               {% endifnotequal %}
               {% ifnotequal language.code 'nl' %}
-              <li><a href="{% url "apps.gcd.views.index" %}?lang=nl">Nederlandse startpagina</a></li>
+              <li><a href="{% url "home" %}?lang=nl">Nederlandse startpagina</a></li>
               {% endifnotequal %}
               {% ifnotequal language.code 'sv' %}
-              <li><a href="{% url "apps.gcd.views.index" %}?lang=sv">Svensk startsida</a></li>
+              <li><a href="{% url "home" %}?lang=sv">Svensk startsida</a></li>
               {% endifnotequal %}
             </ul>
           </div>

--- a/templates/gcd/search/list_header.html
+++ b/templates/gcd/search/list_header.html
@@ -23,12 +23,12 @@
   {% endwith %}
 </div>
 </div>
-{% if position = 'top' and not select_key and not confirm_selection %}
+{% if position == 'top' and not select_key and not confirm_selection %}
 <div id="search_reminder">
 Refine your search using an <a href="{% url "apps.gcd.views.search.advanced_search" %}?{{ query_string }}">advanced search query</a> or go to the <a href="{% url "haystack_search" %}?q={{ search_term }}">standard search</a>.
 {% if change_order %}
 Change sort order to <a href="{{ change_order}}">{% if 'chrono' in change_order %} chronological{% else %} alphabetical{% endif %}</a>.
-  {% if item_name = 'series' %}
+  {% if item_name == 'series' %}
 <br>This series search result also shows series for which an issue title matches.
   {% endif %}
 {% endif %}

--- a/templates/oi/bits/compare.html
+++ b/templates/oi/bits/compare.html
@@ -22,7 +22,7 @@
     {% endifequal %}
   {% endifequal %}
   {% if prev_rev %}
-    {% if revision.changeset.change_type = CTYPES.two_issues and revision.issue != prev_rev.issue or revision.changeset.change_type = CTYPES.variant_add and revision.issue != prev_rev.issue %}
+    {% if revision.changeset.change_type == CTYPES.two_issues and revision.issue != prev_rev.issue or revision.changeset.change_type == CTYPES.variant_add and revision.issue != prev_rev.issue %}
 <h3>This sequence is <span class="comparison_highlight">moved from the other issue</span>.</h3>
     {% endif %}
   {% endif %}
@@ -145,7 +145,7 @@
       {% endwith %}
     {% endif %}
     {% if changeset_type == 'story' %}
-      {% if revision.migration_status and not revision.migration_status.reprint_confirmed or revision.migration_status.modified > revision.changeset.created and revision.changeset.modified > revision.migration_status.modified or revision.migration_status.modified > revision.changeset.created and not revision.changeset.state = states.APPROVED %}
+      {% if revision.migration_status and not revision.migration_status.reprint_confirmed or revision.migration_status.modified > revision.changeset.created and revision.changeset.modified > revision.migration_status.modified or revision.migration_status.modified > revision.changeset.created and not revision.changeset.state == states.APPROVED %}
         {% if not revision.migration_status.reprint_confirmed %}
   <tr class="False">
         {% else %}

--- a/templates/oi/bits/compare_issue.html
+++ b/templates/oi/bits/compare_issue.html
@@ -13,7 +13,7 @@
 {% endif %}
 {% if revision.previous and revision.series != revision.previous.series %}
 <h2> Issue moved from <span class="comparison_highlight">{{ revision.previous.series.full_name }}</span> to <span class="comparison_highlight"><a href="{{ revision.series.get_absolute_url }}">{{ revision.series.full_name }}</a></span> </h2>
-  {% if revision.changeset.state = states.REVIEWING %}
+  {% if revision.changeset.state == states.REVIEWING %}
 After approval the <span class="comparison_highlight">approver needs to check the sort order</span> of the series this issue is moved to.
   {% endif %}
 {% endif %}

--- a/templates/oi/bits/pending_actions.html
+++ b/templates/oi/bits/pending_actions.html
@@ -1,4 +1,4 @@
-{% if changeset.state = states.REVIEWING or changeset.state = states.DISCUSSED %}
+{% if changeset.state == states.REVIEWING or changeset.state == states.DISCUSSED %}
   {% if changeset.approver == user %}
 <form action="{% url "process" id=changeset.id %}" method="POST">
   {% csrf_token %}
@@ -9,7 +9,7 @@
   No actions available
   {% endif %}
 {% else %}
-  {% if perms.indexer.can_approve and changeset.indexer != user or changeset.indexer = user and changeset.editable and section.object_type != 'cover' %}
+  {% if perms.indexer.can_approve and changeset.indexer != user or changeset.indexer == user and changeset.editable and section.object_type != 'cover' %}
 <form action="{% url "process" id=changeset.id %}" method="POST">
   {% csrf_token %}
   <input type="hidden" name="comments" class="comments" />

--- a/templates/oi/bits/reprint_type_list.html
+++ b/templates/oi/bits/reprint_type_list.html
@@ -1,7 +1,7 @@
 {% load display %}
 {% load editing %}
-<tr colspan="2" align="left" {% if reprint.deleted %} class="deleted" {% endif %} {% if reprint.changeset and reprint.in_type = None and reprint.out_type = None %} class="added" {% endif %}>
-  {% if reprint.changeset and not reprint.changeset = changeset and reprint.source %}
+<tr colspan="2" align="left" {% if reprint.deleted %} class="deleted" {% endif %} {% if reprint.changeset and reprint.in_type == None and reprint.out_type == None %} class="added" {% endif %}>
+  {% if reprint.changeset and not reprint.changeset == changeset and reprint.source %}
   <td> {{ reprint.source|link_other_reprint:is_source }}</td>
   {% else %}
   <td> {{ reprint|link_other_reprint:is_source }}</td>
@@ -39,7 +39,7 @@
   {% endif %}
 </form>
 {% else %}
-    {% if reprint.changeset_id = changeset.id %}
+    {% if reprint.changeset_id == changeset.id %}
 <form action="{% url "edit_reprint" id=reprint.id %}" method="POST">
       {% csrf_token %}
       {% if reprint.deleted %}
@@ -79,7 +79,7 @@
       {% endif %}
 </form>
     {% else %}
-      {% if reprint.changeset.state = states.APPROVED %}
+      {% if reprint.changeset.state == states.APPROVED %}
 <form action="{% url "reserve_reprint" reprint_id=reprint.source.id changeset_id=changeset.id reprint_type=reprint_type %}" method="POST">
         {% csrf_token %}
         {% if not is_source %}

--- a/templates/oi/bits/standard_queues.html
+++ b/templates/oi/bits/standard_queues.html
@@ -11,7 +11,7 @@
 </h2>
 <table>
   <tr>
-      {% if perms.indexer.can_approve or queue_name = 'editing' %}
+      {% if perms.indexer.can_approve or queue_name == 'editing' %}
     <th> </th>
       {% endif %}
     <th> Name {{ queue_name }}</th>
@@ -32,7 +32,7 @@
   </tr>
       {% for changeset in section.changesets %}
   <tr>
-        {% if perms.indexer.can_approve or queue_name = 'editing' %}
+        {% if perms.indexer.can_approve or queue_name == 'editing' %}
     <td>
           {% if queue_name != 'editing' or changeset.state > states.OPEN %} {{ changeset.magnitude }} {% endif %}
     </td>

--- a/templates/oi/edit/compare.html
+++ b/templates/oi/edit/compare.html
@@ -70,7 +70,7 @@ The above sequence was moved from the following issue.
   <!-- end of variant_add -->
   {% endif %}
 {% else %}
-  {% if changeset_type = 'series' %}
+  {% if changeset_type == 'series' %}
     {% if revision.previous and revision.publisher != revision.previous.publisher %}
     <div class="edit">
     <h2> Series moved from <span class="comparison_highlight">{{ revision.previous.publisher }}</span> to <span class="comparison_highlight">{{ revision.publisher }}</span> </h2>
@@ -89,7 +89,7 @@ The <span class="comparison_highlight">{{ revision.series.issue_count|sub_int:re
 {% include 'oi/bits/comments.html' %}
 {% endwith %}
 
-{% if user == changeset.indexer and changeset.state = states.OPEN %}
+{% if user == changeset.indexer and changeset.state == states.OPEN %}
 <p>
   <a href="{% url "edit" id=changeset.id %}">Edit changes</a>
 </p>

--- a/templates/oi/edit/compare_bulk_issue.html
+++ b/templates/oi/edit/compare_bulk_issue.html
@@ -35,7 +35,7 @@ This bulk change considers the following issues, the search terms used are given
 <tr>
   <td> <a href="{{ issue.get_absolute_url }}">{{ issue }}</a>
   <td> {% if issue.previous %}<a href="{% url "compare" id=issue.previous.changeset.id %}?collapse=1"> Previous Change ({{ issue.previous.modified|date:"Y-m-d" }}) {% endif %} </a>
-{% if changeset.state = states.APPROVED %}
+{% if changeset.state == states.APPROVED %}
   <td> {% if issue.posterior %}<a href="{% url "compare" id=issue.posterior.changeset.id %}?collapse=1"> Next Change ({{ issue.posterior.modified|date:"Y-m-d" }}) {% endif %} </a>
 {% endif %}
   <td> <a class="new_window" href="{% url "preview_revision" model_name=model_name id=issue.id %}" target=_blank>Preview</a>

--- a/templates/oi/edit/compare_cover.html
+++ b/templates/oi/edit/compare_cover.html
@@ -119,8 +119,8 @@ Cover {% if revision.deleted %}deleted{% else %}uploaded{% endif %} on {{ revisi
     The variant cover has the same artwork as the base issue, no separate story sequence needed.
   {% endif %}
   </p>
-  {% if changeset.state = states.REVIEWING %}
-    {% if user = changeset.approver %}
+  {% if changeset.state == states.REVIEWING %}
+    {% if user == changeset.approver %}
       <form action="{% url "flip_artwork_flag" revision_id=revision.id %}" method="POST">
         {% csrf_token %}
         <input type="submit" name="flip_artwork_flag" value="Flip the variant artwork flag" />

--- a/templates/oi/edit/compare_issue_skeletons.html
+++ b/templates/oi/edit/compare_issue_skeletons.html
@@ -48,7 +48,7 @@ the following issues (links open in new windows):
   <td> {{ issue.number }}
   <td> {{ issue.display_number }}
   <td> <a class="new_window" href="{% url "preview_revision" model_name=model_name id=issue.id %}" target=_blank>Preview</a>
-    {% if changeset.state = states.APPROVED %}
+    {% if changeset.state == states.APPROVED %}
   <td> {% if issue.posterior %}<a href="{% url "compare" id=issue.posterior.changeset.id %}?collapse=1"> Next Change ({{ issue.posterior.modified|date:"Y-m-d" }}) {% endif %} </a>
     {% endif %}
 </tr>

--- a/templates/oi/edit/confirm_internal.html
+++ b/templates/oi/edit/confirm_internal.html
@@ -55,8 +55,8 @@
 
 is
 <select name="direction" id="id_direction">
-<option value="from" {% if which_side = 'target' %}selected="selected"{% else %}disabled="disabled"{% endif %}>reprinted from
-<option type="hidden" value="to" {% if which_side = 'origin' %}selected="selected"{% else %}disabled="disabled"{% endif %}>reprinted in
+<option value="from" {% if which_side == 'target' %}selected="selected"{% else %}disabled="disabled"{% endif %}>reprinted from
+<option type="hidden" value="to" {% if which_side == 'origin' %}selected="selected"{% else %}disabled="disabled"{% endif %}>reprinted in
 </select>
 
 <hr class="divider">

--- a/templates/oi/edit/confirm_reprint.html
+++ b/templates/oi/edit/confirm_reprint.html
@@ -64,8 +64,8 @@
 
 is 
 <select name="direction" id="id_direction">
-<option value="from" {% if which_side = 'origin' %}selected="selected"{% endif %}>reprinted from
-<option value="to" {% if which_side = 'target' %}selected="selected"{% endif %}>reprinted in
+<option value="from" {% if which_side == 'origin' %}selected="selected"{% endif %}>reprinted from
+<option value="to" {% if which_side == 'target' %}selected="selected"{% endif %}>reprinted in
 </select>
 
 <hr class="divider">

--- a/templates/oi/edit/issue_changeset.html
+++ b/templates/oi/edit/issue_changeset.html
@@ -81,7 +81,7 @@
     </td>
   </tr>
   {% endif %}
-  {% if issue_revision.issue and not issue_revision.variant_of and changeset.issuerevisions.count = 1 and changeset.reprintrevisions.count = 0 %}
+  {% if issue_revision.issue and not issue_revision.variant_of and changeset.issuerevisions.count == 1 and changeset.reprintrevisions.count == 0 %}
   <tr>
     <td colspan="2">
       <form class="changeset" method="GET"
@@ -131,7 +131,7 @@
   {% for issuerevision in changeset.issuerevisions.all %}
     {% if changeset.issuerevisions.count > 1 %}
       {{ issuerevision.full_name }}
-      {% if issuerevision.story_set.count = 0 %}
+      {% if issuerevision.story_set.count == 0 %}
 <p>No stories for this issue/variant.</p>
       {% endif %}
     {% endif %}

--- a/templates/oi/edit/upload_cover.html
+++ b/templates/oi/edit/upload_cover.html
@@ -41,11 +41,11 @@ GCD :: Cover upload for {{ issue.series.name }} {{ issue.display_number }}
 <div>
   <fieldset class="universal">
     <ol>
-{% if upload_type = 'replacement' %}
+{% if upload_type == 'replacement' %}
       <form action="{% url "replace_cover" cover_id=cover.id %}" method="post" enctype="multipart/form-data">
       {% csrf_token %}
 {% else %}
-  {% if upload_type = 'variant' %}
+  {% if upload_type == 'variant' %}
       <form action="{% url "upload_variant" issue_id=issue.id %}" method="post" enctype="multipart/form-data">
       {% csrf_token %}
   {% else %}

--- a/templates/oi/queues/covers.html
+++ b/templates/oi/queues/covers.html
@@ -40,7 +40,7 @@
         {% endif %}
         {{ cover.created }}<br>
         {{ cover.changeset.indexer.indexer|absolute_url }}<br>
-        {% if cover.changeset.state = states.REVIEWING or cover.changeset.state = states.DISCUSSED %}
+        {% if cover.changeset.state == states.REVIEWING or cover.changeset.state == states.DISCUSSED %}
           reviewed by {{ cover.changeset.approver.indexer|absolute_url }}
         {% else %}
             {% if perms.indexer.can_approve %}


### PR DESCRIPTION
will take till 1.10 to be removed, warnings start with 1.8, but changes work with 1.7 as well

1) = -> == in templates 
2) use name in url-calls, not method-path