### PR TITLE
Repair test suite

### DIFF
--- a/apps/gcd/tests/test_issue.py
+++ b/apps/gcd/tests/test_issue.py
@@ -518,10 +518,14 @@ def test_stat_counts_base_indexed_covers_stories(any_series, stat_count_mocks):
 
 
 def test_stat_counts_variant_partial(any_series, stat_count_mocks):
+    # A saved-looking parent in the same series, cached on the instance
+    # so that stat_counts() does not hit the database.
+    variant_parent = Issue(number='0', series=any_series)
+    variant_parent.pk = 1234
     i = Issue(number='1',
               series=any_series,
               is_indexed=INDEXED['partial'],
-              variant_of_id=1234)
+              variant_of=variant_parent)
 
     counts = i.stat_counts()
     assert counts == {

--- a/apps/gcd/tests/test_publisher.py
+++ b/apps/gcd/tests/test_publisher.py
@@ -208,16 +208,19 @@ def brand_dep_mocks():
     b = '%s.Brand' % PATH
     with mock.patch('%s.use_revisions' % b) as bu_mock, \
             mock.patch('%s.issue_revisions' % b) as ish_mock, \
-            mock.patch('%s.in_use' % b) as in_use_mock:
+            mock.patch('%s.in_use' % b) as in_use_mock, \
+            mock.patch('%s.active_issues' % b) as ai_mock:
 
         for m in (bu_mock, ish_mock):
             m.active_set.return_value.exists.return_value = False
         in_use_mock.exists.return_value = False
+        ai_mock.return_value.exists.return_value = False
 
         yield {
             'bu': bu_mock,
             'ish': ish_mock,
             'in_use': in_use_mock,
+            'ai': ai_mock,
         }
 
 

--- a/apps/gcd/tests/test_series.py
+++ b/apps/gcd/tests/test_series.py
@@ -116,8 +116,10 @@ def test_delete():
     (True, True), (True, False), (False, True), (False, False)])
 def test_has_dependents(issues, issue_revisions):
     with mock.patch('%s.active_issues' % SERIES_PATH) as is_mock, \
-            mock.patch('%s.active_set' % REVMGR_PATH) as rev_mock:
+            mock.patch('%s.active_set' % REVMGR_PATH) as rev_mock, \
+            mock.patch('%s.has_series_bonds' % SERIES_PATH) as bond_mock:
         rev_mock.return_value.exists.return_value = issue_revisions
+        bond_mock.return_value = False
         s = Series()
         is_mock.return_value.exists.return_value = issues
 
@@ -151,9 +153,10 @@ def test_active_non_base_variants(issues_qs):
 
 def test_active_indexed_issues(issues_qs):
     s = Series()
+    s.active_issues.return_value.filter.return_value = issues_qs
     assert s.active_indexed_issues() == issues_qs
-    s.active_issues.return_value.exclude.assert_called_once_with(
-        is_indexed=INDEXED['skeleton'])
+    s.active_issues.return_value.filter.assert_called_once_with(
+        is_indexed__gt=INDEXED['some_data'])
 
 
 def test_active_base_issues_variant_count():
@@ -265,8 +268,8 @@ def test_update_cached_counts_subtract(f_mock):
 
 def test_set_first_last_issues_empty():
     with mock.patch('apps.gcd.models.series.Series.save'), \
-            mock.patch('apps.gcd.models.series.models.QuerySet.order_by') \
-            as order_mock, \
+            mock.patch('apps.gcd.models.series.Series.active_issues') \
+            as active_mock, \
             mock.patch('apps.gcd.models.issue.Issue.series'):
 
         # Create some issues that are set as first/last even though no longer
@@ -284,7 +287,7 @@ def test_set_first_last_issues_empty():
         qs.count.return_value = 0
         qs.__getitem__.side_effect = index_faker
 
-        order_mock.return_value = qs
+        active_mock.return_value.order_by.return_value = qs
 
         s.set_first_last_issues()
 
@@ -295,8 +298,8 @@ def test_set_first_last_issues_empty():
 
 def test_set_first_last_issues_nonempty():
     with mock.patch('apps.gcd.models.series.Series.save'), \
-            mock.patch('apps.gcd.models.series.models.QuerySet.order_by') \
-            as order_mock, \
+            mock.patch('apps.gcd.models.series.Series.active_issues') \
+            as active_mock, \
             mock.patch('apps.gcd.models.issue.Issue.series'):
 
         s = Series(issue_count=0)
@@ -315,7 +318,7 @@ def test_set_first_last_issues_nonempty():
         qs.__getitem__.side_effect = index_faker
         qs.__iter__.return_value = iter(issue_list)
 
-        order_mock.return_value = qs
+        active_mock.return_value.order_by.return_value = qs
 
         s.set_first_last_issues()
 

--- a/apps/oi/tests/db/test_printer_revision.py
+++ b/apps/oi/tests/db/test_printer_revision.py
@@ -29,11 +29,8 @@ def test_commit_added_revision(any_added_printer_rev, printer_add_values,
     with mock.patch(update_all) as updater:
         rev.commit_to_display()
 
-    updater.assert_has_calls([
-        mock.call({}, country=None, language=None, negate=True),
-        mock.call({}, country=rev.printer.country, language=None),
-    ])
-    assert updater.call_count == 2
+    # Printers do not opt into _update_stats, so no stats calls are made.
+    assert updater.call_count == 0
 
     assert rev.printer is not None
     assert rev.source is rev.printer

--- a/apps/oi/tests/test_issue_revision.py
+++ b/apps/oi/tests/test_issue_revision.py
@@ -58,10 +58,11 @@ def test_classification():
         'series': gf('series'),
         'indicia_publisher': gf('indicia_publisher'),
         'indicia_pub_not_printed': gf('indicia_pub_not_printed'),
-        'brand': gf('brand'),
+        'brand_emblem': gf('brand_emblem'),
         'no_brand': gf('no_brand'),
-        'no_indicia_printer': gf('no_indicia_printer'),
         'indicia_printer': gf('indicia_printer'),
+        'indicia_printer_not_printed': gf('indicia_printer_not_printed'),
+        'indicia_printer_sourced_by': gf('indicia_printer_sourced_by'),
     }
 
     irregular_fields = {
@@ -79,9 +80,13 @@ def test_classification():
     single_value_fields = regular_fields.copy()
     del single_value_fields['keywords']
     del single_value_fields['indicia_printer']
+    del single_value_fields['brand_emblem']
     assert IssueRevision._get_single_value_fields() == single_value_fields
 
-    assert IssueRevision._get_multi_value_fields() == {'indicia_printer': gf('indicia_printer'),}
+    assert IssueRevision._get_multi_value_fields() == {
+        'indicia_printer': gf('indicia_printer'),
+        'brand_emblem': gf('brand_emblem'),
+    }
 
 
 def test_conditional_field_mapping():
@@ -99,7 +104,7 @@ def test_conditional_field_mapping():
         'indicia_frequency': ('series', 'has_indicia_frequency'),
         'no_indicia_frequency': ('series', 'has_indicia_frequency'),
         'indicia_printer': ('series', 'has_indicia_printer'),
-        'no_indicia_printer': ('series', 'has_indicia_printer'),
+        'indicia_printer_not_printed': ('series', 'has_indicia_printer'),
     }
 
 
@@ -107,9 +112,10 @@ def test_parent_field_tuples():
     assert IssueRevision._get_parent_field_tuples() == {
         ('series',),
         ('series', 'publisher'),
-        ('brand', 'group'),
-        ('brand',),
+        ('brand_emblem', 'group'),
+        ('brand_emblem',),
         ('indicia_publisher',),
+        ('indicia_printer',),
     }
 
 
@@ -604,7 +610,7 @@ def test_post_save_new_gains_gallery(patch_for_move):
     assert new.has_gallery is True
 
     assert not old.save.called
-    new.save.assert_called_once_with()
+    new.save.assert_called_once_with(update_fields=['has_gallery'])
 
 
 @pytest.mark.parametrize('has_gallery, count', [(True, 1), (False, 0)])
@@ -627,7 +633,7 @@ def test_post_save_old_loses_gallery(patch_for_move, has_gallery, count):
     assert old.has_gallery is False
     assert new.has_gallery is has_gallery
 
-    old.save.assert_called_once_with()
+    old.save.assert_called_once_with(update_fields=['has_gallery'])
     assert not new.save.called
 
 

--- a/apps/oi/tests/test_reprint_revision.py
+++ b/apps/oi/tests/test_reprint_revision.py
@@ -20,11 +20,13 @@ def patched_for_save():
             mock.patch('apps.gcd.models.story.Story.__str__', story_uni), \
             mock.patch('apps.gcd.models.issue.Issue.__str__', issue_uni):
         s = Series(name='Test Series')
+        o_issue = Issue(number='1', title='o issue', series=s)
+        o_issue.pk = 1
+        t_issue = Issue(number='9', title='t issue', series=s)
+        t_issue.pk = 9
         yield (save_mock,
-               Story(title='origin',
-                     issue=Issue(number='1', title='o issue', series=s)),
-               Story(title='target',
-                     issue=Issue(number='9', title='t issue', series=s)))
+               Story(title='origin', issue=o_issue),
+               Story(title='target', issue=t_issue))
 
 
 @pytest.fixture
@@ -87,7 +89,8 @@ def test_save_origin_mismatch(patched_for_save):
 
     v = str(exc_info.value)
     assert "origin story and issue do not match" in v
-    expected = "issue: '%s'; Issue: '%s'" % (origin.issue, target.issue)
+    expected = "issue: '%d: %s'; Issue: '%d: %s'" % (
+        origin.issue.id, origin.issue, target.issue.id, target.issue)
     assert expected in v
     assert not save_mock.called
 
@@ -102,7 +105,8 @@ def test_save_target_mismatch(patched_for_save):
 
     v = str(exc_info.value)
     assert "target story and issue do not match" in v
-    expected = "issue: '%s'; Issue: '%s'" % (target.issue, origin.issue)
+    expected = "issue: '%d: %s'; Issue: '%d: %s'" % (
+        target.issue.id, target.issue, origin.issue.id, origin.issue)
     assert expected in v
     assert not save_mock.called
 

--- a/apps/oi/tests/test_revision.py
+++ b/apps/oi/tests/test_revision.py
@@ -211,7 +211,7 @@ def test_set_source():
 
 
 def test_source_class():
-    assert Revision.source_class is NotImplemented
+    assert Revision.source_class is NotImplementedError
     assert DummyRevision.source_class is Dummy
 
 

--- a/apps/oi/tests/test_series_revision.py
+++ b/apps/oi/tests/test_series_revision.py
@@ -340,7 +340,11 @@ def pre_save_mocks():
     with mock.patch('%s.get_ongoing_reservation' % SERIES) as get_ongoing, \
       mock.patch('apps.gcd.models.series.Series.scan_count',
                  new_callable=mock.PropertyMock) as scan_count:
-        yield SeriesRevision(series=Series()), get_ongoing, scan_count
+        # A previous_revision makes this an edit, not an add; the
+        # has_gallery update only runs for edits.
+        yield (SeriesRevision(series=Series(),
+                              previous_revision=SeriesRevision()),
+               get_ongoing, scan_count)
 
 
 def test_pre_save_object_from_current(pre_save_mocks):

--- a/apps/stats/tests/test_countstats.py
+++ b/apps/stats/tests/test_countstats.py
@@ -54,8 +54,10 @@ def patched_filters():
         cr_filter.return_value.count.return_value = CREATOR_COUNT
         s_filter.return_value.count.return_value = SERIES_COUNT
         i_filter.return_value.count.return_value = ISSUE_COUNT
-        i_filter.return_value.exclude.return_value.count.side_effect = (
-            VARIANT_COUNT, INDEX_COUNT)
+        i_filter.return_value.exclude.return_value.count.return_value = \
+            VARIANT_COUNT
+        i_filter.return_value.filter.return_value.count.return_value = \
+            INDEX_COUNT
         c_filter.return_value.count.return_value = COVER_COUNT
         t_filter.return_value.count.return_value = STORY_COUNT
 
@@ -105,8 +107,8 @@ def test_init_stats_language(patched_filters):
             mock.call().exclude(variant_of=None),
             mock.call().exclude().count(),
             mock.call(variant_of=None, **i_kwargs),
-            mock.call().exclude(is_indexed=INDEXED['skeleton']),
-            mock.call().exclude().count()])
+            mock.call().filter(is_indexed__gt=INDEXED['some_data']),
+            mock.call().filter().count()])
 
         c_filter.assert_called_once_with(**c_t_kwargs)
         t_filter.assert_called_once_with(**c_t_kwargs)
@@ -143,8 +145,8 @@ def test_init_stats_country(patched_filters):
             mock.call().exclude(variant_of=None),
             mock.call().exclude().count(),
             mock.call(variant_of=None, **i_kwargs),
-            mock.call().exclude(is_indexed=INDEXED['skeleton']),
-            mock.call().exclude().count()])
+            mock.call().filter(is_indexed__gt=INDEXED['some_data']),
+            mock.call().filter().count()])
 
         c_filter.assert_called_once_with(**c_t_kwargs)
         t_filter.assert_called_once_with(**c_t_kwargs)
@@ -185,8 +187,8 @@ def test_init_stats_neither(patched_filters):
             mock.call().exclude(variant_of=None),
             mock.call().exclude().count(),
             mock.call(variant_of=None, **i_kwargs),
-            mock.call().exclude(is_indexed=INDEXED['skeleton']),
-            mock.call().exclude().count()])
+            mock.call().filter(is_indexed__gt=INDEXED['some_data']),
+            mock.call().filter().count()])
 
         c_filter.assert_called_once_with(**c_t_kwargs)
         t_filter.assert_called_once_with(**c_t_kwargs)


### PR DESCRIPTION
Updates the red remaining tests for recent changes, brand_emblem and indicia printer
renames, and fixes a has_calls typo that silently skipped assertions. 
Suite is green afterwards: 408 passed

builds on PR https://github.com/GrandComicsDatabase/gcd-django/pull/723 so that should be handled first (and this rebased if that PR leads to changes).