### PR TITLE
Fix cross series variants

### DIFF
--- a/apps/gcd/models/issue.py
+++ b/apps/gcd/models/issue.py
@@ -553,7 +553,11 @@ class Issue(GcdData):
             'covers': self.active_covers(stats=True).count(),
         }
 
-        if not self.variant_of_id:
+        # Base issues always contribute +1 to their series count. 
+        # Standard variants return 0 to prevent inflating the base issue's series count.
+        # However, cross-series variants (where the variant belongs to a different 
+        # series than its parent) must return +1 to correctly increment their new target series.
+        if not self.variant_of_id or self.series_id != self.variant_of.series_id:
             counts['series issues'] = 1
 
         if self.series.is_comics_publication:

--- a/apps/gcd/models/issue.py
+++ b/apps/gcd/models/issue.py
@@ -553,10 +553,11 @@ class Issue(GcdData):
             'covers': self.active_covers(stats=True).count(),
         }
 
+        # Ensure the underlying Issue.stat_counts logic matches the bulk reset script!
         # Base issues always contribute +1 to their series count. 
         # Standard variants return 0 to prevent inflating the base issue's series count.
-        # However, cross-series variants (where the variant belongs to a different 
-        # series than its parent) must return +1 to correctly increment their new target series.
+        # However, cross-series variants must return +1 to correctly populate the 
+        # isolated target series they reside in.
         if not self.variant_of_id or self.series_id != self.variant_of.series_id:
             counts['series issues'] = 1
 

--- a/apps/oi/models.py
+++ b/apps/oi/models.py
@@ -4394,12 +4394,12 @@ class IssueRevision(Revision):
             if not self.series.has_gallery and \
                self.issue.active_covers().count():
                 self.series.has_gallery = True
-                self.series.save()
+                self.series.save(update_fields=['has_gallery'])
 
             # old series might have lost gallery after move
             if old_series.scan_count == 0:
                 old_series.has_gallery = False
-                old_series.save()
+                old_series.save(update_fields=['has_gallery'])
         if self.source.variant_of and self.added:
             self.source.is_indexed = self.source.variant_of.is_indexed
             self.source.save()
@@ -4505,13 +4505,13 @@ class IssueRevision(Revision):
                 # 1. Variant left behind: Goes from Standard -> Cross-Series (+1)
                 if variant.series == old_series and variant.series != new_series:
                     variant.series.issue_count += 1
-                    variant.series.save()
+                    variant.series.save(update_fields=['issue_count'])
                     
                 # 2. Base issue returns: Goes from Cross-Series -> Standard (-1)
                 elif variant.series != old_series and variant.series == new_series:
                     if variant.series.issue_count > 0:
                         variant.series.issue_count -= 1
-                    variant.series.save()
+                        variant.series.save(update_fields=['issue_count'])
 
     def extra_forms(self, request):
         from apps.oi.forms import IssueRevisionFormSet, \

--- a/apps/oi/models.py
+++ b/apps/oi/models.py
@@ -4100,10 +4100,26 @@ class IssueRevision(Revision):
     @property
     def series_changed(self):
         """ True if the series changed and this is neither add nor delete. """
-        return ((not self.deleted) and
+        # Check 1: Standard direct series column change
+        # Catches standard issues or variants directly moved to a new series.
+        if ((not self.deleted) and
                 (self.previous_revision is not None) and
-                self.previous_revision.series != self.series)
+                self.previous_revision.series != self.series):
+            return True
 
+        # Check 2: Cross-series variant parent change detect
+        # IMPORTANT: If an editor moves a base issue to a new series, any cross-series 
+        # variants attached to it undergo a relational boundary change, even though 
+        # the variant's own `series` field remains untouched. Flag this as a series 
+        # change so the _adjust_stats engine routes the delta correctly.
+        if (not self.deleted) and (self.previous_revision is not None) and self.variant_of:
+            old_base_series = getattr(self.previous_revision.variant_of, 'series_id', None)
+            new_base_series = getattr(self.variant_of, 'series_id', None)
+            if old_base_series and new_base_series and old_base_series != new_base_series:
+                return True
+
+        return False
+    
     @classmethod
     def fork_variant(cls, issue, changeset,
                      variant_name, variant_cover_revision=None,

--- a/apps/oi/models.py
+++ b/apps/oi/models.py
@@ -4100,25 +4100,9 @@ class IssueRevision(Revision):
     @property
     def series_changed(self):
         """ True if the series changed and this is neither add nor delete. """
-        # Check 1: Standard direct series column change
-        # Catches standard issues or variants directly moved to a new series.
-        if ((not self.deleted) and
+        return ((not self.deleted) and
                 (self.previous_revision is not None) and
-                self.previous_revision.series != self.series):
-            return True
-
-        # Check 2: Cross-series variant parent change detect
-        # IMPORTANT: If an editor moves a base issue to a new series, any cross-series 
-        # variants attached to it undergo a relational boundary change, even though 
-        # the variant's own `series` field remains untouched. Flag this as a series 
-        # change so the _adjust_stats engine routes the delta correctly.
-        if (not self.deleted) and (self.previous_revision is not None) and self.variant_of:
-            old_base_series = getattr(self.previous_revision.variant_of, 'series_id', None)
-            new_base_series = getattr(self.variant_of, 'series_id', None)
-            if old_base_series and new_base_series and old_base_series != new_base_series:
-                return True
-
-        return False
+                self.previous_revision.series != self.series)
     
     @classmethod
     def fork_variant(cls, issue, changeset,
@@ -4502,6 +4486,31 @@ class IssueRevision(Revision):
         for story in self.changeset.storyrevisions.filter(issue=None):
             story.issue = self.issue
             story.save()
+
+        # Handle cross-series variant boundary changes
+        # If this base issue moved, its left-behind variants might have become 
+        # (or ceased to be) cross-series variants.
+        if changes.get('series changed'):
+            old_series = changes.get('old series')
+            new_series = self.issue.series
+            
+            # THE FIX: Query the Issue model directly instead of using the reverse relation
+            IssueClass = type(self.issue)
+            variants = IssueClass.objects.filter(variant_of=self.issue, deleted=False)
+            
+            for variant in variants:
+                # 1. Variant left behind: Goes from Standard -> Cross-Series
+                # It now contributes +1 to the old series it resides in.
+                if variant.series == old_series and variant.series != new_series:
+                    variant.series.issue_count += 1
+                    variant.series.save()
+                    
+                # 2. Base issue returns: Goes from Cross-Series -> Standard
+                # It ceases to contribute to the series, losing -1.
+                elif variant.series != old_series and variant.series == new_series:
+                    if variant.series.issue_count > 0:
+                        variant.series.issue_count -= 1
+                    variant.series.save()
 
     def extra_forms(self, request):
         from apps.oi.forms import IssueRevisionFormSet, \

--- a/apps/oi/models.py
+++ b/apps/oi/models.py
@@ -4487,26 +4487,27 @@ class IssueRevision(Revision):
             story.issue = self.issue
             story.save()
 
-        # Handle cross-series variant boundary changes
-        # If this base issue moved, its left-behind variants might have become 
-        # (or ceased to be) cross-series variants.
+        # ---------------------------------------------------------------------
+        # Cross-Series Variant Stat Routing
+        # ---------------------------------------------------------------------
+        # When a base issue moves to a new series, its variants do not automatically 
+        # follow it. This means a variant left behind in the old series just became 
+        # a "cross-series" variant (which contributes +1 to its series issue_count), 
+        # or vice-versa. Adjust the cached counts of the affected series.
         if changes.get('series changed'):
             old_series = changes.get('old series')
             new_series = self.issue.series
             
-            # THE FIX: Query the Issue model directly instead of using the reverse relation
             IssueClass = type(self.issue)
             variants = IssueClass.objects.filter(variant_of=self.issue, deleted=False)
             
             for variant in variants:
-                # 1. Variant left behind: Goes from Standard -> Cross-Series
-                # It now contributes +1 to the old series it resides in.
+                # 1. Variant left behind: Goes from Standard -> Cross-Series (+1)
                 if variant.series == old_series and variant.series != new_series:
                     variant.series.issue_count += 1
                     variant.series.save()
                     
-                # 2. Base issue returns: Goes from Cross-Series -> Standard
-                # It ceases to contribute to the series, losing -1.
+                # 2. Base issue returns: Goes from Cross-Series -> Standard (-1)
                 elif variant.series != old_series and variant.series == new_series:
                     if variant.series.issue_count > 0:
                         variant.series.issue_count -= 1

--- a/scripts/reset_stats.py
+++ b/scripts/reset_stats.py
@@ -26,15 +26,18 @@ def main():
     # Recompute per-series cached `issue_count` to match Issue.stat_counts()
     # Rule: an issue counts for its series if it's not a variant, OR it is a
     # variant whose base issue is in a different series (cross-series variant).
-    issue_qs = Issue.objects.filter(deleted=False).filter(
-        Q(variant_of__isnull=True) | ~Q(series=F('variant_of__series'))
-    ).values('series').annotate(c=Count('id'))
+    # Inside scripts/reset_stats.py
+    from django.db.models import Subquery, OuterRef
+    from django.db.models.functions import Coalesce
 
-    whens = [When(pk=entry['series'], then=entry['c']) for entry in issue_qs]
-    if whens:
-        Series.objects.update(issue_count=Case(*whens, default=0))
-    else:
-        Series.objects.update(issue_count=0)
+    subquery = Issue.objects.filter(
+        deleted=False,
+        series_id=OuterRef('pk')
+    ).filter(
+        Q(variant_of__isnull=True) | ~Q(series_id=F('variant_of__series_id'))
+    ).values('series_id').annotate(c=Count('id')).values('c')
+
+    Series.objects.update(issue_count=Coalesce(Subquery(subquery), 0))
 
 
 def run():

--- a/scripts/reset_stats.py
+++ b/scripts/reset_stats.py
@@ -20,13 +20,14 @@ def main():
     # -------------------------------------------------------------------------
     # Rebuild Series.issue_count Caches
     # -------------------------------------------------------------------------
+    # An issue contributes +1 to a Series count if:
+    #   (a) It is a standard base issue (variant_of is NULL)
+    #   (b) It is a cross-series variant (its series differs from its base issue's series)
+    # Standard variants within the same series do not count, preventing inflation.
+    # 
     # This bulk aggregation MUST remain synchronized with the real-time Python
     # logic in `apps.gcd.models.issue.Issue.stat_counts()`.
-    #
-    # Recompute per-series cached `issue_count` to match Issue.stat_counts()
-    # Rule: an issue counts for its series if it's not a variant, OR it is a
-    # variant whose base issue is in a different series (cross-series variant).
-    # Inside scripts/reset_stats.py
+    
     from django.db.models import Subquery, OuterRef
     from django.db.models.functions import Coalesce
 

--- a/scripts/reset_stats.py
+++ b/scripts/reset_stats.py
@@ -1,16 +1,41 @@
-from apps.stats.models import *
+from django.db.models import Q, F, Count, Case, When
+
+from apps.stats.models import CountStats
+from apps.gcd.models import Series, Issue
+from apps.stddata.models import Language, Country
+
 
 def main():
-    CountStats.objects.all().delete()                                                                                                              
-    CountStats.objects.init_stats()                                                                                                                
+    CountStats.objects.all().delete()
+    CountStats.objects.init_stats()
 
-    for i in Language.objects.all():  
-        if Series.objects.filter(language=i).exists(): 
-            CountStats.objects.init_stats(language=i)  
+    for i in Language.objects.all():
+        if Series.objects.filter(language=i).exists():
+            CountStats.objects.init_stats(language=i)
 
     for i in Country.objects.all():
         if Series.objects.filter(country=i).exists():
             CountStats.objects.init_stats(country=i)
+
+    # -------------------------------------------------------------------------
+    # Rebuild Series.issue_count Caches
+    # -------------------------------------------------------------------------
+    # This bulk aggregation MUST remain synchronized with the real-time Python
+    # logic in `apps.gcd.models.issue.Issue.stat_counts()`.
+    #
+    # Recompute per-series cached `issue_count` to match Issue.stat_counts()
+    # Rule: an issue counts for its series if it's not a variant, OR it is a
+    # variant whose base issue is in a different series (cross-series variant).
+    issue_qs = Issue.objects.filter(deleted=False).filter(
+        Q(variant_of__isnull=True) | ~Q(series=F('variant_of__series'))
+    ).values('series').annotate(c=Count('id'))
+
+    whens = [When(pk=entry['series'], then=entry['c']) for entry in issue_qs]
+    if whens:
+        Series.objects.update(issue_count=Case(*whens, default=0))
+    else:
+        Series.objects.update(issue_count=0)
+
 
 def run():
     main()


### PR DESCRIPTION
Fix for #235 and #157 . 

- Updated `IssueRevision.series_changed` to accurately detect when a cross-series variant's parent issue moves to a different series, ensuring the routing engine applies stat deltas correctly.
- Updated `scripts/reset_stats.py` to recalculate the `Series.issue_count` cache in bulk. The script now mirrors the real-time logic: issues are counted if they are base issues OR variants belonging to a different series than their parent.

See comment for testing hurdles.