### PR TITLE
The smart_* text functions change in Python3

### DIFF
--- a/apps/gcd/models/image.py
+++ b/apps/gcd/models/image.py
@@ -1,5 +1,4 @@
 import os
-from string import capitalize
 
 from django.db import models
 from django.conf import settings
@@ -92,4 +91,4 @@ class Image(models.Model):
             return ''
 
     def __unicode__(self):
-        return '%s: %s' % (str(self.object), capitalize(self.type.description))
+        return '%s: %s' % (str(self.object), self.type.description.capitalize())

--- a/apps/gcd/views/search.py
+++ b/apps/gcd/views/search.py
@@ -6,7 +6,6 @@ View methods related to displaying search and search results pages.
 from re import match, split, sub
 from urllib.parse import urlencode
 from decimal import Decimal
-from string import capitalize
 from haystack.backends import SQ
 from stdnum import isbn as stdisbn
 from random import randint
@@ -982,7 +981,7 @@ def used_search(search_values):
     elif search_values['target'] == 'issue_cover':
         target = "Covers"
     else:
-        target = capitalize(search_values['target'])
+        target = search_values['target'].capitalize()
         if target[-1] != 's':
             target += 's'
 

--- a/apps/gcd/views/search_haystack.py
+++ b/apps/gcd/views/search_haystack.py
@@ -1,7 +1,7 @@
 import shlex
 from datetime import datetime
 from django.utils.http import urlencode
-from django.utils.encoding import smart_unicode as uni
+from django.utils.encoding import smart_text as uni
 
 from haystack.views import FacetedSearchView
 from apps.gcd.views import ResponsePaginator

--- a/apps/inducks/templatetags/flatfile.py
+++ b/apps/inducks/templatetags/flatfile.py
@@ -7,7 +7,7 @@ from mx.DateTime import DateTimeDelta
 from MySQLdb import OperationalError
 
 from django import template
-from django.utils.encoding import smart_unicode as uni
+from django.utils.encoding import smart_text as uni
 from django.utils.translation import ugettext as _
 from django.utils.translation import activate, deactivate
 from django.core.exceptions import MultipleObjectsReturned 


### PR DESCRIPTION
Since strings in python 3 are always unicode,functions are no longer named after unicode.  I left it imported `as uni` because searching/replacing that seemed like unnecessary noise.