### PR TITLE
Pin setuptools<81 to resolve pkg_resources ModuleNotFoundError

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -65,3 +65,4 @@ redis<5.1
 rq<2.7
 django-rq<3.3
 git+https://github.com/GrandComicsDatabase/haystack-rqueue.git
+setuptools<81

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ simplejson<3.21
 tablib<3.10
 unidecode
 # is used by python-graph-core, which has a successor python-graph, which just was released, check
-setuptools
+setuptools<81
 
 # REST-API
 djangorestframework
@@ -65,4 +65,3 @@ redis<5.1
 rq<2.7
 django-rq<3.3
 git+https://github.com/GrandComicsDatabase/haystack-rqueue.git
-setuptools<81


### PR DESCRIPTION
This PR explicitly pins setuptools<81 in requirements.txt to resolve a fatal crash that occurs when initializing the Django web container on a fresh Docker build.

The Issue:
Recent versions of the setuptools package (82.0.0 and newer) have permanently removed the deprecated pkg_resources module. Because the project's legacy voting libraries (py3votecore and pygraph) rely on this API to declare their namespaces, the web server throws a ModuleNotFoundError: No module named 'pkg_resources' and halts execution. This breaks the out-of-the-box Docker onboarding pipeline.

The Fix:
By pinning setuptools to a version prior to the deprecation purge, the missing API is restored and the web container is allowed to boot cleanly.

Future Considerations:
To safely remove this pin in the future, the upstream math libraries will either need to be updated to use the importlib.metadata standard, or the voting application will need to migrate to actively maintained dependencies.