### PR TITLE
Deprecate universe field direct on characters and groups

### DIFF
--- a/apps/oi/forms/character.py
+++ b/apps/oi/forms/character.py
@@ -144,6 +144,16 @@ class CharacterRevisionForm(CharacterBaseForm):
         self.helper.label_class = 'col-md-3 create-label'
         self.helper.field_class = 'col-md-9'
         self.helper.form_tag = False
+        if self.instance.universe_id:
+            self.fields['universe'].help_text = (
+                'This field is deprecated. The universe should be set per '
+                'appearance in sequences. Please remove this value if this '
+                'is the only version of this character. If a specialization '
+                'with no universe exists for this character, then transfer '
+                'notes to that and remove this character.'
+            )
+        else:
+            self.fields.pop('universe')
         ordering = list(self.fields)
         # in django 1.9 there is Form.order_fields
         new_fields = OrderedDict([(f, self.fields[f]) for f in ordering])
@@ -267,6 +277,14 @@ class GroupRevisionForm(CharacterRevisionForm):
         self.helper.label_class = 'col-md-3 create-label'
         self.helper.field_class = 'col-md-9'
         self.helper.form_tag = False
+        if 'universe' in self.fields:
+            self.fields['universe'].help_text = (
+                'This field is deprecated. The universe should be set per '
+                'appearance in sequences. Please remove this value if this '
+                'is the only version of this group. If a specialization '
+                'with no universe exists for this group, then transfer '
+                'notes to that and remove this group.'
+            )
         ordering = list(self.fields)
         # in django 1.9 there is Form.order_fields
         new_fields = OrderedDict([(f, self.fields[f]) for f in ordering])

--- a/apps/oi/models.py
+++ b/apps/oi/models.py
@@ -7562,6 +7562,10 @@ class CharacterRevision(CharacterGroupRevisionBase):
                         'year_first_published_uncertain', 'language',
                         'description', 'notes', 'keywords']
 
+    @classmethod
+    def _get_deprecated_field_names(cls):
+        return frozenset({'universe'})
+
     @property
     def source(self):
         return self.character
@@ -7825,6 +7829,10 @@ class GroupRevision(CharacterGroupRevisionBase):
 
     source_name = 'group'
     source_class = Group
+
+    @classmethod
+    def _get_deprecated_field_names(cls):
+        return frozenset({'universe'})
 
     @property
     def source(self):

--- a/templates/gcd/details/tw_character.html
+++ b/templates/gcd/details/tw_character.html
@@ -38,7 +38,7 @@ GCD :: Character :: {{ character.name }}
 {% if character.universe %}
             <tr>
               <td>Universe:</td>
-              <td>{{ character.universe|absolute_url }}</td>
+              <td>{{ character.universe|absolute_url }} <span class="text-sm italic">(deprecated)</span></td>
             </tr>
 {% endif %}
 {% if character.year_first_published %}

--- a/templates/gcd/details/tw_group.html
+++ b/templates/gcd/details/tw_group.html
@@ -38,7 +38,7 @@ GCD :: Group :: {{ group.name }}
 {% if group.universe %}
             <tr>
               <td>Universe:</td>
-              <td>{{ group.universe|absolute_url }}</td>
+              <td>{{ group.universe|absolute_url }} <span class="text-sm italic">(deprecated)</span></td>
             </tr>
 {% endif %}
 {% if group.year_first_published %}


### PR DESCRIPTION
This implements the first stage of the vote (https://www.comics.org/voting/ballot/553/) to deprecate universe being directly set on characters and groups.

**Testing:**

_New characters / groups no longer show the field:_

<img width="563" height="541" alt="image" src="https://github.com/user-attachments/assets/f5d17f9b-b625-412d-b2e5-cc4b1e672817" />

<img width="699" height="584" alt="image" src="https://github.com/user-attachments/assets/13b00513-e299-435b-a3a4-7679a3273c22" />

Adding a new character / groups continues to work.

_Editing characters / groups with no universe, don't show it_

<img width="483" height="575" alt="image" src="https://github.com/user-attachments/assets/abc6166c-6e30-4c10-8b26-d7460f5df196" />

<img width="590" height="587" alt="image" src="https://github.com/user-attachments/assets/80afda08-e345-447b-a363-7cb9241ff244" />

_If universe already set, view marks it as deprecated_

<img width="472" height="293" alt="image" src="https://github.com/user-attachments/assets/f69ecb76-ee7b-4710-981e-5a2b6ecab692" />

<img width="645" height="219" alt="image" src="https://github.com/user-attachments/assets/12e6158b-4e5a-4966-9962-f640ef263034" />

_When editing with universe set, shows explaination text_

<img width="1406" height="396" alt="image" src="https://github.com/user-attachments/assets/2882842b-8786-40dc-a184-d404dbe1d4ea" />

<img width="1481" height="397" alt="image" src="https://github.com/user-attachments/assets/b3fb2ea9-5ec6-47a6-8f86-b025efa0a478" />

--
Happy to tweak anything, just let me know :) 