### PR TITLE
Keep bracketed text when feature migration fails

### DIFF
--- a/apps/oi/models.py
+++ b/apps/oi/models.py
@@ -5712,10 +5712,11 @@ class StoryRevision(Revision):
             features = self.feature.split(';')
             old_features = ''
             for feature in features:
-                if feature.find('[') > 1:
-                    feature = feature[:feature.find('[')]
                 feature = feature.strip()
                 save_feature = feature
+                if feature.find('[') > 1:
+                    feature = feature[:feature.find('[')]
+                    feature = feature.strip()
                 feature_object = Feature.objects.filter(
                   name=feature, deleted=False, feature_type__id=1,
                   language=self.issue.series.language)


### PR DESCRIPTION
I believe this will fix #557, but I'm making this change blind and without testing.