### PR TITLE
Add pytest config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@
 
 # Local configuration
 settings_local.py
-pytest.ini
 
 # Editor temp and config files
 *.py~

--- a/apps/gcd/tests/test_issue.py
+++ b/apps/gcd/tests/test_issue.py
@@ -24,7 +24,7 @@ def any_series():
                   is_comics_publication=True)
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def image_and_content_type():
     """
     Returns a 4-tuple of mocks for use in testing image properties.
@@ -152,7 +152,7 @@ def test_cant_upload_variants_active_revisions(any_series):
         assert can_upload_variants is False
 
 
-#@pytest.yield_fixture
+#@pytest.fixture
 #def re_issue_mocks(any_series):
     #with mock.patch('%s.from_all_reprints' % ISSUE_PATH) as from_mock, \
             #mock.patch('%s.to_all_reprints' % ISSUE_PATH) as to_mock:
@@ -231,7 +231,7 @@ def test_delete():
         i.save.assert_called_once_with()
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def del_issue_mocks():
     """ Dict of mocks of things needed for deletability testing. """
     with mock.patch('%s.has_reprints' % ISSUE_PATH) as issue_hr_mock, \
@@ -471,7 +471,7 @@ def test_shown_covers(any_series):
         assert second == [v3, v4, v5]
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def stat_count_mocks():
     """
     Yields a 2-tuple of mocks for testing statistics.

--- a/apps/gcd/tests/test_publisher.py
+++ b/apps/gcd/tests/test_publisher.py
@@ -25,7 +25,7 @@ DELTAS = {
 }
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def f_mock():
     with mock.patch('%s.F' % PATH) as f_mock:
 
@@ -79,7 +79,7 @@ def test_update_cached_counts_subtract(f_mock):
     assert p.issue_count == ISSUE_COUNT - DELTAS['issues']
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def pub_dep_mocks():
     p = '%s.Publisher' % PATH
     with mock.patch('%s.active_brands' % p) as ab_mock, \
@@ -135,7 +135,7 @@ def test_pub_has_non_dependents_nonzero_counts(pub_dep_mocks, which_count):
     assert has is False
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def ipub_dep_mock():
     ip = '%s.IndiciaPublisher' % PATH
     with mock.patch('%s.issue_revisions' % ip) as ip_mock:
@@ -163,7 +163,7 @@ def test_ipub_has_dependents_issue_count(ipub_dep_mock):
     assert has is True
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def group_dep_mocks():
     g = '%s.BrandGroup' % PATH
     with mock.patch('%s.brand_revisions' % g) as br_mock, \
@@ -203,7 +203,7 @@ def test_group_has_dependents_issue_count(group_dep_mocks):
     assert has is True
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def brand_dep_mocks():
     b = '%s.Brand' % PATH
     with mock.patch('%s.use_revisions' % b) as bu_mock, \
@@ -303,7 +303,7 @@ def test_brand_use_active_issues():
             issue__series__publisher=bu.publisher)
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def pub_child_set_mocks():
     p = '%s.Publisher' % PATH
     with mock.patch('%s.active_indicia_publishers' % p) as ip_mock, \

--- a/apps/gcd/tests/test_reprint.py
+++ b/apps/gcd/tests/test_reprint.py
@@ -8,7 +8,7 @@ from django.utils.html import conditional_escape as esc
 from apps.gcd.models import Story, Issue, Series, Reprint
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patched_for_save():
     with mock.patch('apps.gcd.models.reprint.GcdLink.save') as save_mock:
         yield (save_mock,
@@ -64,7 +64,7 @@ def test_save_fields_target_with_story(patched_for_save):
     assert r.target_issue == target.issue
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patched_for_strings():
     def full_name(self):
         return self.number

--- a/apps/gcd/tests/test_reset_stats.py
+++ b/apps/gcd/tests/test_reset_stats.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+"""
+Grouped querysets need the model's default ordering cleared, or Django folds
+those fields into the GROUP BY and the counts come out wrong — hence the
+.order_by() in reset_series_issue_count_cache, which rebuilds the cached
+Series.issue_count.
+"""
+
+import pytest
+
+from apps.gcd.models import Publisher, Series, Issue
+from apps.stats.models import CountStats
+from apps.stddata.models import Country, Language
+from scripts.reset_stats import main, reset_series_issue_count_cache
+
+
+@pytest.fixture
+def two_series(db):
+    country, _ = Country.objects.get_or_create(
+        code='zz', defaults={'name': 'Zedland'})
+    language, _ = Language.objects.get_or_create(
+        code='zz', defaults={'name': 'Zedish'})
+    publisher = Publisher.objects.create(
+        name='Stats Publishing', country=country, year_began=1990)
+
+    def series(name):
+        return Series.objects.create(
+            name=name, sort_name=name, year_began=1990, country=country,
+            language=language, publisher=publisher,
+            is_comics_publication=True, has_gallery=False)
+
+    return series('Alpha'), series('Beta')
+
+
+def _issue(series, sort_code, **kwargs):
+    return Issue.objects.create(
+        number=str(sort_code), series=series, sort_code=sort_code,
+        **kwargs)
+
+
+@pytest.mark.django_db
+def test_rebuild_counts_base_and_cross_series_variants(two_series):
+    alpha, beta = two_series
+    base = _issue(alpha, 1)
+    _issue(alpha, 2)                    # second base issue: counted
+    _issue(alpha, 3, variant_of=base)   # same-series variant: not counted
+    _issue(beta, 1, variant_of=base)    # cross-series variant: counted
+    _issue(beta, 2, deleted=True)       # deleted: not counted
+
+    # Corrupt the cached counts; the rebuild must repair them.
+    Series.objects.update(issue_count=99)
+
+    reset_series_issue_count_cache()
+
+    alpha.refresh_from_db()
+    beta.refresh_from_db()
+    assert alpha.issue_count == 2
+    assert beta.issue_count == 1
+
+
+@pytest.mark.django_db
+def test_rebuild_zeroes_series_without_issues(two_series):
+    alpha, _ = two_series
+    Series.objects.update(issue_count=7)
+
+    reset_series_issue_count_cache()
+
+    alpha.refresh_from_db()
+    assert alpha.issue_count == 0
+
+
+@pytest.mark.django_db
+def test_main_rebuilds_countstats(two_series):
+    CountStats.objects.all().delete()
+
+    main()
+
+    assert CountStats.objects.exists()

--- a/apps/gcd/tests/test_series.py
+++ b/apps/gcd/tests/test_series.py
@@ -126,7 +126,7 @@ def test_has_dependents(issues, issue_revisions):
         assert s.has_dependents() is any((issue_revisions, issues))
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def issues_qs():
     """
     Provides a queryset mock for active_issues().exclude(...)
@@ -235,7 +235,7 @@ def test_counts_deleted():
     assert s.stat_counts() == {}
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def f_mock():
     with mock.patch('apps.gcd.models.series.F') as f_mock:
 

--- a/apps/gcd/tests/test_story.py
+++ b/apps/gcd/tests/test_story.py
@@ -19,7 +19,7 @@ def test_stat_counts(is_comics, deleted):
     assert story.stat_counts() == {} if deleted else {'stories': 1}
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def re_story_mocks():
     with mock.patch('%s.from_all_reprints' % STORY_PATH) as from_mock, \
             mock.patch('%s.to_all_reprints' % STORY_PATH) as to_mock:

--- a/apps/stats/tests/test_countstats.py
+++ b/apps/stats/tests/test_countstats.py
@@ -30,7 +30,7 @@ def test_init_stats_not_both():
     assert 'either country or language stats' in str(excinfo.value)
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patched_filters():
     """
     Returns all of the *.objects.filter/create methods patched as a tuple.
@@ -208,7 +208,7 @@ def test_init_stats_neither(patched_filters):
             mock.call(name='stories', count=STORY_COUNT, **lc_args)])
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mocks_for_update():
     """
     Returns a 4-tuple of mocks for testing CountStatsManager.update().
@@ -355,7 +355,7 @@ def test_update_init_country_no_language(mocks_for_update):
     _check_delta_applications(f_mock, cs_mocks, 1)
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mocks_for_update_all():
     """
     Returns a 3-tuple of mocks for testing update_all().

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.pytest.ini_options]
+# Boot Django with these settings first; without this the suite won't start at all.
+DJANGO_SETTINGS_MODULE = "settings"
+# Where the tests live, so a bare `pytest` finds them.
+testpaths = ["apps"]

--- a/scripts/reset_stats.py
+++ b/scripts/reset_stats.py
@@ -25,10 +25,10 @@ def reset_series_issue_count_cache():
     #   (a) It is a standard base issue (variant_of is NULL)
     #   (b) It is a cross-series variant (its series differs from its base issue's series)
     # Standard variants within the same series do not count, preventing inflation.
-    # 
+    #
     # This bulk aggregation MUST remain synchronized with the real-time Python
     # logic in `apps.gcd.models.issue.Issue.stat_counts()`.
-    
+
     from django.db.models import Subquery, OuterRef
     from django.db.models.functions import Coalesce
 
@@ -37,7 +37,7 @@ def reset_series_issue_count_cache():
         series_id=OuterRef('pk')
     ).filter(
         Q(variant_of__isnull=True) | ~Q(series_id=F('variant_of__series_id'))
-    ).values('series_id').annotate(c=Count('id')).values('c')
+    ).values('series_id').annotate(c=Count('id')).values('c').order_by()
 
     Series.objects.update(issue_count=Coalesce(Subquery(subquery), 0))
 
@@ -46,4 +46,3 @@ def run():
     main()
     # only reset the series issue count cache if explicitly requested
     # reset_series_issue_count_cache()
-


### PR DESCRIPTION
 `pytest` doesn't run on a fresh clone. Nothing tells it which Django settings to load:

  ```
  $ pytest
  ImproperlyConfigured: Requested setting ..., but settings are not configured
  no tests collected, 7 errors
  ```

  This commits the small info needed to  `pyproject.toml`, the standard home for tool config. Now `pytest` gives `412
  tests collected`. 

I also dropped `pytest.ini` from `.gitignore`. It takes precedence over `pyproject.toml`, so a
  leftover existing local one silently overrides this. But the pyproject.toml is enough.
 (Note: The machine-specific parts live in `settings_local.py so this ini was never needed to gitignore.`).

 Also swapped the deprecated `pytest.yield_fixture` for `pytest.fixture`.

  Ignore the first commit, that's the reset_stats fix from #725. It drops once that merges and I'll rebase this, if SHA changes.