### PR TITLE
Update from now unavailable git: protocol

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,8 +20,8 @@ django-recaptcha<2.1
 django-rosetta
 django-tables2<2.5
 django-model-utils<4.2
-git+git://github.com/GrandComicsDatabase/django-taggit.git@django32
-git+git://github.com/GrandComicsDatabase/django-templatesadmin.git@python3
+git+https://github.com/GrandComicsDatabase/django-taggit.git@django32
+git+https://github.com/GrandComicsDatabase/django-templatesadmin.git@python3
 chardet<3.1
 elasticsearch<3.0
 python-memcached<1.60
@@ -51,4 +51,4 @@ django-extensions<3.2
 redis<3.6
 rq<2.0
 django-rq<2.5
-git+git://github.com/mandx/haystack-rqueue.git
+git+https://github.com/mandx/haystack-rqueue.git


### PR DESCRIPTION
Noticed this when trying the docker way today. Github is now blocking the git protocol, so need to update. This then works with the docker file (please check any other consumption).

See https://github.blog/2021-09-01-improving-git-protocol-security-github/ .