### PR TITLE
Daily creators: Use window.scrollTo() in iframe when loading previous day

### DIFF
--- a/static/js/infinite_scroll.js
+++ b/static/js/infinite_scroll.js
@@ -31,7 +31,7 @@ const attachInfiniteScroll = (sentinel, scrollElement, baseUrl, addUrl, directio
         if (direction < 0){
           scrollElement.innerHTML = body + scrollElement.innerHTML;
           let elements = document.getElementById('top-scroll-element').getElementsByTagName('p');
-          elements[1].scrollIntoView();
+          window.scrollTo(0, elements[1].offsetTop);
         } else {
           scrollElement.innerHTML += body ;
         }
@@ -43,3 +43,4 @@ const attachInfiniteScroll = (sentinel, scrollElement, baseUrl, addUrl, directio
   })
   observer.observe(sentinel);
 };
+

--- a/templates/gcd/bits/daily_creators.html
+++ b/templates/gcd/bits/daily_creators.html
@@ -1,3 +1,8 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>GCD Daily Creators</title>
 {% load display %}
 {% load compress %}
 {% load static %}
@@ -5,12 +10,9 @@
   <link rel="stylesheet" type="text/css"
         href="{% static "css/gcd/default.css" %}"/>
 {% endcompress %}
-{% compress js %}
-<script type="text/javascript"
-        src="{% static "js/infinite_scroll.js" %}"></script>
-{% endcompress %}
-
 <base target="_parent">
+</head>
+<body>
 
 <div style="font-size: 0.9em;">
 
@@ -31,21 +33,21 @@
   <div id="bottom-sentinel">...</div>
 </div>
 
+{% compress js %}
+<script type="text/javascript"
+        src="{% static "js/infinite_scroll.js" %}"></script>
 <script>
-  document.addEventListener("DOMContentLoaded", () => {
-    let sentinel = document.querySelector("#bottom-sentinel");
-    let scrollElement = document.querySelector("#bottom-scroll-element");
+  window.addEventListener("load", () => {
     let baseUrl = "{% url 'daily_creators' %}";
     let addUrl = "offset/";
-    let direction = 1;
-    attachInfiniteScroll(sentinel, scrollElement, baseUrl, addUrl, direction);
-  })
-  document.addEventListener("DOMContentLoaded", () => {
-    let sentinel = document.querySelector("#top-sentinel");
-    let scrollElement = document.querySelector("#top-scroll-element");
-    let baseUrl = "{% url 'daily_creators' %}";
-    let addUrl = "offset/";
-    let direction = -1;
-    attachInfiniteScroll(sentinel, scrollElement, baseUrl, addUrl, direction);
+    let topSentinel = document.getElementById("top-sentinel");
+    let topScrollElement = document.getElementById("top-scroll-element");
+    let bottomSentinel = document.getElementById("bottom-sentinel");
+    let bottomScrollElement = document.getElementById("bottom-scroll-element");
+    attachInfiniteScroll(topSentinel, topScrollElement, baseUrl, addUrl, -1);
+    attachInfiniteScroll(bottomSentinel, bottomScrollElement, baseUrl, addUrl, 1);
   })
 </script>
+{% endcompress %}
+</body>
+</html>


### PR DESCRIPTION
This is needed to avoid the whole page jumping to this scroll point when using element.scrollIntoView().

I have this change running at https://gcd.devel.comix.gr/ - compare what happens when you scroll the creators iframe. With this change, only the iframe scrolls to keep the current view. I also cleaned up the HTML in the iframe a bit to avoid warnings.