### PR TITLE
Move award initial data to new migration.

### DIFF
--- a/apps/gcd/fixtures/award.json
+++ b/apps/gcd/fixtures/award.json
@@ -1,1430 +1,2224 @@
 [
 {
-    "fields": {
-        "name": "9th Art Award, The"
-    },
-    "model": "gcd.award",
-    "pk": 1
-},
-{
-    "fields": {
-        "name": "Academy of Comic Book Arts"
-    },
-    "model": "gcd.award",
-    "pk": 2
-},
-{
-    "fields": {
-        "name": "Adamson Awards"
-    },
-    "model": "gcd.award",
-    "pk": 3
-},
-{
-    "fields": {
-        "name": "African Centre for Media Excellence Editorial Cartooning Award"
-    },
-    "model": "gcd.award",
-    "pk": 4
-},
-{
-    "fields": {
-        "name": "Akatsuka Award"
-    },
-    "model": "gcd.award",
-    "pk": 5
-},
-{
-    "fields": {
-        "name": "Alley Awards"
-    },
-    "model": "gcd.award",
-    "pk": 6
-},
-{
-    "fields": {
-        "name": "Ally Sloper Award"
-    },
-    "model": "gcd.award",
-    "pk": 7
-},
-{
-    "fields": {
-        "name": "Alph-Art"
-    },
-    "model": "gcd.award",
-    "pk": 8
-},
-{
-    "fields": {
-        "name": "Amasya Municipality Cartoon Contest"
-    },
-    "model": "gcd.award",
-    "pk": 9
-},
-{
-    "fields": {
-        "name": "American Anime Awards"
-    },
-    "model": "gcd.award",
-    "pk": 10
-},
-{
-    "fields": {
-        "name": "Angoul\u00eame International Comics Festival"
-    },
-    "model": "gcd.award",
-    "pk": 11
-},
-{
-    "fields": {
-        "name": "Arab Cartoon Award"
-    },
-    "model": "gcd.award",
-    "pk": 12
-},
-{
-    "fields": {
-        "name": "Aronson Award for Cartooning"
-    },
-    "model": "gcd.award",
-    "pk": 13
-},
-{
-    "fields": {
-        "name": "Asahi Award"
-    },
-    "model": "gcd.award",
-    "pk": 14
-},
-{
-    "fields": {
-        "name": "Associated Collegiate Press Cartooning Award"
-    },
-    "model": "gcd.award",
-    "pk": 15
-},
-{
-    "fields": {
-        "name": "Atila Ozer Internatioanal Cartoon Contest"
-    },
-    "model": "gcd.award",
-    "pk": 16
-},
-{
-    "fields": {
-        "name": "Attilio Micheluzzi Award"
-    },
-    "model": "gcd.award",
-    "pk": 17
-},
-{
-    "fields": {
-        "name": "Barcelona International Comics Convention Prizes"
-    },
-    "model": "gcd.award",
-    "pk": 18
-},
-{
-    "fields": {
-        "name": "B\u00e9d\u00e9lys Prize"
-    },
-    "model": "gcd.award",
-    "pk": 19
-},
-{
-    "fields": {
-        "name": "Big Comic Original Award"
-    },
-    "model": "gcd.award",
-    "pk": 20
-},
-{
-    "fields": {
-        "name": "Bill Finger Award"
-    },
-    "model": "gcd.award",
-    "pk": 21
-},
-{
-    "fields": {
-        "name": "Bram Stoker Awards"
-    },
-    "model": "gcd.award",
-    "pk": 22
-},
-{
-    "fields": {
-        "name": "British Comic Awards"
-    },
-    "model": "gcd.award",
-    "pk": 23
-},
-{
-    "fields": {
-        "name": "British Fantasy Awards"
-    },
-    "model": "gcd.award",
-    "pk": 24
-},
-{
-    "fields": {
-        "name": "British Press Awards Cartoonist"
-    },
-    "model": "gcd.award",
-    "pk": 25
-},
-{
-    "fields": {
-        "name": "Bronzen Adhemar"
-    },
-    "model": "gcd.award",
-    "pk": 26
-},
-{
-    "fields": {
-        "name": "Bulletje en Boonestaakschaal"
-    },
-    "model": "gcd.award",
-    "pk": 27
-},
-{
-    "fields": {
-        "name": "Bungei Shunju Manga Award"
-    },
-    "model": "gcd.award",
-    "pk": 28
-},
-{
-    "fields": {
-        "name": "Bungeishunju Manga Awards"
-    },
-    "model": "gcd.award",
-    "pk": 29
-},
-{
-    "fields": {
-        "name": "Bunka ch\u014d media geijutsusai, jush\u014d sakuhin (\u6587\u5316\u5e81\u30e1\u30c7\u30a3\u30a2\u82b8\u8853\u796d \u53d7\u8cde\u4f5c\u54c1, Media Arts Awards)"
-    },
-    "model": "gcd.award",
-    "pk": 30
-},
-{
-    "fields": {
-        "name": "Cakovec Awards"
-    },
-    "model": "gcd.award",
-    "pk": 31
-},
-{
-    "fields": {
-        "name": "Caldecott Awards"
-    },
-    "model": "gcd.award",
-    "pk": 32
-},
-{
-    "fields": {
-        "name": "Cartoonist Studio Prize"
-    },
-    "model": "gcd.award",
-    "pk": 33
-},
-{
-    "fields": {
-        "name": "Cartoonists Rights Network International Courage in Editorial Cartooning"
-    },
-    "model": "gcd.award",
-    "pk": 34
-},
-{
-    "fields": {
-        "name": "CAT Awards"
-    },
-    "model": "gcd.award",
-    "pk": 35
-},
-{
-    "fields": {
-        "name": "Charles M. Schulz Award for College Cartoonist"
-    },
-    "model": "gcd.award",
-    "pk": 36
-},
-{
-    "fields": {
-        "name": "Chesley Awards"
-    },
-    "model": "gcd.award",
-    "pk": 37
-},
-{
-    "fields": {
-        "name": "Clickies"
-    },
-    "model": "gcd.award",
-    "pk": 38
-},
-{
-    "fields": {
-        "name": "Clifford K. and James T. Berryman Award"
-    },
-    "model": "gcd.award",
-    "pk": 39
-},
-{
-    "fields": {
-        "name": "Comic Fan Art Awards"
-    },
-    "model": "gcd.award",
-    "pk": 40
-},
-{
-    "fields": {
-        "name": "Comicdom Awards"
-    },
-    "model": "gcd.award",
-    "pk": 41
-},
-{
-    "fields": {
-        "name": "Comics Buyers Guide Fan Awards"
-    },
-    "model": "gcd.award",
-    "pk": 42
-},
-{
-    "fields": {
-        "name": "Comics Laureate"
-    },
-    "model": "gcd.award",
-    "pk": 43
-},
-{
-    "fields": {
-        "name": "ComiIdol"
-    },
-    "model": "gcd.award",
-    "pk": 44
-},
-{
-    "fields": {
-        "name": "Contest of Caricature and Cartoon of Vianden"
-    },
-    "model": "gcd.award",
-    "pk": 45
-},
-{
-    "fields": {
-        "name": "De Blikken Biebel"
-    },
-    "model": "gcd.award",
-    "pk": 46
-},
-{
-    "fields": {
-        "name": "Don Thompson Awards"
-    },
-    "model": "gcd.award",
-    "pk": 47
-},
-{
-    "fields": {
-        "name": "Doug Wright Awards, The"
-    },
-    "model": "gcd.award",
-    "pk": 48
-},
-{
-    "fields": {
-        "name": "Dragon*Con Dragon Awards"
-    },
-    "model": "gcd.award",
-    "pk": 49
-},
-{
-    "fields": {
-        "name": "Drunken Druid Awards, The"
-    },
-    "model": "gcd.award",
-    "pk": 50
-},
-{
-    "fields": {
-        "name": "Dutch International Cartoonfestival"
-    },
-    "model": "gcd.award",
-    "pk": 51
-},
-{
-    "fields": {
-        "name": "Eagle Awards"
-    },
-    "model": "gcd.award",
-    "pk": 52
-},
-{
-    "fields": {
-        "name": "Eisner Award"
-    },
-    "model": "gcd.award",
-    "pk": 53
-},
-{
-    "fields": {
-        "name": "Firecracker Alternative Book Awards"
-    },
-    "model": "gcd.award",
-    "pk": 54
-},
-{
-    "fields": {
-        "name": "Fischetti Award"
-    },
-    "model": "gcd.award",
-    "pk": 55
-},
-{
-    "fields": {
-        "name": "Gaiman Award"
-    },
-    "model": "gcd.award",
-    "pk": 56
-},
-{
-    "fields": {
-        "name": "Galaxy Award"
-    },
-    "model": "gcd.award",
-    "pk": 57
-},
-{
-    "fields": {
-        "name": "Gene Day Award for Self-Publishing"
-    },
-    "model": "gcd.award",
-    "pk": 58
-},
-{
-    "fields": {
-        "name": "Ghastly Awards"
-    },
-    "model": "gcd.award",
-    "pk": 59
-},
-{
-    "fields": {
-        "name": "GIN Graphic Humor Contest"
-    },
-    "model": "gcd.award",
-    "pk": 60
-},
-{
-    "fields": {
-        "name": "GLAAD Media Award"
-    },
-    "model": "gcd.award",
-    "pk": 61
-},
-{
-    "fields": {
-        "name": "Glyph Comics Awards"
-    },
-    "model": "gcd.award",
-    "pk": 62
-},
-{
-    "fields": {
-        "name": "Goethe Awards"
-    },
-    "model": "gcd.award",
-    "pk": 63
-},
-{
-    "fields": {
-        "name": "Gouden Adhemar"
-    },
-    "model": "gcd.award",
-    "pk": 64
-},
-{
-    "fields": {
-        "name": "Gran Guinigi Award"
-    },
-    "model": "gcd.award",
-    "pk": 65
-},
-{
-    "fields": {
-        "name": "Grand Prix Mi\u0119dzynarodowego Festiwalu Komiksu"
-    },
-    "model": "gcd.award",
-    "pk": 66
-},
-{
-    "fields": {
-        "name": "Harvey Award"
-    },
-    "model": "gcd.award",
-    "pk": 67
-},
-{
-    "fields": {
-        "name": "Herblock Prize"
-    },
-    "model": "gcd.award",
-    "pk": 68
-},
-{
-    "fields": {
-        "name": "Horror Writers' Association Bram Stoker Awards"
-    },
-    "model": "gcd.award",
-    "pk": 69
-},
-{
-    "fields": {
-        "name": "Howard E. Day Prize"
-    },
-    "model": "gcd.award",
-    "pk": 70
-},
-{
-    "fields": {
-        "name": "Hugo Award"
-    },
-    "model": "gcd.award",
-    "pk": 71
-},
-{
-    "fields": {
-        "name": "Humodeva Cartoon Contest"
-    },
-    "model": "gcd.award",
-    "pk": 72
-},
-{
-    "fields": {
-        "name": "Ignatz Award"
-    },
-    "model": "gcd.award",
-    "pk": 73
-},
-{
-    "fields": {
-        "name": "Indian Comics Fandom Awards"
-    },
-    "model": "gcd.award",
-    "pk": 74
-},
-{
-    "fields": {
-        "name": "Inkpot Award"
-    },
-    "model": "gcd.award",
-    "pk": 75
-},
-{
-    "fields": {
-        "name": "Inkwell Awards"
-    },
-    "model": "gcd.award",
-    "pk": 76
-},
-{
-    "fields": {
-        "name": "Internatinal Cartoon Contest (Sinaloa M\u00e9xico)"
-    },
-    "model": "gcd.award",
-    "pk": 77
-},
-{
-    "fields": {
-        "name": "Internatinal City and Citizen Cartoon Contest (Tabriz)"
-    },
-    "model": "gcd.award",
-    "pk": 78
-},
-{
-    "fields": {
-        "name": "Internatinal Olive Cartoon Contest Prize"
-    },
-    "model": "gcd.award",
-    "pk": 79
-},
-{
-    "fields": {
-        "name": "International Beinnial Book Cartoon Contest"
-    },
-    "model": "gcd.award",
-    "pk": 80
-},
-{
-    "fields": {
-        "name": "International Car Cartoon"
-    },
-    "model": "gcd.award",
-    "pk": 81
-},
-{
-    "fields": {
-        "name": "International Cartoon Contest (Syria)"
-    },
-    "model": "gcd.award",
-    "pk": 82
-},
-{
-    "fields": {
-        "name": "International Cartoonfestival Knokke-Heist"
-    },
-    "model": "gcd.award",
-    "pk": 83
-},
-{
-    "fields": {
-        "name": "International Festival of Cartoon and Aphorisms - Srumica"
-    },
-    "model": "gcd.award",
-    "pk": 84
-},
-{
-    "fields": {
-        "name": "International Green Crescent Cartoon Contest"
-    },
-    "model": "gcd.award",
-    "pk": 85
-},
-{
-    "fields": {
-        "name": "International Horror Guild Award"
-    },
-    "model": "gcd.award",
-    "pk": 86
-},
-{
-    "fields": {
-        "name": "International Manga Award"
-    },
-    "model": "gcd.award",
-    "pk": 87
-},
-{
-    "fields": {
-        "name": "International Turhan Sel\u00e7uk Cartoon Competition"
-    },
-    "model": "gcd.award",
-    "pk": 88
-},
-{
-    "fields": {
-        "name": "Iwaya Konami Bungei Award"
-    },
-    "model": "gcd.award",
-    "pk": 89
-},
-{
-    "fields": {
-        "name": "James Tiptree, Jr. Award, The"
-    },
-    "model": "gcd.award",
-    "pk": 90
-},
-{
-    "fields": {
-        "name": "Japan Academy Prize for Animation of the Year"
-    },
-    "model": "gcd.award",
-    "pk": 91
-},
-{
-    "fields": {
-        "name": "Japan Culture Design Award"
-    },
-    "model": "gcd.award",
-    "pk": 92
-},
-{
-    "fields": {
-        "name": "Japan Manga Association Award"
-    },
-    "model": "gcd.award",
-    "pk": 93
-},
-{
-    "fields": {
-        "name": "Japanese Science Fiction Award"
-    },
-    "model": "gcd.award",
-    "pk": 94
-},
-{
-    "fields": {
-        "name": "Joe Shuster Awards"
-    },
-    "model": "gcd.award",
-    "pk": 95
-},
-{
-    "fields": {
-        "name": "Joe Shuster Canadian Comic Book Creator Awards"
-    },
-    "model": "gcd.award",
-    "pk": 96
-},
-{
-    "fields": {
-        "name": "John Locher Memorial Award"
-    },
-    "model": "gcd.award",
-    "pk": 97
-},
-{
-    "fields": {
-        "name": "KalDer Bursa Cartoon Contest"
-    },
-    "model": "gcd.award",
-    "pk": 98
-},
-{
-    "fields": {
-        "name": "Kirby Award"
-    },
-    "model": "gcd.award",
-    "pk": 99
-},
-{
-    "fields": {
-        "name": "Klein Award"
-    },
-    "model": "gcd.award",
-    "pk": 100
-},
-{
-    "fields": {
-        "name": "Kodansha Manga Award"
-    },
-    "model": "gcd.award",
-    "pk": 101
-},
-{
-    "fields": {
-        "name": "Kodansha Manga Award"
-    },
-    "model": "gcd.award",
-    "pk": 102
-},
-{
-    "fields": {
-        "name": "Kodansha Manga Award"
-    },
-    "model": "gcd.award",
-    "pk": 103
-},
-{
-    "fields": {
-        "name": "Ledger Awards"
-    },
-    "model": "gcd.award",
-    "pk": 104
-},
-{
-    "fields": {
-        "name": "Les Grands Prix de la Ville d'Angoul\u00eame (Grand Prize of the City of Angoul\u00eame, The)"
-    },
-    "model": "gcd.award",
-    "pk": 105
-},
-{
-    "fields": {
-        "name": "Les prix du Festival international de la bande dessin\u00e9e d'Angoul\u00eame (Awards of the Angoul\u00eame International Comics Festival)"
-    },
-    "model": "gcd.award",
-    "pk": 106
-},
-{
-    "fields": {
-        "name": "Lightning Game Manga Awards"
-    },
-    "model": "gcd.award",
-    "pk": 107
-},
-{
-    "fields": {
-        "name": "Locher Award"
-    },
-    "model": "gcd.award",
-    "pk": 108
-},
-{
-    "fields": {
-        "name": "Lulu Awards"
-    },
-    "model": "gcd.award",
-    "pk": 109
-},
-{
-    "fields": {
-        "name": "Lurie Awards"
-    },
-    "model": "gcd.award",
-    "pk": 110
-},
-{
-    "fields": {
-        "name": "Mahmoud Kahil Awards"
-    },
-    "model": "gcd.award",
-    "pk": 111
-},
-{
-    "fields": {
-        "name": "Manga Festival in France"
-    },
-    "model": "gcd.award",
-    "pk": 112
-},
-{
-    "fields": {
-        "name": "Manga Taish\u014d"
-    },
-    "model": "gcd.award",
-    "pk": 113
-},
-{
-    "fields": {
-        "name": "Marten Toonderprijs"
-    },
-    "model": "gcd.award",
-    "pk": 114
-},
-{
-    "fields": {
-        "name": "Max und Moritz Preis (Max & Moritz Prize)"
-    },
-    "model": "gcd.award",
-    "pk": 115
-},
-{
-    "fields": {
-        "name": "Maya Kamath Memorial Award"
-    },
-    "model": "gcd.award",
-    "pk": 116
-},
-{
-    "fields": {
-        "name": "Maya Kamath Memorial Award"
-    },
-    "model": "gcd.award",
-    "pk": 117
-},
-{
-    "fields": {
-        "name": "Mercosur International Diogenes Taborda Salon"
-    },
-    "model": "gcd.award",
-    "pk": 118
-},
-{
-    "fields": {
-        "name": "Michael L. Printz Award for Excellence in Young Adult Literature"
-    },
-    "model": "gcd.award",
-    "pk": 119
-},
-{
-    "fields": {
-        "name": "Molla Nasreddin"
-    },
-    "model": "gcd.award",
-    "pk": 120
-},
-{
-    "fields": {
-        "name": "Narayan Debntah Comics Puroskar"
-    },
-    "model": "gcd.award",
-    "pk": 121
-},
-{
-    "fields": {
-        "name": "Nasreddin Hodja Cartoon Contest Prize"
-    },
-    "model": "gcd.award",
-    "pk": 122
-},
-{
-    "fields": {
-        "name": "National Book Awards"
-    },
-    "model": "gcd.award",
-    "pk": 123
-},
-{
-    "fields": {
-        "name": "National Book Awards (U.S.)"
-    },
-    "model": "gcd.award",
-    "pk": 124
-},
-{
-    "fields": {
-        "name": "National Book Awards (UK)"
-    },
-    "model": "gcd.award",
-    "pk": 125
-},
-{
-    "fields": {
-        "name": "National Cartoonists Society Division Awards"
-    },
-    "model": "gcd.award",
-    "pk": 126
-},
-{
-    "fields": {
-        "name": "National Comics Awards"
-    },
-    "model": "gcd.award",
-    "pk": 127
-},
-{
-    "fields": {
-        "name": "National Headliner Award"
-    },
-    "model": "gcd.award",
-    "pk": 128
-},
-{
-    "fields": {
-        "name": "National Newspaper Awards of Canada"
-    },
-    "model": "gcd.award",
-    "pk": 129
-},
-{
-    "fields": {
-        "name": "New York Library Award"
-    },
-    "model": "gcd.award",
-    "pk": 130
-},
-{
-    "fields": {
-        "name": "Newbery Medal"
-    },
-    "model": "gcd.award",
-    "pk": 131
-},
-{
-    "fields": {
-        "name": "Niels Bugge Cartoon Award"
-    },
-    "model": "gcd.award",
-    "pk": 132
-},
-{
-    "fields": {
-        "name": "\u014cfuji Nobur\u014d Award"
-    },
-    "model": "gcd.award",
-    "pk": 133
-},
-{
-    "fields": {
-        "name": "Osamu Tezuka Awards"
-    },
-    "model": "gcd.award",
-    "pk": 134
-},
-{
-    "fields": {
-        "name": "Overstreet Hall of Fame"
-    },
-    "model": "gcd.award",
-    "pk": 135
-},
-{
-    "fields": {
-        "name": "P. Hans Frankfurtherprijs"
-    },
-    "model": "gcd.award",
-    "pk": 136
-},
-{
-    "fields": {
-        "name": "Pantera di Lucca Comics (Lucca Comics' Panther Award)"
-    },
-    "model": "gcd.award",
-    "pk": 137
-},
-{
-    "fields": {
-        "name": "Parents' Choice Award"
-    },
-    "model": "gcd.award",
-    "pk": 138
-},
-{
-    "fields": {
-        "name": "Plastieken Plunk"
-    },
-    "model": "gcd.award",
-    "pk": 139
-},
-{
-    "fields": {
-        "name": "PortoCartoon-World Festival Prize"
-    },
-    "model": "gcd.award",
-    "pk": 140
-},
-{
-    "fields": {
-        "name": "Premiados - Sal\u00e3o Internacional de Humor de Piracicaba"
-    },
-    "model": "gcd.award",
-    "pk": 141
-},
-{
-    "fields": {
-        "name": "Pr\u00eamio Angelo Agostini"
-    },
-    "model": "gcd.award",
-    "pk": 142
-},
-{
-    "fields": {
-        "name": "Premios Haxtur (Haxtur Awards)"
-    },
-    "model": "gcd.award",
-    "pk": 143
-},
-{
-    "fields": {
-        "name": "Prix B\u00e9d\u00e9is Causa"
-    },
-    "model": "gcd.award",
-    "pk": 144
-},
-{
-    "fields": {
-        "name": "Prix Saint-Michel"
-    },
-    "model": "gcd.award",
-    "pk": 145
-},
-{
-    "fields": {
-        "name": "Prometheus Awards"
-    },
-    "model": "gcd.award",
-    "pk": 146
-},
-{
-    "fields": {
-        "name": "Pulitzer Prize"
-    },
-    "model": "gcd.award",
-    "pk": 147
-},
-{
-    "fields": {
-        "name": "Quill Award"
-    },
-    "model": "gcd.award",
-    "pk": 148
-},
-{
-    "fields": {
-        "name": "Reuben Award"
-    },
-    "model": "gcd.award",
-    "pk": 149
-},
-{
-    "fields": {
-        "name": "Reuben Award/Barney Award"
-    },
-    "model": "gcd.award",
-    "pk": 150
-},
-{
-    "fields": {
-        "name": "Ringo Awards"
-    },
-    "model": "gcd.award",
-    "pk": 151
-},
-{
-    "fields": {
-        "name": "Robert F. Kennedy Journalism Award"
-    },
-    "model": "gcd.award",
-    "pk": 152
-},
-{
-    "fields": {
-        "name": "Robert F. Sibert Informational Book Medal"
-    },
-    "model": "gcd.award",
-    "pk": 153
-},
-{
-    "fields": {
-        "name": "Rotary Cartoon Awards"
-    },
-    "model": "gcd.award",
-    "pk": 154
-},
-{
-    "fields": {
-        "name": "Russ Manning Award"
-    },
-    "model": "gcd.award",
-    "pk": 155
-},
-{
-    "fields": {
-        "name": "Sal\u00e3o de Humor de Piracicaba"
-    },
-    "model": "gcd.award",
-    "pk": 156
-},
-{
-    "fields": {
-        "name": "Satyrkon Awards"
-    },
-    "model": "gcd.award",
-    "pk": 157
-},
-{
-    "fields": {
-        "name": "Seferihisar Cartoon Competition Prize"
-    },
-    "model": "gcd.award",
-    "pk": 158
-},
-{
-    "fields": {
-        "name": "Science Fiction Grand Prix Award"
-    },
-    "model": "gcd.award",
-    "pk": 159
-},
-{
-    "fields": {
-        "name": "Scream Awards"
-    },
-    "model": "gcd.award",
-    "pk": 160
-},
-{
-    "fields": {
-        "name": "Scripps-Howard National Journalism Award"
-    },
-    "model": "gcd.award",
-    "pk": 161
-},
-{
-    "fields": {
-        "name": "Seiun Award"
-    },
-    "model": "gcd.award",
-    "pk": 162
-},
-{
-    "fields": {
-        "name": "Seiyuu Awards\u200e"
-    },
-    "model": "gcd.award",
-    "pk": 163
-},
-{
-    "fields": {
-        "name": "Sergio Aragones Award"
-    },
-    "model": "gcd.award",
-    "pk": 164
-},
-{
-    "fields": {
-        "name": "SFERA Award"
-    },
-    "model": "gcd.award",
-    "pk": 165
-},
-{
-    "fields": {
-        "name": "Shazam Award"
-    },
-    "model": "gcd.award",
-    "pk": 166
-},
-{
-    "fields": {
-        "name": "Shibata Renzaburo Award"
-    },
-    "model": "gcd.award",
-    "pk": 167
-},
-{
-    "fields": {
-        "name": "Sigma Delta Chi Award"
-    },
-    "model": "gcd.award",
-    "pk": 168
-},
-{
-    "fields": {
-        "name": "Sondermann"
-    },
-    "model": "gcd.award",
-    "pk": 169
-},
-{
-    "fields": {
-        "name": "Spectrum Awards"
-    },
-    "model": "gcd.award",
-    "pk": 170
-},
-{
-    "fields": {
-        "name": "SPJA Anime Award"
-    },
-    "model": "gcd.award",
-    "pk": 171
-},
-{
-    "fields": {
-        "name": "Sports Cartoons Award"
-    },
-    "model": "gcd.award",
-    "pk": 172
-},
-{
-    "fields": {
-        "name": "Sproing Award"
-    },
-    "model": "gcd.award",
-    "pk": 173
-},
-{
-    "fields": {
-        "name": "Squiddy Award"
-    },
-    "model": "gcd.award",
-    "pk": 174
-},
-{
-    "fields": {
-        "name": "Stan Lee Excelsior Award"
-    },
-    "model": "gcd.award",
-    "pk": 175
-},
-{
-    "fields": {
-        "name": "Stanley Award"
-    },
-    "model": "gcd.award",
-    "pk": 176
-},
-{
-    "fields": {
-        "name": "Stonewall Book Awards"
-    },
-    "model": "gcd.award",
-    "pk": 177
-},
-{
-    "fields": {
-        "name": "Stripschapprijs"
-    },
-    "model": "gcd.award",
-    "pk": 178
-},
-{
-    "fields": {
-        "name": "Stripvos"
-    },
-    "model": "gcd.award",
-    "pk": 179
-},
-{
-    "fields": {
-        "name": "Studio d'Arte Andromeda"
-    },
-    "model": "gcd.award",
-    "pk": 180
-},
-{
-    "fields": {
-        "name": "Tanimoto Kiyoshi Peace Prize"
-    },
-    "model": "gcd.award",
-    "pk": 181
-},
-{
-    "fields": {
-        "name": "Tapir Cartoon Festival Prize"
-    },
-    "model": "gcd.award",
-    "pk": 182
-},
-{
-    "fields": {
-        "name": "Thomas Nast Award"
-    },
-    "model": "gcd.award",
-    "pk": 183
-},
-{
-    "fields": {
-        "name": "Tokyo Anime Award"
-    },
-    "model": "gcd.award",
-    "pk": 184
-},
-{
-    "fields": {
-        "name": "Trof\u00e9u HQ Mix"
-    },
-    "model": "gcd.award",
-    "pk": 185
-},
-{
-    "fields": {
-        "name": "Urhunden Prize"
-    },
-    "model": "gcd.award",
-    "pk": 186
-},
-{
-    "fields": {
-        "name": "VPRO Debuutprijs"
-    },
-    "model": "gcd.award",
-    "pk": 187
-},
-{
-    "fields": {
-        "name": "Web Cartoonists' Choice Awards"
-    },
-    "model": "gcd.award",
-    "pk": 188
-},
-{
-    "fields": {
-        "name": "Wilbur"
-    },
-    "model": "gcd.award",
-    "pk": 189
-},
-{
-    "fields": {
-        "name": "Willy Vandersteenprijs"
-    },
-    "model": "gcd.award",
-    "pk": 190
-},
-{
-    "fields": {
-        "name": "Wizard Fan Awards"
-    },
-    "model": "gcd.award",
-    "pk": 191
-},
-{
-    "fields": {
-        "name": "World Fantasy Award"
-    },
-    "model": "gcd.award",
-    "pk": 192
-},
-{
-    "fields": {
-        "name": "World Press Cartoon Award"
-    },
-    "model": "gcd.award",
-    "pk": 193
-},
-{
-    "fields": {
-        "name": "Worldwide Manga Reader Awards"
-    },
-    "model": "gcd.award",
-    "pk": 194
-},
-{
-    "fields": {
-        "name": "Worldwide Manga Reader Awards"
-    },
-    "model": "gcd.award",
-    "pk": 195
-},
-{
-    "fields": {
-        "name": "Xeric Foundation"
-    },
-    "model": "gcd.award",
-    "pk": 196
-},
-{
-    "fields": {
-        "name": "Yamamoto Shugoro Award"
-    },
-    "model": "gcd.award",
-    "pk": 197
-},
-{
-    "fields": {
-        "name": "Yellow Kid Award"
-    },
-    "model": "gcd.award",
-    "pk": 198
-},
-{
-    "fields": {
-        "name": "Yomiuri International Manga Award"
-    },
-    "model": "gcd.award",
-    "pk": 199
-},
-{
-    "fields": {
-        "name": "\u0395\u03bb\u03bb\u03b7\u03bd\u03b9\u03ba\u03ac \u0392\u03c1\u03b1\u03b2\u03b5\u03af\u03b1 \u039a\u03cc\u03bc\u03b9\u03ba\u03c2 (Greek Comics Awards)"
-    },
-    "model": "gcd.award",
-    "pk": 200
-},
-{
-    "fields": {
-        "name": "\u5c0f\u5b66\u9928\u6f2b\u753b\u8cde (Sh\u014dgakukan Manga Sh\u014d, Shogakukan Comics Award)"
-    },
-    "model": "gcd.award",
-    "pk": 201
-},
-{
-    "fields": {
-        "name": "\u624b\u585a\u6cbb\u866b\u6587\u5316\u8cde (Tezuka Osamu Bunkash\u014d, Tezuka Osamu Cultural Prize)"
-    },
-    "model": "gcd.award",
-    "pk": 202
-},
-{
-    "fields": {
-        "name": "\u65e5\u672c\u6f2b\u753b\u5bb6\u5354\u4f1a\u8cde, (Nihon Mangaka Ky\u014dkai sh\u014d, Japanese Cartoonists' Association Award)"
-    },
-    "model": "gcd.award",
-    "pk": 203
-},
-{
-    "fields": {
-        "name": "\u96fb\u6483 (\u30df\u30c3\u30af\u30b0\u30e9\u30f3\u30d7\u30ea, Dengeki Komikku Guran Puri, Dengeki Comic Grand Prix)"
-    },
-    "model": "gcd.award",
-    "pk": 204
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "9th Art Award, The",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 1
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Academy of Comic Book Arts",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 2
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Adamson Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 3
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "African Centre for Media Excellence Editorial Cartooning Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 4
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Akatsuka Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 5
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Alley Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 6
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Ally Sloper Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 7
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Alph-Art",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 8
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Amasya Municipality Cartoon Contest",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 9
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "American Anime Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 10
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Angoul\u00eame International Comics Festival",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 11
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Arab Cartoon Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 12
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Aronson Award for Cartooning",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 13
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Asahi Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 14
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Associated Collegiate Press Cartooning Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 15
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Atila Ozer Internatioanal Cartoon Contest",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 16
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Attilio Micheluzzi Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 17
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Barcelona International Comics Convention Prizes",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 18
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "B\u00e9d\u00e9lys Prize",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 19
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Big Comic Original Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 20
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Bill Finger Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 21
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Bram Stoker Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 22
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "British Comic Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 23
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "British Fantasy Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 24
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "British Press Awards Cartoonist",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 25
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Bronzen Adhemar",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 26
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Bulletje en Boonestaakschaal",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 27
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Bungeishunju Manga Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 29
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Bunka ch\u014d media geijutsusai, jush\u014d sakuhin (\u6587\u5316\u5e81\u30e1\u30c7\u30a3\u30a2\u82b8\u8853\u796d \u53d7\u8cde\u4f5c\u54c1, Media Arts Awards)",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 30
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Cakovec Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 31
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Caldecott Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 32
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Cartoonist Studio Prize",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 33
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Cartoonists Rights Network International Courage in Editorial Cartooning",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 34
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "CAT Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 35
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Charles M. Schulz Award for College Cartoonist",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 36
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Chesley Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 37
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Clickies",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 38
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Clifford K. and James T. Berryman Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 39
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Comic Fan Art Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 40
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Comicdom Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 41
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Comics Buyers Guide Fan Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 42
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Comics Laureate",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 43
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "ComiIdol",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 44
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Contest of Caricature and Cartoon of Vianden",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 45
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "De Blikken Biebel",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 46
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Don Thompson Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 47
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Doug Wright Awards, The",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 48
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Dragon*Con Dragon Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 49
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Drunken Druid Awards, The",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 50
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Dutch International Cartoonfestival",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 51
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Eagle Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 52
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Eisner Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 53
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Firecracker Alternative Book Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 54
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Fischetti Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 55
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Gaiman Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 56
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Galaxy Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 57
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Gene Day Award for Self-Publishing",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 58
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Ghastly Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 59
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "GIN Graphic Humor Contest",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 60
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "GLAAD Media Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 61
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Glyph Comics Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 62
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Goethe Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 63
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Gouden Adhemar",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 64
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Gran Guinigi Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 65
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Grand Prix Mi\u0119dzynarodowego Festiwalu Komiksu",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 66
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Harvey Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 67
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Herblock Prize",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 68
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Horror Writers' Association Bram Stoker Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 69
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Howard E. Day Prize",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 70
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Hugo Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 71
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Humodeva Cartoon Contest",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 72
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Ignatz Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 73
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Indian Comics Fandom Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 74
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Inkpot Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 75
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Inkwell Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 76
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Internatinal Cartoon Contest (Sinaloa M\u00e9xico)",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 77
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Internatinal City and Citizen Cartoon Contest (Tabriz)",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 78
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Internatinal Olive Cartoon Contest Prize",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 79
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "International Beinnial Book Cartoon Contest",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 80
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "International Car Cartoon",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 81
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "International Cartoon Contest (Syria)",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 82
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "International Cartoonfestival Knokke-Heist",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 83
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "International Festival of Cartoon and Aphorisms - Srumica",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 84
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "International Green Crescent Cartoon Contest",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 85
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "International Horror Guild Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 86
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "International Manga Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 87
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "International Turhan Sel\u00e7uk Cartoon Competition",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 88
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Iwaya Konami Bungei Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 89
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "James Tiptree, Jr. Award, The",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 90
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Japan Academy Prize for Animation of the Year",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 91
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Japan Culture Design Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 92
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Japan Manga Association Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 93
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Japanese Science Fiction Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 94
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Joe Shuster Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 95
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "John Locher Memorial Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 97
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "KalDer Bursa Cartoon Contest",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 98
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Kirby Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 99
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Klein Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 100
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Kodansha Manga Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 101
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Ledger Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 104
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Les Grands Prix de la Ville d'Angoul\u00eame (Grand Prize of the City of Angoul\u00eame, The)",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 105
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Les prix du Festival international de la bande dessin\u00e9e d'Angoul\u00eame (Awards of the Angoul\u00eame International Comics Festival)",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 106
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Lightning Game Manga Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 107
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Locher Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 108
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Lulu Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 109
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Lurie Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 110
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Mahmoud Kahil Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 111
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Manga Festival in France",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 112
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Manga Taish\u014d",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 113
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Marten Toonderprijs",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 114
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Max und Moritz Preis (Max & Moritz Prize)",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 115
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Maya Kamath Memorial Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 117
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Mercosur International Diogenes Taborda Salon",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 118
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Michael L. Printz Award for Excellence in Young Adult Literature",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 119
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Molla Nasreddin",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 120
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Narayan Debntah Comics Puroskar",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 121
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Nasreddin Hodja Cartoon Contest Prize",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 122
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "National Book Awards (U.S.)",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 124
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "National Book Awards (UK)",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 125
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "National Cartoonists Society Division Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 126
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "National Comics Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 127
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "National Headliner Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 128
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "National Newspaper Awards of Canada",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 129
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "New York Library Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 130
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Newbery Medal",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 131
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Niels Bugge Cartoon Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 132
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "\u014cfuji Nobur\u014d Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 133
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Osamu Tezuka Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 134
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Overstreet Hall of Fame",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 135
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "P. Hans Frankfurtherprijs",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 136
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Pantera di Lucca Comics (Lucca Comics' Panther Award)",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 137
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Parents' Choice Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 138
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Plastieken Plunk",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 139
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "PortoCartoon-World Festival Prize",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 140
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Premiados - Sal\u00e3o Internacional de Humor de Piracicaba",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 141
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Pr\u00eamio Angelo Agostini",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 142
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Premios Haxtur (Haxtur Awards)",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 143
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Prix B\u00e9d\u00e9is Causa",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 144
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Prix Saint-Michel",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 145
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Prometheus Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 146
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Pulitzer Prize",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 147
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Quill Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 148
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Reuben Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 149
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Ringo Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 151
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Robert F. Kennedy Journalism Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 152
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Robert F. Sibert Informational Book Medal",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 153
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Rotary Cartoon Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 154
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Russ Manning Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 155
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Sal\u00e3o de Humor de Piracicaba",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 156
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Satyrkon Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 157
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Seferihisar Cartoon Competition Prize",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 158
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Science Fiction Grand Prix Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 159
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Scream Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 160
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Scripps-Howard National Journalism Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 161
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Seiun Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 162
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Seiyuu Awards\u200e",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 163
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Sergio Aragones Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 164
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "SFERA Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 165
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Shazam Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 166
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Shibata Renzaburo Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 167
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Sigma Delta Chi Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 168
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Sondermann",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 169
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Spectrum Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 170
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "SPJA Anime Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 171
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Sports Cartoons Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 172
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Sproing Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 173
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Squiddy Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 174
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Stan Lee Excelsior Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 175
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Stanley Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 176
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Stonewall Book Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 177
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Stripschapprijs",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 178
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Stripvos",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 179
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Studio d'Arte Andromeda",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 180
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Tanimoto Kiyoshi Peace Prize",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 181
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Tapir Cartoon Festival Prize",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 182
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Thomas Nast Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 183
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Tokyo Anime Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 184
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Trof\u00e9u HQ Mix",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 185
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Urhunden Prize",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 186
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "VPRO Debuutprijs",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 187
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Web Cartoonists' Choice Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 188
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Wilbur",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 189
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Willy Vandersteenprijs",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 190
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Wizard Fan Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 191
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "World Fantasy Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 192
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "World Press Cartoon Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 193
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Worldwide Manga Reader Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 194
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Worldwide Manga Reader Awards",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 195
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Xeric Foundation",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 196
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Yamamoto Shugoro Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 197
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Yellow Kid Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 198
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Yomiuri International Manga Award",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 199
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "\u0395\u03bb\u03bb\u03b7\u03bd\u03b9\u03ba\u03ac \u0392\u03c1\u03b1\u03b2\u03b5\u03af\u03b1 \u039a\u03cc\u03bc\u03b9\u03ba\u03c2 (Greek Comics Awards)",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 200
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "\u5c0f\u5b66\u9928\u6f2b\u753b\u8cde (Sh\u014dgakukan Manga Sh\u014d, Shogakukan Comics Award)",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 201
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "\u624b\u585a\u6cbb\u866b\u6587\u5316\u8cde (Tezuka Osamu Bunkash\u014d, Tezuka Osamu Cultural Prize)",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 202
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "\u65e5\u672c\u6f2b\u753b\u5bb6\u5354\u4f1a\u8cde, (Nihon Mangaka Ky\u014dkai sh\u014d, Japanese Cartoonists' Association Award)",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 203
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "\u96fb\u6483 (\u30df\u30c3\u30af\u30b0\u30e9\u30f3\u30d7\u30ea, Dengeki Komikku Guran Puri, Dengeki Comic Grand Prix)",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 204
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Pondus-prisen",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 205
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Jaarprijs voor Bijzondere Verdiensten",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 206
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Kulturdepartementets tegneseriepris",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 207
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Inktspotprijs",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 208
+},
+{
+  "fields": {
+    "deleted": false,
+    "notes": "",
+    "modified": "2018-01-01T00:00:00",
+    "name": "Junior Inktspotprijs",
+    "created": "2018-01-01T00:00:00"
+  },
+  "model": "gcd.award",
+  "pk": 209
 }
 ]

--- a/apps/gcd/migrations/0004_initial_creator_data.py
+++ b/apps/gcd/migrations/0004_initial_creator_data.py
@@ -10,7 +10,7 @@ def load_initial_creator_data(apps, schema_editor):
     for model in ('degree', 'membershiptype', 'nametype',
                   'noncomicworkrole', 'noncomicworktype',
                   'relationtype', 'school', 'sourcetype',
-                  'award', 'imagetype'):
+                  'imagetype'):
         call_command('loaddata', model.lower())
 
 

--- a/apps/gcd/migrations/0007_initial_award_data.py
+++ b/apps/gcd/migrations/0007_initial_award_data.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+from django.core.management import call_command
+
+
+def load_initial_award_data(apps, schema_editor):
+    call_command('loaddata', 'award')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('gcd', '0006_award_editable'),
+    ]
+
+    operations = [
+        migrations.RunPython(load_initial_award_data),
+    ]


### PR DESCRIPTION
This is needed to avoid the following problem when starting from an
empty database:

Running migrations:
  Applying gcd.0004_initial_creator_data...
  [...]
  django.db.utils.OperationalError: Problem installing fixture
    'apps/gcd/fixtures/award.json': Could not load gcd.Award(pk=1):
    (1054, "Unknown column 'created' in 'field list'")

The modified award.json contains all current awards from production.

On an instance where the award data already exist, we might need to do:

./manage.py migrate --fake gcd 0007_initial_award_data

to mark the migration as already applied (although it shouldn't matter).