### PR TITLE
Fix reset stats mysql crash

### DIFF
--- a/apps/gcd/tests/test_reset_stats.py
+++ b/apps/gcd/tests/test_reset_stats.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+"""
+Grouped querysets need the model's default ordering cleared, or Django folds
+those fields into the GROUP BY and the counts come out wrong — hence the
+.order_by() in reset_series_issue_count_cache, which rebuilds the cached
+Series.issue_count.
+"""
+
+import pytest
+
+from apps.gcd.models import Publisher, Series, Issue
+from apps.stats.models import CountStats
+from apps.stddata.models import Country, Language
+from scripts.reset_stats import main, reset_series_issue_count_cache
+
+
+@pytest.fixture
+def two_series(db):
+    country, _ = Country.objects.get_or_create(
+        code='zz', defaults={'name': 'Zedland'})
+    language, _ = Language.objects.get_or_create(
+        code='zz', defaults={'name': 'Zedish'})
+    publisher = Publisher.objects.create(
+        name='Stats Publishing', country=country, year_began=1990)
+
+    def series(name):
+        return Series.objects.create(
+            name=name, sort_name=name, year_began=1990, country=country,
+            language=language, publisher=publisher,
+            is_comics_publication=True, has_gallery=False)
+
+    return series('Alpha'), series('Beta')
+
+
+def _issue(series, sort_code, **kwargs):
+    return Issue.objects.create(
+        number=str(sort_code), series=series, sort_code=sort_code,
+        **kwargs)
+
+
+@pytest.mark.django_db
+def test_rebuild_counts_base_and_cross_series_variants(two_series):
+    alpha, beta = two_series
+    base = _issue(alpha, 1)
+    _issue(alpha, 2)                    # second base issue: counted
+    _issue(alpha, 3, variant_of=base)   # same-series variant: not counted
+    _issue(beta, 1, variant_of=base)    # cross-series variant: counted
+    _issue(beta, 2, deleted=True)       # deleted: not counted
+
+    # Corrupt the cached counts; the rebuild must repair them.
+    Series.objects.update(issue_count=99)
+
+    reset_series_issue_count_cache()
+
+    alpha.refresh_from_db()
+    beta.refresh_from_db()
+    assert alpha.issue_count == 2
+    assert beta.issue_count == 1
+
+
+@pytest.mark.django_db
+def test_rebuild_zeroes_series_without_issues(two_series):
+    alpha, _ = two_series
+    Series.objects.update(issue_count=7)
+
+    reset_series_issue_count_cache()
+
+    alpha.refresh_from_db()
+    assert alpha.issue_count == 0
+
+
+@pytest.mark.django_db
+def test_main_rebuilds_countstats(two_series):
+    CountStats.objects.all().delete()
+
+    main()
+
+    assert CountStats.objects.exists()

--- a/scripts/reset_stats.py
+++ b/scripts/reset_stats.py
@@ -25,10 +25,10 @@ def reset_series_issue_count_cache():
     #   (a) It is a standard base issue (variant_of is NULL)
     #   (b) It is a cross-series variant (its series differs from its base issue's series)
     # Standard variants within the same series do not count, preventing inflation.
-    # 
+    #
     # This bulk aggregation MUST remain synchronized with the real-time Python
     # logic in `apps.gcd.models.issue.Issue.stat_counts()`.
-    
+
     from django.db.models import Subquery, OuterRef
     from django.db.models.functions import Coalesce
 
@@ -37,7 +37,7 @@ def reset_series_issue_count_cache():
         series_id=OuterRef('pk')
     ).filter(
         Q(variant_of__isnull=True) | ~Q(series_id=F('variant_of__series_id'))
-    ).values('series_id').annotate(c=Count('id')).values('c')
+    ).values('series_id').annotate(c=Count('id')).values('c').order_by()
 
     Series.objects.update(issue_count=Coalesce(Subquery(subquery), 0))
 
@@ -46,4 +46,3 @@ def run():
     main()
     # only reset the series issue count cache if explicitly requested
     # reset_series_issue_count_cache()
-


### PR DESCRIPTION
reset_stats currently crashes on MySQL with error 1093 partway through: the statistics are rebuilt, but the Series.issue_count stage that came in with #717 never runs.  Issue's default ordering ('series', 'sort_code') pulls a join on gcd_series into the update's own subquery, and MySQL refuses to update a table its subquery reads. The Django aggregation docs say to clear the ordering in grouped queries, so that is the fix: one order_by().  
  https://docs.djangoproject.com/en/5.2/topics/db/aggregation/#interaction-with-order-by