### PR TITLE
Add js to show/hide printer source when not printed is checked/unchecked

### DIFF
--- a/static/js/oi/issuerevision_form_utils.js
+++ b/static/js/oi/issuerevision_form_utils.js
@@ -433,6 +433,14 @@ $(document).on('change', 'input[type=checkbox]', function () {
             inputRow.hide()
         }
     }
+    else if (id == 'id_indicia_printer_not_printed') {
+        var inputRow = $('#id_indicia_printer_sourced_by').parent().parent();
+        if ($(this).is(':checked')) {
+            inputRow.show()
+        } else {
+            inputRow.hide()
+        }
+    }
 })
 
 $('input[type=checkbox]').change()


### PR DESCRIPTION
Tested locally:

Default -
<img width="458" height="127" alt="image" src="https://github.com/user-attachments/assets/3851956c-eab2-4779-835f-6fb82e5a26f8" />

and then when checked -
<img width="496" height="158" alt="image" src="https://github.com/user-attachments/assets/96c0953e-027e-424d-a5d2-838b8cd1b556" />

and coming back to the page shows if already present -
<img width="445" height="167" alt="image" src="https://github.com/user-attachments/assets/d4a643dd-8fac-4cb6-a42d-9395da6e3199" />
