### PR TITLE
Fix default collections so series pages load on new dev envs

### DIFF
--- a/apps/indexer/fixtures/users.yaml
+++ b/apps/indexer/fixtures/users.yaml
@@ -32,6 +32,8 @@
     user: 1
     grade_system: 1
     default_language: 25 # English
+    default_have_collection: 1
+    default_want_collection: 101
 
 - model: mycomics.collection
   pk: 1
@@ -88,6 +90,8 @@
     user: 2
     grade_system: 1
     default_language: 25 # English
+    default_have_collection: 2
+    default_want_collection: 102
 
 - model: mycomics.collection
   pk: 2
@@ -144,6 +148,8 @@
     user: 3
     grade_system: 1
     default_language: 25 # English
+    default_have_collection: 3
+    default_want_collection: 103
 
 - model: mycomics.collection
   pk: 3
@@ -200,6 +206,8 @@
     user: 4
     grade_system: 1
     default_language: 25 # English
+    default_have_collection: 4
+    default_want_collection: 104
 
 - model: mycomics.collection
   pk: 4


### PR DESCRIPTION
Fixes issue where a new development environment when logged into one of the test users and viewing a series overview page:

'NoneType' object has no attribute 'id' Error during template rendering
In template /code/gcd-django/templates/mycomics/bits/tw_series_control.html, error at line 32