### PR TITLE
Handle HttpResponse needing byte strings

### DIFF
--- a/apps/gcd/views/details.py
+++ b/apps/gcd/views/details.py
@@ -1601,7 +1601,7 @@ def agenda(request, language):
     except HTTPError:
         raise Http404
 
-    a = f.read()
+    a = f.read().decode(encoding='UTF-8')
     # two possibilites here
     # a) use an absolute url to the calendar, but than not all works,
     #    i.e. images don't show
@@ -1623,4 +1623,5 @@ def agenda(request, language):
     javascript_text = '<script type="text/javascript" src="'
     javascript_pos = a.find(javascript_text) + len(javascript_text)
     a = a[:javascript_pos] + '//www.google.com' + a[javascript_pos:]
-    return HttpResponse(a)
+
+    return HttpResponse(a.encode(encoding='UTF-8'))

--- a/apps/oi/import_export.py
+++ b/apps/oi/import_export.py
@@ -758,7 +758,7 @@ def export_issue_to_file(request, issue_id, use_csv=False, revision=False):
         else:
             export += '\t'.join(export_data) + '\r\n'
     if not use_csv:
-        response = HttpResponse(export,
+        response = HttpResponse(export.encode(encoding='UTF-8'),
                                 content_type='text/tab-separated-values')
         response['Content-Disposition'] = 'attachment; filename="%s.tsv"' % \
                                           filename


### PR DESCRIPTION
The only other place we use HttpResponse (writing to the stream a bit at a time) was already doing encoding.