### PR TITLE
Fix next() and keys() for Python 3

### DIFF
--- a/apps/gcd/views/redirect.py
+++ b/apps/gcd/views/redirect.py
@@ -8,7 +8,7 @@ from django.http import HttpResponsePermanentRedirect
 
 
 def _find_key(request, key='SeriesID'):
-    matches = [k for k in list(request.GET.keys()) if re.match('%s$' %key, k, re.IGNORECASE)]
+    matches = [k for k in list(request.GET) if re.match('%s$' %key, k, re.IGNORECASE)]
     if len(matches) > 0:
         return request.GET[matches[0]]
 

--- a/apps/oi/forms/award.py
+++ b/apps/oi/forms/award.py
@@ -63,7 +63,7 @@ class ReceivedAwardRevisionForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(ReceivedAwardRevisionForm, self).__init__(*args, **kwargs)
-        ordering = list(self.fields.keys())
+        ordering = list(self.fields)
         insert_data_source_fields('', ordering, self.fields,
                                   'notes')
         new_fields = OrderedDict([(f, self.fields[f]) for f in ordering])

--- a/apps/oi/forms/creator.py
+++ b/apps/oi/forms/creator.py
@@ -144,7 +144,7 @@ class CreatorRevisionForm(forms.ModelForm):
         self.helper.label_class = 'col-md-3 create-label'
         self.helper.field_class = 'col-md-9'
         self.helper.form_tag = False
-        ordering = list(self.fields.keys())
+        ordering = list(self.fields)
         creator_sourced_fields = _get_creator_sourced_fields()
         for field in creator_sourced_fields:
             insert_data_source_fields(field, ordering, self.fields,
@@ -236,7 +236,7 @@ class CreatorSchoolRevisionForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(CreatorSchoolRevisionForm, self).__init__(*args, **kwargs)
-        ordering = list(self.fields.keys())
+        ordering = list(self.fields)
         insert_data_source_fields('', ordering, self.fields,
                                   'notes')
         new_fields = OrderedDict([(f, self.fields[f]) for f in ordering])
@@ -275,7 +275,7 @@ class CreatorDegreeRevisionForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(CreatorDegreeRevisionForm, self).__init__(*args, **kwargs)
-        ordering = list(self.fields.keys())
+        ordering = list(self.fields)
         insert_data_source_fields('', ordering, self.fields,
                                   'notes')
         new_fields = OrderedDict([(f, self.fields[f]) for f in ordering])
@@ -315,7 +315,7 @@ class CreatorMembershipRevisionForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(CreatorMembershipRevisionForm, self).__init__(*args, **kwargs)
-        ordering = list(self.fields.keys())
+        ordering = list(self.fields)
         insert_data_source_fields('', ordering, self.fields,
                                   'notes')
         new_fields = OrderedDict([(f, self.fields[f]) for f in ordering])
@@ -367,7 +367,7 @@ class CreatorArtInfluenceRevisionForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(CreatorArtInfluenceRevisionForm, self).__init__(*args, **kwargs)
-        ordering = list(self.fields.keys())
+        ordering = list(self.fields)
         insert_data_source_fields('', ordering, self.fields,
                                   'notes')
         new_fields = OrderedDict([(f, self.fields[f]) for f in ordering])
@@ -423,7 +423,7 @@ class CreatorNonComicWorkRevisionForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(CreatorNonComicWorkRevisionForm, self).__init__(*args, **kwargs)
-        ordering = list(self.fields.keys())
+        ordering = list(self.fields)
         insert_data_source_fields('', ordering, self.fields, 'notes')
         new_fields = OrderedDict([(f, self.fields[f]) for f in ordering])
         self.fields = new_fields
@@ -491,7 +491,7 @@ class CreatorRelationRevisionForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(CreatorRelationRevisionForm, self).__init__(*args, **kwargs)
-        ordering = list(self.fields.keys())
+        ordering = list(self.fields)
         insert_data_source_fields('', ordering, self.fields, 'notes')
         new_fields = OrderedDict([(f, self.fields[f]) for f in ordering])
         self.fields = new_fields

--- a/apps/oi/forms/image.py
+++ b/apps/oi/forms/image.py
@@ -92,7 +92,7 @@ class UploadScanForm(forms.Form):
 class UploadVariantScanForm(UploadScanForm):
     def __init__(self, *args, **kwargs):
         super(UploadVariantScanForm, self).__init__(*args, **kwargs)
-        ordering = list(self.fields.keys())
+        ordering = list(self.fields)
         ordering.remove('variant_name')
         ordering.remove('variant_artwork')
         ordering.remove('reservation_requested')

--- a/apps/oi/forms/publisher.py
+++ b/apps/oi/forms/publisher.py
@@ -215,7 +215,7 @@ def get_brand_revision_form(user=None, revision=None,
         def __init__(self, *args, **kw):
             super(BrandRevisionForm, self).__init__(*args, **kw)
             # brand_group_other_publisher_id is last field, move it after group
-            ordering = list(self.fields.keys())
+            ordering = list(self.fields)
             ordering.insert(ordering.index('group') + 1,
                             ordering.pop())
             new_fields = OrderedDict([(f, self.fields[f]) for f in ordering])

--- a/apps/oi/import_export.py
+++ b/apps/oi/import_export.py
@@ -90,7 +90,7 @@ class UTF8Recoder:
         return self
 
     def __next__(self):
-        return self.reader.next().encode("utf-8")
+        return next(self.reader).encode("utf-8")
 
 
 class UnicodeReader:

--- a/apps/oi/models.py
+++ b/apps/oi/models.py
@@ -544,7 +544,7 @@ class Changeset(models.Model):
                                             last.display_number)
             return 'Unknown State'
         elif self.change_type == CTYPES['issue']:
-            return self.cached_revisions.next().queue_name()
+            return next(self.cached_revisions).queue_name()
         elif self.change_type == CTYPES['two_issues']:
             issuerevisions = self.issuerevisions.all()
             name = issuerevisions[0].queue_name() + " and "
@@ -570,7 +570,7 @@ class Changeset(models.Model):
             return '[ADDED]'
         elif self.change_type == CTYPES['variant_add']:
             return '[VARIANT + BASE]'
-        return self.cached_revisions.next().queue_descriptor()
+        return next(self.cached_revisions).queue_descriptor()
 
     def changeset_action(self):
         """
@@ -846,7 +846,7 @@ class Changeset(models.Model):
             # are uniform across all revisions in the change.  When we
             # allow non-uniform changes we may need to calculate all of
             # the imp revisions and take the maximum value or something.
-            self.imps += self.revisions.next().calculate_imps()
+            self.imps += next(self.revisions).calculate_imps()
         else:
             if self.change_type == CTYPES['cover']:
                 # coverrevisions can have issuerevisions and storyrevisions
@@ -1579,11 +1579,11 @@ class Revision(models.Model):
         # old values even for deprecated fields.
         rev_kwargs = {field: getattr(data_object, field)
                       for field
-                      in cls._get_single_value_fields().keys() - exclude}
+                      in set(cls._get_single_value_fields()) - exclude}
 
         # Keywords are not assignable but behave the same way whenever
         # they are present, so handle them here.
-        if 'keywords' in cls._get_regular_fields().keys() - exclude:
+        if 'keywords' in set(cls._get_regular_fields()) - exclude:
             rev_kwargs['keywords'] = get_keywords(data_object)
 
         # Instantiate the revision.  Since we do not know the exact
@@ -1609,7 +1609,7 @@ class Revision(models.Model):
 
         # Populate all of the many to many relations that don't use
         # their own separate revision classes.
-        for m2m in revision._get_multi_value_fields().keys() - exclude:
+        for m2m in set(revision._get_multi_value_fields()) - exclude:
             getattr(revision, m2m).add(*list(getattr(data_object, m2m).all()))
         revision._post_m2m_add(fork=fork, fork_source=data_object,
                                exclude=exclude)
@@ -1720,7 +1720,7 @@ class Revision(models.Model):
 
         deltas = {
             k: new_counts.get(k, 0) - old_counts.get(k, 0)
-            for k in old_counts.keys() | new_counts.keys()
+            for k in set(old_counts) | set(new_counts)
         }
         if any(deltas.values()) or True in list(changes.values()):
             for parent_tuple in self._get_parent_field_tuples():
@@ -4593,9 +4593,9 @@ class StoryRevision(Revision):
                 source_story = fork_source
             # copy single value fields which are specific to biblio_entry
             for field in biblio_revision.\
-                           _get_single_value_fields().keys() - \
+                           list(_get_single_value_fields()) - \
                          biblio_revision.storyrevision_ptr.\
-                           _get_single_value_fields().keys():
+                           list(_get_single_value_fields()):
                 setattr(biblio_revision, field,
                         getattr(source_story.biblioentry, field))
             biblio_revision.save()

--- a/apps/oi/views.py
+++ b/apps/oi/views.py
@@ -2049,7 +2049,7 @@ def _display_add_series_form(request, publisher, form):
 
 
 def init_added_variant(form_class, initial, issue, revision=False):
-    for key in list(initial.keys()):
+    for key in list(initial):
         if key.startswith('_'):
             initial.pop(key)
     if issue.brand:

--- a/apps/select/views.py
+++ b/apps/select/views.py
@@ -45,7 +45,7 @@ def store_select_data(request, select_key, data):
         select_key = hashlib.sha1(salt + str(request.user)).hexdigest()
     for item in data:
         request.session['%s_%s' % (select_key, item)] = data[item]
-    request.session['%s_items' % select_key] = list(data.keys())
+    request.session['%s_items' % select_key] = list(data)
     return select_key
 
 

--- a/apps/voting/views.py
+++ b/apps/voting/views.py
@@ -283,7 +283,7 @@ def vote(request):
     ranks = {}
     if not option_params:
         # ranked_choice, collect all ranks
-        values = list(request.POST.keys())
+        values = list(request.POST)
         for value in values:
             if value.startswith('option'):
                 if request.POST[value]:
@@ -294,7 +294,7 @@ def vote(request):
                         'You must enter a full number for the ranking.')
                 else:
                     ranks[int(value[7:])] = None
-        options = Option.objects.filter(id__in=list(ranks.keys()))
+        options = Option.objects.filter(id__in=list(ranks))
     else:
         options = Option.objects.filter(id__in=option_params)
         # Get all of these now because we may need to iterate twice.


### PR DESCRIPTION
Iteration changes a bit in Python3, with `next()` now a builtin function, and `dict.keys()` removed in favor of just allowing dictionaries to be iterables on their own.  So if you need a `list` of keys, you just build one from the `dict` as an iterable.

Note that some `keys()` calls needed to produce a `set` rather than a `list`, in order to do set operations on the results.