### PR TITLE
Fix some broken tests

### DIFF
--- a/apps/gcd/tests/test_series.py
+++ b/apps/gcd/tests/test_series.py
@@ -161,11 +161,11 @@ def test_active_base_issues_variant_count():
             mock.patch('apps.gcd.models.series.Count') as count_class_mock:
         count_mock = mock.MagicMock(spec=Count)
         count_class_mock.return_value = count_mock
-        ab_issues.return_value.annotate.return_value = 100
+        ab_issues.return_value.order_by.return_value.annotate.return_value = 100
 
         s = Series()
         assert s.active_base_issues_variant_count() == 100
-        s.active_base_issues.return_value.annotate.assert_called_once_with(
+        s.active_base_issues.return_value.order_by.return_value.annotate.assert_called_once_with(
             variant_count=count_mock)
 
 

--- a/apps/oi/tests/conftest.py
+++ b/apps/oi/tests/conftest.py
@@ -38,6 +38,7 @@ def django_db_setup(django_db_setup, django_db_blocker):
         CountStats.objects.init_stats()
         CountStats.objects.init_stats(country=any_country())
 
+
 @pytest.fixture
 def any_changeset(any_indexer):
     """

--- a/apps/oi/tests/test_issue_revision.py
+++ b/apps/oi/tests/test_issue_revision.py
@@ -69,6 +69,7 @@ def test_classification():
         'on_sale_date': gf('on_sale_date'),
         'sort_code': gf('sort_code'),
         'is_indexed': gf('is_indexed'),
+        'external_link': gf('external_link'),
     }
 
     assert IssueRevision._get_regular_fields() == regular_fields
@@ -155,7 +156,7 @@ def test_pre_initial_save_no_date():
     assert rev.day_on_sale is None
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def pre_commit_rev():
     with mock.patch('%s._same_series_revisions' % IREV), \
             mock.patch('%s._same_series_open_with_after' % IREV):
@@ -253,7 +254,7 @@ def test_pre_commit_check_after_not_first(pre_commit_rev):
             "the lowest revision_sort_code.") in str(excinfo.value)
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def multiple_issue_revs():
     with mock.patch('apps.oi.models.Issue.objects') as obj_mock, \
             mock.patch('%s._same_series_revisions' % IREV) as same_mock, \
@@ -415,7 +416,7 @@ def test_handle_prerequisites_non_move_edit():
         assert not open_mock.called
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def multiple_issue_revs_pre_stats(multiple_issue_revs):
     # While multiple_issue_revs has a few things the pre_stats_measurement
     # tests don't need, those things are harmless, and otherwise the
@@ -505,7 +506,7 @@ def test_handle_prerequisites_exit_infinite_loop(
     rev3.commit_to_display.assert_called_once_with()
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_for_optional_move():
     with mock.patch('%s.set_first_last_issues' % SERIES), \
             mock.patch('%s.scan_count' % SERIES), \
@@ -532,7 +533,7 @@ def test_post_save_no_series_changed(patch_for_optional_move):
     s.set_first_last_issues.assert_called_once_with()
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_for_move(patch_for_optional_move):
     patch_for_optional_move.return_value = True
 
@@ -635,7 +636,7 @@ def story_revs():
             mock.MagicMock(spec=StoryRevision)]
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patched_edit(story_revs):
     with mock.patch(RECENT) as recent_mock, mock.patch(SAVE), \
             mock.patch('%s.storyrevisions' % CSET) as story_mock:

--- a/apps/oi/tests/test_reprint_revision.py
+++ b/apps/oi/tests/test_reprint_revision.py
@@ -7,7 +7,7 @@ from apps.gcd.models import Story, Issue, Series
 from apps.oi.models import StoryRevision, ReprintRevision, Changeset
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patched_for_save():
     def story_uni(self):
         return self.title
@@ -27,7 +27,7 @@ def patched_for_save():
                      issue=Issue(number='9', title='t issue', series=s)))
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patched_for_commit(patched_for_save):
     # We don't actually need save patched, but it's harmless and easy.
     save_mock, origin, target = patched_for_save

--- a/apps/oi/tests/test_revision.py
+++ b/apps/oi/tests/test_revision.py
@@ -308,7 +308,7 @@ def test_check_major_change_no_changes():
     }
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mock_update_all():
     with mock.patch(
             'apps.oi.models.CountStats.objects.update_all_counts') \
@@ -316,7 +316,7 @@ def mock_update_all():
         yield uac_mock
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patched_other_dummy():
     # Don't set a source- this way we can just fake the country/language stuff.
     # Note that OtherDummy.save must be patched before
@@ -481,7 +481,7 @@ def test_adjust_parent_counts_multi_no_change(patched_other_dummy):
             v.save.assert_called_once_with()
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patched_dummy():
     p = 'apps.oi.models.Revision'
     with mock.patch('%s._copy_fields_to' % p), \
@@ -574,7 +574,7 @@ def test_commit_deleted(patched_dummy):
     data_obj.save.assert_called_once_with()
 
     # stat_counts called twice for deletes, at beginning and end.
-    d.source.stat_counts.has_calls([mock.call(), mock.call()])
+    d.source.stat_counts.assert_has_calls([mock.call(), mock.call()])
     assert d.source.stat_counts.call_count == 2
     d._adjust_stats.assert_called_once_with(changes, stats[0], stats[1])
     d._handle_dependents.assert_called_once_with(changes)
@@ -614,7 +614,7 @@ def test_commit_edited_dont_clear(patched_dummy):
     data_obj.save.assert_called_once_with()
 
     # stat_counts called twice for deletes, at beginning and end.
-    d.source.stat_counts.has_calls([mock.call(), mock.call()])
+    d.source.stat_counts.assert_has_calls([mock.call(), mock.call()])
     assert d.source.stat_counts.call_count == 2
     d._adjust_stats.assert_called_once_with(changes, stats[0], stats[1])
     d._handle_dependents.assert_called_once_with(changes)

--- a/apps/oi/tests/test_series_revision.py
+++ b/apps/oi/tests/test_series_revision.py
@@ -29,7 +29,7 @@ def test_excluded_fields():
     } | Revision._get_excluded_field_names()
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patched_series_class():
     """ Patches foreign keys to prevent database access. """
     with mock.patch('%s.previous_revision' % SREV) as pr, \
@@ -201,7 +201,7 @@ def test_get_major_changes_deleted(patched_series_class):
     }
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def series_and_revision():
     """
     Tuple of series, series revision, and a mock of update_all_counts.
@@ -335,7 +335,7 @@ def test_post_assign_fields_leading_article(leading_article, name, sort_name):
     assert s.sort_name == sort_name
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def pre_save_mocks():
     with mock.patch('%s.get_ongoing_reservation' % SERIES) as get_ongoing, \
       mock.patch('apps.gcd.models.series.Series.scan_count',


### PR DESCRIPTION
- Pass test_active_base_issues_variant_count
- Pass test_classification
- Pass test_commit_deleted
- Pass test_commit_edited_dont_clear
- Follow PEP8 in conftest.py
- Prefer @pytest.fixture over @pytest.yield_fixture Yield_fixture has been deprecated for some time.