### PR TITLE
Get elasticsearch working for searches

### DIFF
--- a/apps/gcd/views/search_haystack.py
+++ b/apps/gcd/views/search_haystack.py
@@ -76,7 +76,7 @@ def parse_query_into_sq(query, fields):
     sq = None
     not_sq = None
     or_flag = False
-    for phrase in safe_split(query.encode('utf-8')):
+    for phrase in safe_split(query):
         if phrase[0] == '-' and len(phrase) > 1:
             not_sq = prepare_sq(phrase[1:], fields, not_sq)
             or_flag = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ git+git://github.com/GrandComicsDatabase/django-mobile.git@django111
 django-model-utils<3.3
 git+git://github.com/GrandComicsDatabase/django-taggit.git@django111
 git+git://github.com/GrandComicsDatabase/django-templatesadmin.git@python3
-elasticsearch<7.2
+elasticsearch<2.0
 elasticstack<0.6
 facebook-sdk<3.2
 python-graph-core<1.9

--- a/settings.py
+++ b/settings.py
@@ -258,6 +258,9 @@ HAYSTACK_CONNECTIONS = {
     },
 }
 
+# This processes the updates inline, and shouldn't be used in production.
+HAYSTACK_SIGNAL_PROCESSOR = 'haystack.signals.RealtimeSignalProcessor'
+
 # assumingly this needs elasticstack
 ELASTICSEARCH_INDEX_SETTINGS = {
     # index settings


### PR DESCRIPTION
This downgrades us back to the appropriate elasticsearch library for our existing version of elasticsearch.  We'll look at updating that after Python3 is deployed.

This will now index the database and run searches successfully.  It is not yet updating the index on a new write to the database, but that can be a later PR.