### PR TITLE
The db query does not distinguish accented chars, try in code where accents do need to match so we migrate more creators automatically

### DIFF
--- a/apps/oi/models.py
+++ b/apps/oi/models.py
@@ -5290,6 +5290,12 @@ class StoryRevision(Revision):
                         credit = credit.strip().strip(']')
                     creator = CreatorNameDetail.objects.filter(name=credit,
                                                                deleted=False)
+
+                    if creator.count() > 1:
+                        # Database query cannot filter down to accent level (i.e. e versus é), so we try in code
+                        # If we still end up with > 1 then theres probably genuinely two different creators
+                        creator = [c for c in creator if c.name == credit]
+
                     if creator.count() == 1:
                         creator = creator.get()
                         if uncertain and not creator.is_official_name:


### PR DESCRIPTION
This is untested and not compiled.

If it looks good as an idea though let me know here or on the GCC tech thread I've just opened and I'll happily test this on beta.