### PR TITLE
No more need for __unicode__()

### DIFF
--- a/apps/gcd/models/award.py
+++ b/apps/gcd/models/award.py
@@ -33,7 +33,7 @@ class Award(GcdData):
                 'show_award',
                 kwargs={'award_id': self.id})
 
-    def __unicode__(self):
+    def __str__(self):
         return str(self.name)
 
 
@@ -91,5 +91,5 @@ class ReceivedAward(GcdData):
                 'show_received_award',
                 kwargs={'received_award_id': self.id})
 
-    def __unicode__(self):
+    def __str__(self):
         return str(self.award_name)

--- a/apps/gcd/models/cover.py
+++ b/apps/gcd/models/cover.py
@@ -83,5 +83,5 @@ class Cover(models.Model):
     def deletable(self):
         return self.revisions.filter(changeset__state__in=states.ACTIVE).count() == 0
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s %s cover' % (self.issue.series, self.issue.display_number)

--- a/apps/gcd/models/creator.py
+++ b/apps/gcd/models/creator.py
@@ -88,7 +88,7 @@ class NameType(models.Model):
     description = models.TextField(default='', blank=True)
     type = models.CharField(max_length=50)
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s' % str(self.type)
 
 
@@ -169,7 +169,7 @@ class CreatorNameDetail(GcdData):
                 'show_creator',
                 kwargs={'creator_id': self.creator.id})
 
-    def __unicode__(self):
+    def __str__(self):
         if self.creator.birth_date.year:
             year = '(b. %s)' % self.creator.birth_date.year
         else:
@@ -197,7 +197,7 @@ class RelationType(models.Model):
     type = models.CharField(max_length=50)
     reverse_type = models.CharField(max_length=50)
 
-    def __unicode__(self):
+    def __str__(self):
         return str(self.type)
 
 
@@ -366,7 +366,7 @@ class Creator(GcdData):
                 'show_creator',
                 kwargs={'creator_id': self.id})
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s' % str(self.gcd_official_name)
 
 
@@ -393,7 +393,7 @@ class CreatorRelation(GcdData):
     notes = models.TextField()
     data_source = models.ManyToManyField(DataSource)
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s >Relation< %s :: %s' % (str(self.from_creator),
                                            str(self.to_creator),
                                            str(self.relation_type)
@@ -412,7 +412,7 @@ class School(models.Model):
 
     school_name = models.CharField(max_length=200)
 
-    def __unicode__(self):
+    def __str__(self):
         return str(self.school_name)
 
 
@@ -444,7 +444,7 @@ class CreatorSchool(GcdData):
                 'show_creator_school',
                 kwargs={'creator_school_id': self.id})
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s - %s' % (str(self.creator),
                             str(self.school.school_name))
 
@@ -461,7 +461,7 @@ class Degree(models.Model):
 
     degree_name = models.CharField(max_length=200)
 
-    def __unicode__(self):
+    def __str__(self):
         return str(self.degree_name)
 
 
@@ -492,7 +492,7 @@ class CreatorDegree(GcdData):
                 'show_creator_degree',
                 kwargs={'creator_degree_id': self.id})
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s - %s' % (str(self.creator),
                             str(self.degree.degree_name))
 
@@ -529,7 +529,7 @@ class CreatorArtInfluence(GcdData):
                 'show_creator_art_influence',
                 kwargs={'creator_art_influence_id': self.id})
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s > %s' % (self.influence(), self.creator.gcd_official_name)
 
 
@@ -545,7 +545,7 @@ class MembershipType(models.Model):
 
     type = models.CharField(max_length=100)
 
-    def __unicode__(self):
+    def __str__(self):
         return str(self.type)
 
 
@@ -579,7 +579,7 @@ class CreatorMembership(GcdData):
     def has_dependents(self):
         return self.creator.pending_deletion()
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s' % str(self.organization_name)
 
 
@@ -595,7 +595,7 @@ class NonComicWorkType(models.Model):
 
     type = models.CharField(max_length=100)
 
-    def __unicode__(self):
+    def __str__(self):
         return str(self.type)
 
 
@@ -611,7 +611,7 @@ class NonComicWorkRole(models.Model):
 
     role_name = models.CharField(max_length=200)
 
-    def __unicode__(self):
+    def __str__(self):
         return str(self.role_name)
 
 
@@ -676,7 +676,7 @@ class CreatorNonComicWork(GcdData):
                 'show_creator_non_comic_work',
                 kwargs={'creator_non_comic_work_id': self.id})
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s' % (str(self.publication_title))
 
 
@@ -697,6 +697,6 @@ class NonComicWorkYear(models.Model):
     work_year = models.PositiveSmallIntegerField(null=True)
     work_year_uncertain = models.BooleanField(default=False)
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s - %s' % (str(self.non_comic_work),
                             str(self.work_year))

--- a/apps/gcd/models/datasource.py
+++ b/apps/gcd/models/datasource.py
@@ -15,7 +15,7 @@ class SourceType(models.Model):
 
     type = models.CharField(max_length=50)
 
-    def __unicode__(self):
+    def __str__(self):
         return str(self.type)
 
 
@@ -34,7 +34,7 @@ class DataSource(GcdData):
     source_description = models.TextField()
     field = models.CharField(max_length=256)
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s - %s' % (str(self.field),
                             str(self.source_type.type))
 

--- a/apps/gcd/models/feature.py
+++ b/apps/gcd/models/feature.py
@@ -24,7 +24,7 @@ class FeatureRelationType(models.Model):
     description = models.CharField(max_length=255)
     reverse_description = models.CharField(max_length=255)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
@@ -36,7 +36,7 @@ class FeatureType(models.Model):
 
     name = models.CharField(max_length=255, db_index=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
@@ -78,7 +78,7 @@ class Feature(GcdData):
                 'show_feature',
                 kwargs={'feature_id': self.id})
 
-    def __unicode__(self):
+    def __str__(self):
         base_name = str('%s (%s)' % (self.name, self.language.name))
         if self.feature_type.id != 1:
             base_name += ' [%s]' % self.feature_type.name[0]
@@ -147,9 +147,9 @@ class FeatureLogo(GcdData):
             kwargs={'feature_logo_id': self.id } )
 
     def full_name(self):
-        return self.__unicode__()
+        return self.__str__()
 
-    def __unicode__(self):
+    def __str__(self):
         return str(self.name)
 
 
@@ -172,7 +172,7 @@ class FeatureRelation(GcdLink):
                                       related_name='relation_type')
     notes = models.TextField()
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s >Relation< %s :: %s' % (str(self.from_feature),
                                            str(self.to_feature),
                                            str(self.relation_type)

--- a/apps/gcd/models/image.py
+++ b/apps/gcd/models/image.py
@@ -21,7 +21,7 @@ class ImageType(models.Model):
     unique = models.BooleanField(default=True)
     description = models.CharField(max_length=255)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 # we need to save the model instance first without a file to get an id and
@@ -91,5 +91,5 @@ class Image(models.Model):
         else:
             return ''
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s: %s' % (str(self.object), capitalize(self.type.description))

--- a/apps/gcd/models/issue.py
+++ b/apps/gcd/models/issue.py
@@ -426,7 +426,7 @@ class Issue(GcdData):
         else:
             return '%s %s' % (self.series.name, self.display_number)
 
-    def __unicode__(self):
+    def __str__(self):
         if self.variant_name:
             return '%s %s [%s]' % (self.series, self.display_number,
                                     self.variant_name)

--- a/apps/gcd/models/issuereprint.py
+++ b/apps/gcd/models/issuereprint.py
@@ -48,5 +48,5 @@ class IssueReprint(models.Model):
             reprint = '%s [%s]' % (reprint, esc(self.notes))
         return mark_safe(reprint)
 
-    def __unicode__(self):
+    def __str__(self):
         return 'from %s reprint in %s' % (self.origin_issue, self.target_issue)

--- a/apps/gcd/models/publisher.py
+++ b/apps/gcd/models/publisher.py
@@ -63,7 +63,7 @@ class BasePublisher(GcdData):
     def full_name(self):
         return str(self)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
@@ -347,7 +347,7 @@ class BrandUse(GcdLink):
             'show_brand',
             kwargs={'brand_id': self.emblem.id } )
 
-    def __unicode__(self):
+    def __str__(self):
         return 'emblem %s was used from %s to %s by %s.' % (self.emblem,
           _display_year(self.year_began, self.year_began_uncertain),
           _display_year(self.year_ended, self.year_ended_uncertain),

--- a/apps/gcd/models/reprint.py
+++ b/apps/gcd/models/reprint.py
@@ -48,6 +48,6 @@ class Reprint(models.Model):
             reprint = '%s [%s]' % (reprint, esc(self.notes))
         return mark_safe(reprint)
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s of %s is reprinted in %s of %s' % (self.origin,
           self.origin.issue, self.target, self.target.issue)

--- a/apps/gcd/models/reprintfromissue.py
+++ b/apps/gcd/models/reprintfromissue.py
@@ -51,6 +51,6 @@ class ReprintFromIssue(models.Model):
             reprint = '%s [%s]' % (reprint, esc(self.notes))
         return mark_safe(reprint)
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s reprinted in %s of %s' % (self.origin_issue, self.target,
                                               self.target.issue)

--- a/apps/gcd/models/reprinttoissue.py
+++ b/apps/gcd/models/reprinttoissue.py
@@ -51,6 +51,6 @@ class ReprintToIssue(models.Model):
             reprint = '%s [%s]' % (reprint, esc(self.notes))
         return mark_safe(reprint)
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s of %s reprinted in %s' % (self.origin, self.origin.issue,
                                               self.target_issue)

--- a/apps/gcd/models/series.py
+++ b/apps/gcd/models/series.py
@@ -36,7 +36,7 @@ class SeriesPublicationType(models.Model):
     name = models.CharField(max_length=255, db_index=True)
     notes = models.TextField()
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
@@ -432,7 +432,7 @@ class Series(GcdData):
             else:
                 return mark_safe('<a href="%s">Add</a>' % (table_url))
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s (%s%s series)' % (self.name, self.year_began,
                                      self._date_uncertain(
                                        self.year_began_uncertain))

--- a/apps/gcd/models/seriesbond.py
+++ b/apps/gcd/models/seriesbond.py
@@ -17,7 +17,7 @@ class SeriesBondType(models.Model):
     description = models.TextField()
     notes = models.TextField(blank=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.description
 
 class SeriesBond(models.Model):
@@ -47,7 +47,7 @@ class SeriesBond(models.Model):
     def deletable(self):
         return True
 
-    def __unicode__(self):
+    def __str__(self):
         if self.origin_issue:
             object_string = '%s' % self.origin_issue
         else:

--- a/apps/gcd/models/story.py
+++ b/apps/gcd/models/story.py
@@ -119,7 +119,7 @@ class StoryType(models.Model):
     def natural_key(self):
         return (self.name,)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
@@ -268,7 +268,7 @@ class Story(GcdData):
             'show_issue',
             kwargs={'issue_id': self.issue_id}) + "#%d" % self.id
 
-    def __unicode__(self):
+    def __str__(self):
         from apps.gcd.templatetags.display import show_story_short
         return show_story_short(self, no_number=True, markup=False)
 

--- a/apps/indexer/models.py
+++ b/apps/indexer/models.py
@@ -134,7 +134,7 @@ class Indexer(models.Model):
     def get_absolute_url(self):
         return self.user.get_absolute_url()
 
-    def __unicode__(self):
+    def __str__(self):
         if self.user.first_name and self.user.last_name:
             full_name = '%s %s' % (self.user.first_name, self.user.last_name)
         elif self.user.first_name:
@@ -170,5 +170,5 @@ class Error(models.Model):
 
     is_safe = models.BooleanField(default=False)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.error_text

--- a/apps/inducks/models/appearance.py
+++ b/apps/inducks/models/appearance.py
@@ -17,5 +17,5 @@ class Appearance(models.Model):
                                   db_column = 'charactercode')
     story_version = models.ForeignKey(StoryVersion, 
                             db_column = 'storyversioncode', null = True)
-    #def __unicode__(self):
+    #def __str__(self):
         #return str(self.character) + str(self.story_version)

--- a/apps/inducks/models/basestory.py
+++ b/apps/inducks/models/basestory.py
@@ -21,6 +21,6 @@ class BaseStory(models.Model):
     error_message = models.TextField(db_column = 'errormessage', null = True)
     original_story = models.CharField(max_length = 20, 
                                     db_column = 'originalstoryversioncode')
-    def __unicode__(self):
+    def __str__(self):
         return self.id
 

--- a/apps/inducks/models/basicstory.py
+++ b/apps/inducks/models/basicstory.py
@@ -21,6 +21,6 @@ class BaseStory(models.Model):
                              null = True)
     error_message = models.TextField(db_column = 'errormessage', null = True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.id
 

--- a/apps/inducks/models/charactername.py
+++ b/apps/inducks/models/charactername.py
@@ -19,5 +19,5 @@ class CharacterName(models.Model):
                                  db_column = 'languagecode')
     preferred = models.CharField(max_length = 5, db_column = 'preferred')
     
-    def __unicode__(self):
+    def __str__(self):
         return str(self.character) + str(self.name) + str(self.language)

--- a/apps/inducks/models/country.py
+++ b/apps/inducks/models/country.py
@@ -16,5 +16,5 @@ class Country(models.Model):
     language = models.CharField(db_column = 'defaultlanguage',
                                 max_length = 100, null = True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name

--- a/apps/inducks/models/countryname.py
+++ b/apps/inducks/models/countryname.py
@@ -16,5 +16,5 @@ class CountryName(models.Model):
     name = models.CharField(max_length = 20, db_column = 'countryname')
     language = models.ForeignKey(Language, primary_key = True, 
                                  db_column = 'languagecode')
-    def __unicode__(self):
+    def __str__(self):
         return self.name

--- a/apps/inducks/models/issue.py
+++ b/apps/inducks/models/issue.py
@@ -31,5 +31,5 @@ class Issue(models.Model):
     series = models.ForeignKey(Series,
                                db_column = 'publicationcode')
 
-    def __unicode__(self):
+    def __str__(self):
         return str(self.series.name) + " #" + self.number

--- a/apps/inducks/models/language.py
+++ b/apps/inducks/models/language.py
@@ -16,5 +16,5 @@ class Language(models.Model):
     class Admin:
         pass
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name + " (" + self.code + ")"

--- a/apps/inducks/models/languagename.py
+++ b/apps/inducks/models/languagename.py
@@ -15,5 +15,5 @@ class LanguageName(models.Model):
     name = models.CharField(max_length = 20, db_column = 'languagename')
     language = models.ForeignKey(Language, 
                                  db_column = 'languagecode')
-    def __unicode__(self):
+    def __str__(self):
         return self.name

--- a/apps/inducks/models/series.py
+++ b/apps/inducks/models/series.py
@@ -38,6 +38,6 @@ class Series(models.Model):
     def get_absolute_url(self):
         return "/gcd/series/%i/" % self.id
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 

--- a/apps/inducks/models/story.py
+++ b/apps/inducks/models/story.py
@@ -45,6 +45,6 @@ class Story(models.Model):
     language = models.ForeignKey(Language, primary_key = True, 
                                  db_column = 'languagecode')
 
-    def __unicode__(self):
+    def __str__(self):
         return self.id
 

--- a/apps/inducks/models/storyversion.py
+++ b/apps/inducks/models/storyversion.py
@@ -34,6 +34,6 @@ class StoryVersion(models.Model):
                             db_column = 'storycode', null = False)
 
 
-    def __unicode__(self):
+    def __str__(self):
         return self.id
 

--- a/apps/mycomics/models.py
+++ b/apps/mycomics/models.py
@@ -127,7 +127,7 @@ class Collection(models.Model):
         return urlresolvers.reverse('view_collection',
                                     kwargs={'collection_id':self.id})
 
-    def __unicode__(self):
+    def __str__(self):
         return str(self.name)
 
 
@@ -150,7 +150,7 @@ class Location(models.Model):
     name = models.CharField(blank=True, max_length=255)
     description = models.TextField(blank=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return str(self.name)
 
 
@@ -163,7 +163,7 @@ class PurchaseLocation(models.Model):
     name = models.CharField(blank=True, max_length=255)
     description = models.TextField(blank=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return str(self.name)
 
 
@@ -243,7 +243,7 @@ class ConditionGradeScale(models.Model):
     name=models.CharField(blank=False,max_length=255)
     description=models.CharField(max_length=2000, blank=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return str(self.name)
 
 
@@ -261,6 +261,6 @@ class ConditionGrade(models.Model):
     def __cmp__(self, other):
         return self.value.__cmp__(other.value)
 
-    def __unicode__(self):
+    def __str__(self):
         return "%s - %s" % (self.code, self.name)
 

--- a/apps/oi/models.py
+++ b/apps/oi/models.py
@@ -899,7 +899,7 @@ class Changeset(models.Model):
             return calculated + IMP_BONUS_ADD
         return calculated
 
-    def __unicode__(self):
+    def __str__(self):
         if self.inline():
             return str(self.inline_revision())
         if self.change_type in CTYPES_BULK:
@@ -1964,7 +1964,7 @@ class Revision(models.Model):
     # #####################################################################
     # Methods not involved in the Revision lifecycle.
 
-    def __unicode__(self):
+    def __str__(self):
         """
         String representation for debugging purposes only.
 
@@ -2152,7 +2152,7 @@ class Revision(models.Model):
     def queue_name(self):
         """
         Long name form to display in queues.
-        This allows revision objects to use their linked object's __unicode__
+        This allows revision objects to use their linked object's __str__
         method for compatibility in preview pages, but display a more
         verbose form in places like queues that need them.
 
@@ -2233,7 +2233,7 @@ class OngoingReservation(models.Model):
     """
     created = models.DateTimeField(auto_now_add=True, db_index=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s reserved by %s' % (self.series, self.indexer.indexer)
 
 
@@ -2252,7 +2252,7 @@ class PublisherRevisionBase(Revision):
     keywords = models.TextField(blank=True, default='')
     url = models.URLField(blank=True)
 
-    def __unicode__(self):
+    def __str__(self):
         if self.source is None:
             return self.name
         return str(self.source)
@@ -2743,7 +2743,7 @@ class BrandUseRevision(Revision):
         self.publisher = publisher
         self.emblem = emblem
 
-    def __unicode__(self):
+    def __str__(self):
         return 'brand emblem %s used by %s.' % (self.emblem, self.publisher)
 
     ######################################
@@ -2988,7 +2988,7 @@ class CoverRevision(Revision):
             return "/cover/revision/%i/preview" % self.id
         return self.cover.get_absolute_url()
 
-    def __unicode__(self):
+    def __str__(self):
         return str(self.issue)
 
 
@@ -3174,7 +3174,7 @@ class SeriesRevision(Revision):
             return "/series/revision/%i/preview" % self.id
         return self.series.get_absolute_url()
 
-    def __unicode__(self):
+    def __str__(self):
         if self.series is None:
             return '%s (%s series)' % (self.name, self.year_began)
         return str(self.series)
@@ -3364,7 +3364,7 @@ class SeriesBondRevision(Revision):
             self.series_bond = series_bond
             self.save()
 
-    def __unicode__(self):
+    def __str__(self):
         if self.origin_issue:
             object_string = '%s' % self.origin_issue
         else:
@@ -4193,7 +4193,7 @@ class IssueRevision(Revision):
         else:
             return '%s %s' % (self.series.name, self.display_number)
 
-    def __unicode__(self):
+    def __str__(self):
         """
         Re-implement locally instead of using self.issue because it may change.
         """
@@ -4722,7 +4722,7 @@ class StoryRevision(Revision):
     def show_feature(self):
         return show_feature(self)
 
-    def __unicode__(self):
+    def __str__(self):
         """
         Re-implement locally instead of using self.story because it may change.
         """
@@ -5253,7 +5253,7 @@ class FeatureRevision(Revision):
             return "/feature/revision/%i/preview" % self.id
         return self.feature.get_absolute_url()
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s' % (self.name)
 
     ######################################
@@ -5347,7 +5347,7 @@ class FeatureLogoRevision(Revision):
             return "/feature_logo/revision/%i/preview" % self.id
         return self.feature_logo.get_absolute_url()
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s' % (self.name)
 
     ######################################
@@ -5460,7 +5460,7 @@ class FeatureRelationRevision(Revision):
             self.feature_relation = feature_relation
             self.save()
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s >%s< %s' % (str(self.from_feature),
                                 str(self.relation_type),
                                 str(self.to_feature)
@@ -5884,7 +5884,7 @@ class ReprintRevision(Revision):
                     show_story_short(self.previous_revision.origin_story)
         return mark_safe(reprint)
 
-    def __unicode__(self):
+    def __str__(self):
         from apps.gcd.templatetags.credits import show_title
         if self.origin_story or self.origin_revision:
             if self.origin_story:
@@ -6040,7 +6040,7 @@ class ImageRevision(Revision):
             _clear_image_cache(image.icon)
         self.save()
 
-    def __unicode__(self):
+    def __str__(self):
         if self.source is None:
             return 'Image for %s' % str(self.object)
         return str(self.source)
@@ -6082,7 +6082,7 @@ class AwardRevision(Revision):
             return "/award/revision/%i/preview" % self.id
         return self.award.get_absolute_url()
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     # #####################################################################
@@ -6157,7 +6157,7 @@ class ReceivedAwardRevision(Revision):
             return "/received_award/revision/%i/preview" % self.id
         return self.received_award.get_absolute_url()
 
-    def __unicode__(self):
+    def __str__(self):
         if self.award:
             name = '%s - %s' % (self.award.name, self.award_name)
         else:
@@ -6316,7 +6316,7 @@ class DataSourceRevision(Revision):
             self.data_source = data_source
             self.save()
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s - %s' % (
             str(self.field), str(self.source_type.type))
 
@@ -6659,7 +6659,7 @@ class CreatorRevision(Revision):
             return "/creator/revision/%i/preview" % self.id
         return self.creator.get_absolute_url()
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s' % str(self.gcd_official_name)
 
     # #####################################################################
@@ -6866,7 +6866,7 @@ class CreatorRelationRevision(Revision):
             self.creator_relation = creator_relation
             self.save()
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s >%s< %s' % (str(self.from_creator),
                                 str(self.relation_type),
                                 str(self.to_creator)
@@ -6926,7 +6926,7 @@ class CreatorNameDetailRevision(Revision):
     def _post_create_for_add(self, changes):
         self.creator = self.creator_revision.creator
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s - %s (%s)' % (
             str(self.creator), str(self.name), str(self.type.type))
 
@@ -7012,7 +7012,7 @@ class CreatorSchoolRevision(Revision):
             return "/creator_school/revision/%i/preview" % self.id
         return self.creator_school.get_absolute_url()
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s - %s' % (
             str(self.creator), str(self.school.school_name))
 
@@ -7121,7 +7121,7 @@ class CreatorDegreeRevision(Revision):
             return "/creator_degree/revision/%i/preview" % self.id
         return self.creator_degree.get_absolute_url()
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s - %s' % (
             str(self.creator), str(self.degree.degree_name))
 
@@ -7225,7 +7225,7 @@ class CreatorMembershipRevision(Revision):
             return "/creator_membership/revision/%i/preview" % self.id
         return self.creator_membership.get_absolute_url()
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s: %s' % (self.creator, str(self.organization_name))
 
     # #####################################################################
@@ -7337,7 +7337,7 @@ class CreatorArtInfluenceRevision(Revision):
             return "/creator_art_influence/revision/%i/preview" % self.id
         return self.creator_art_influence.get_absolute_url()
 
-    def __unicode__(self):
+    def __str__(self):
         if self.influence_name:
             influence = self.influence_name
         else:
@@ -7499,7 +7499,7 @@ class CreatorNonComicWorkRevision(Revision):
             return "/creator_non_comic_work/revision/%i/preview" % self.id
         return self.creator_non_comic_work.get_absolute_url()
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s: %s' % (str(self.creator),
                             str(self.publication_title))
 

--- a/apps/oi/relpath.py
+++ b/apps/oi/relpath.py
@@ -166,7 +166,7 @@ class RelPath(object):
                 values.append(self.get_empty_value(field=self._fields[i]))
         return values
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s.%s' % (self._first_model_class.__name__,
                           '.'.join(self._names))
 

--- a/apps/stats/models.py
+++ b/apps/stats/models.py
@@ -149,7 +149,7 @@ class CountStats(models.Model):
     language = models.ForeignKey(Language, null=True)
     country = models.ForeignKey(Country, null=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name + ": " + str(self.count)
 
 

--- a/apps/stddata/models.py
+++ b/apps/stddata/models.py
@@ -24,7 +24,7 @@ class Country(models.Model):
         """
         return (self.code,)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
@@ -50,7 +50,7 @@ class Currency(models.Model):
     def natural_key(self):
         return (self.code,)
 
-    def __unicode__(self):
+    def __str__(self):
         return str(self.code) + " - " + str(self.name)
 
 
@@ -88,7 +88,7 @@ class Date(models.Model):
         self.day_uncertain = day_uncertain or (not day and not empty) \
                                            or (day is not None and '?' in day)
 
-    def __unicode__(self):
+    def __str__(self):
         year = self.year or ''
         if self.year_uncertain and '?' not in year:
             year += '?'
@@ -137,7 +137,7 @@ class Language(models.Model):
         else:
             return self.name
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 

--- a/apps/voting/models.py
+++ b/apps/voting/models.py
@@ -69,7 +69,7 @@ class MailingList(models.Model):
     class Meta:
         db_table = 'voting_mailing_list'
     address = models.EmailField()
-    def __unicode__(self):
+    def __str__(self):
         return self.address
 
 class Agenda(models.Model):
@@ -89,7 +89,7 @@ class Agenda(models.Model):
     def get_absolute_url(self):
         return urlresolvers.reverse('agenda', kwargs={'id': self.id})
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 class AgendaItem(models.Model):
@@ -123,7 +123,7 @@ class AgendaItem(models.Model):
     def closed(self):
         return self.state is False
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 def agenda_item_pre_save(sender, **kwargs):
@@ -224,7 +224,7 @@ class VoteType(models.Model):
     def natural_key(self):
         return (self.name,)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 class Topic(models.Model):
@@ -323,7 +323,7 @@ class Topic(models.Model):
         receipts = self.receipts.filter(voter=user)
         return votes.count() > 0 or receipts.count() > 0
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 def topic_pre_save(sender, **kwargs):
@@ -406,7 +406,7 @@ class Option(models.Model):
     def rank(self, user):
         return self.votes.get(voter=user).rank
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 class Receipt(models.Model):
@@ -425,7 +425,7 @@ class Vote(models.Model):
     created = models.DateTimeField(auto_now_add=True, editable=False)
     updated = models.DateTimeField(null=True, auto_now=True, editable=False)
 
-    def __unicode__(self):
+    def __str__(self):
         string = '%s: %s' % (self.voter.indexer, self.option)
         if self.rank is not None:
             return string + (' %d' % self.rank)
@@ -442,7 +442,7 @@ class ExpectedVoter(models.Model):
         ordering = ('tenure_began', 'tenure_ended',
                     'voter__last_name', 'voter__first_name')
 
-    def __unicode__(self):
+    def __str__(self):
         uni = '%s (%s - ' % (self.voter_name(), self.tenure_began)
         if self.tenure_ended is None:
             return uni + 'present)'


### PR DESCRIPTION
In Python 3 there is only __str__()!

This looks like a lot but it's all the exact same change.  We can also go through and remove a fair number of `str(foo)` calls that used to be `unicode(foo)` because `foo` was not necessarily unicode (`2to3` changed those calls automatically), but I opted not to do that now in order to keep the changes minimal.  We can do those nice-to-haves after we've cut over to Python3 in production.