### PR TITLE
Update main requirements for Python3+Ubuntu 18.04

### DIFF
--- a/apps/voting/views.py
+++ b/apps/voting/views.py
@@ -1,7 +1,7 @@
 import hashlib
 import os.path
 from datetime import datetime
-from pyvotecore.schulze_method import SchulzeMethod
+from py3votecore.schulze_method import SchulzeMethod
 
 from django.conf import settings
 from django.db.models import Q

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,48 +1,35 @@
-# not fully sure if we actually use it
-#beautifulsoup4==4.6.0
 Django<2.0
-MySQL-python==1.2.5
-Pillow<4.4
-PyICU<2.0
-PyYAML<3.13
-# pytz is django requirement, not ours
-# pytz==2016.6.1
-# not ours
-# argparse==1.2.1
-django-autocomplete-light<3.3
-diff-match-patch==20121119
-django-appconf==1.0.2
-django-bootstrap3<9.2
-django-compressor<2.3
-django-contact-form<1.7
-django-crispy-forms==1.7.2
-django-haystack==2.8.1
+mysqlclient<1.5
+Pillow<6.3
+PyICU<2.5
+PyYAML<5.2
+django-autocomplete-light<3.5
+diff-match-patch==20181111
+django-appconf<1.1
+django-bootstrap3<11.2
+django-compressor<2.4
+django-contact-form<1.8
+django-crispy-forms<1.9
+django-haystack<2.9
 django-imagekit<4.1
-django-queryset-csv==1.0.0
-django-recaptcha<1.5
-django-tables2<1.22
+django-queryset-csv<1.1
+django-recaptcha<2.1
+django-tables2<2.3
 git+git://github.com/GrandComicsDatabase/django-mobile.git@django111
+django-model-utils<3.3
 git+git://github.com/GrandComicsDatabase/django-taggit.git@django111
-git+git://github.com/GrandComicsDatabase/django-templatesadmin.git@gcd-production
-elasticsearch<2.0
+git+git://github.com/GrandComicsDatabase/django-templatesadmin.git@python3
+elasticsearch<7.2
 elasticstack<0.6
-facebook-sdk==2.0
-# do we need feedparser
-# feedparser==5.2.1
-# seems like requirement for haystack, but maybe not ?
-# python-dateutil==2.2
-python-graph-core==1.8.2
-python-memcached==1.59
-python-stdnum<1.10
-python-vote-core==20120423.0
-requests==2.20.1
-simplejson==3.4.0
-# still needed ?
-# versiontools==1.9.1
-wsgiref==0.1.2
+facebook-sdk<3.2
+python-graph-core<1.9
+python-memcached<1.60
+python-stdnum<1.13
+python3-vote-core==20170329.0
+requests<2.23
+simplejson<3.18
 
 # These packages are used in development and testing.
-RBTools
 flake8
 mock
 pytest
@@ -54,7 +41,9 @@ ipython
 # to install other (non-Python-package) software do perform further
 # configuration.  They are included here to ensure that we catch library
 # version dependency interactions.
-rq<0.11
-django-rq<1.1
-redis<2.11
-git+git://github.com/mandx/haystack-rqueue.git
+
+# TODO: Update for Python3 and Ubuntu 18.04 and uncomment
+# rq<0.11
+# django-rq<1.1
+# redis<2.11
+# git+git://github.com/mandx/haystack-rqueue.git


### PR DESCRIPTION
This does not update the production-specific modules yet.

The various commented-out modules seem to be unnecessary, so let's
take them out.  We can always put them back in if needed.

wsgiref's functionality is now covered by the standard library

Two packages needed replacing by forks for Python3:

MySQL-python => mysqlclient
python-vote-core => python3-vote-core

I removed RBTools as we're not using Review Board anymore.

Our fork of django-templatesadmin needed updating for Python 3
so it now points at that branch of our fork (which I went ahead and pushed- the change is trivial).

For everything else, I just tried installing whatever pip defaulted to and that seemed to work.