### PR TITLE
Add API v2 supporting resources

### DIFF
--- a/apps/api_v2/filters/awards.py
+++ b/apps/api_v2/filters/awards.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""django-filter configuration for v2 Award endpoints."""
+
+import django_filters
+
+from apps.api_v2.filters.common import (
+    TIMESTAMP_FILTER_FIELDS,
+    TimestampFilterSet,
+)
+from apps.gcd.models import Award, ReceivedAward
+
+AWARD_RECIPIENT_TYPES = (
+    ('creator', 'Creator'),
+    ('issue', 'Issue'),
+    ('series', 'Series'),
+    ('story', 'Story'),
+)
+
+
+class AwardFilterSet(TimestampFilterSet):
+    """Filters for Award list endpoints."""
+
+    name = django_filters.CharFilter(
+        field_name='name',
+        lookup_expr='icontains',
+    )
+
+    class Meta:
+        """FilterSet metadata for Award filtering."""
+
+        model = Award
+        fields = ('name',) + TIMESTAMP_FILTER_FIELDS
+
+
+class AwardRecipientFilterSet(TimestampFilterSet):
+    """Filters for the paginated Award recipient action."""
+
+    recipient_type = django_filters.ChoiceFilter(
+        choices=AWARD_RECIPIENT_TYPES,
+        method='filter_recipient_type',
+    )
+
+    def filter_recipient_type(self, queryset, name, value):
+        """Filter generic recipients by their supported public type."""
+        del name
+        if not value:
+            return queryset
+        return queryset.filter(
+            content_type__app_label='gcd',
+            content_type__model=value,
+        )
+
+    class Meta:
+        """FilterSet metadata for received Award filtering."""
+
+        model = ReceivedAward
+        fields = (
+            'recipient_type',
+            'award_year',
+        ) + TIMESTAMP_FILTER_FIELDS

--- a/apps/api_v2/filters/brand_groups.py
+++ b/apps/api_v2/filters/brand_groups.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""django-filter configuration for v2 brand group endpoints."""
+
+import django_filters
+
+from apps.api_v2.filters.common import (
+    TIMESTAMP_FILTER_FIELDS,
+    TimestampFilterSet,
+)
+from apps.gcd.models import BrandGroup
+
+
+class BrandGroupFilterSet(TimestampFilterSet):
+    """Filters for brand group list endpoints."""
+
+    name = django_filters.CharFilter(
+        field_name='name',
+        lookup_expr='icontains',
+    )
+    parent = django_filters.NumberFilter(field_name='parent_id')
+
+    class Meta:
+        """FilterSet metadata for brand group filtering."""
+
+        model = BrandGroup
+        fields = (
+            'name',
+            'parent',
+            'year_began',
+            'year_ended',
+        ) + TIMESTAMP_FILTER_FIELDS

--- a/apps/api_v2/filters/brands.py
+++ b/apps/api_v2/filters/brands.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""django-filter configuration for v2 Brand endpoints."""
+
+import django_filters
+
+from apps.api_v2.filters.common import (
+    TIMESTAMP_FILTER_FIELDS,
+    TimestampFilterSet,
+)
+from apps.gcd.models import Brand
+
+
+class BrandFilterSet(TimestampFilterSet):
+    """Filters for Brand list endpoints."""
+
+    name = django_filters.CharFilter(
+        field_name='name',
+        lookup_expr='icontains',
+    )
+    generic = django_filters.BooleanFilter(field_name='generic')
+    group = django_filters.NumberFilter(method='filter_group')
+    publisher = django_filters.NumberFilter(method='filter_publisher')
+
+    def filter_group(self, queryset, name, value):
+        """Filter by an active Brand Group without duplicate rows."""
+        del name
+        return queryset.filter(
+            group__id=value,
+            group__deleted=False,
+            group__parent__deleted=False,
+        ).distinct()
+
+    def filter_publisher(self, queryset, name, value):
+        """Filter by active Brand Uses without duplicate rows."""
+        del name
+        return queryset.filter(
+            in_use__publisher_id=value,
+            in_use__publisher__deleted=False,
+        ).distinct()
+
+    class Meta:
+        """FilterSet metadata for Brand filtering."""
+
+        model = Brand
+        fields = (
+            'name',
+            'generic',
+            'group',
+            'publisher',
+            'year_began',
+            'year_ended',
+        ) + TIMESTAMP_FILTER_FIELDS

--- a/apps/api_v2/filters/features.py
+++ b/apps/api_v2/filters/features.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""django-filter configuration for v2 Feature endpoints."""
+
+import django_filters
+
+from apps.api_v2.filters.common import (
+    TIMESTAMP_FILTER_FIELDS,
+    LanguageCodeFilter,
+    TimestampFilterSet,
+)
+from apps.gcd.models import Feature
+
+
+class FeatureFilterSet(TimestampFilterSet):
+    """Filters for Feature list endpoints."""
+
+    name = django_filters.CharFilter(
+        field_name='name',
+        lookup_expr='icontains',
+    )
+    feature_type = django_filters.NumberFilter(field_name='feature_type_id')
+    language = LanguageCodeFilter(field_name='language')
+    genre = django_filters.CharFilter(
+        field_name='genre',
+        lookup_expr='icontains',
+    )
+
+    class Meta:
+        """FilterSet metadata for Feature filtering."""
+
+        model = Feature
+        fields = (
+            'name',
+            'feature_type',
+            'language',
+            'genre',
+            'year_first_published',
+        ) + TIMESTAMP_FILTER_FIELDS

--- a/apps/api_v2/filters/indicia_printers.py
+++ b/apps/api_v2/filters/indicia_printers.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""django-filter configuration for v2 indicia printer endpoints."""
+
+import django_filters
+
+from apps.api_v2.filters.common import (
+    TIMESTAMP_FILTER_FIELDS,
+    TimestampFilterSet,
+)
+from apps.gcd.models import IndiciaPrinter
+
+
+class IndiciaPrinterFilterSet(TimestampFilterSet):
+    """Filters for indicia printer list endpoints."""
+
+    name = django_filters.CharFilter(
+        field_name='name',
+        lookup_expr='icontains',
+    )
+    parent = django_filters.NumberFilter(field_name='parent_id')
+    country = django_filters.CharFilter(field_name='country__code')
+
+    class Meta:
+        """FilterSet metadata for indicia printer filtering."""
+
+        model = IndiciaPrinter
+        fields = (
+            'name',
+            'parent',
+            'country',
+            'year_began',
+            'year_ended',
+        ) + TIMESTAMP_FILTER_FIELDS

--- a/apps/api_v2/filters/indicia_publishers.py
+++ b/apps/api_v2/filters/indicia_publishers.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""django-filter configuration for v2 indicia publisher endpoints."""
+
+import django_filters
+
+from apps.api_v2.filters.common import (
+    TIMESTAMP_FILTER_FIELDS,
+    TimestampFilterSet,
+)
+from apps.gcd.models import IndiciaPublisher
+
+
+class IndiciaPublisherFilterSet(TimestampFilterSet):
+    """Filters for indicia publisher list endpoints."""
+
+    name = django_filters.CharFilter(
+        field_name='name',
+        lookup_expr='icontains',
+    )
+    parent = django_filters.NumberFilter(field_name='parent_id')
+    country = django_filters.CharFilter(field_name='country__code')
+    is_surrogate = django_filters.BooleanFilter(field_name='is_surrogate')
+
+    class Meta:
+        """FilterSet metadata for indicia publisher filtering."""
+
+        model = IndiciaPublisher
+        fields = (
+            'name',
+            'parent',
+            'country',
+            'is_surrogate',
+            'year_began',
+            'year_ended',
+        ) + TIMESTAMP_FILTER_FIELDS

--- a/apps/api_v2/filters/series_bonds.py
+++ b/apps/api_v2/filters/series_bonds.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""django-filter configuration for v2 Series Bond endpoints."""
+
+import django_filters
+
+from apps.api_v2.filters.common import (
+    TIMESTAMP_FILTER_FIELDS,
+    TimestampFilterSet,
+)
+from apps.gcd.models import SeriesBond
+
+
+class SeriesBondFilterSet(TimestampFilterSet):
+    """Filters for Series Bond list endpoints."""
+
+    origin = django_filters.NumberFilter(field_name='origin_id')
+    origin_issue = django_filters.NumberFilter(field_name='origin_issue_id')
+    target = django_filters.NumberFilter(field_name='target_id')
+    target_issue = django_filters.NumberFilter(field_name='target_issue_id')
+    bond_type = django_filters.NumberFilter(field_name='bond_type_id')
+
+    class Meta:
+        """FilterSet metadata for Series Bond filtering."""
+
+        model = SeriesBond
+        fields = (
+            'origin',
+            'origin_issue',
+            'target',
+            'target_issue',
+            'bond_type',
+        ) + TIMESTAMP_FILTER_FIELDS

--- a/apps/api_v2/serializers/awards.py
+++ b/apps/api_v2/serializers/awards.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Serializers for v2 Award endpoints."""
+
+from drf_spectacular.utils import (
+    PolymorphicProxySerializer,
+    extend_schema_field,
+)
+from rest_framework import serializers
+
+from apps.gcd.models import Award, ReceivedAward
+
+
+def _series_reference(series):
+    """Return a minimal Series reference."""
+    return {
+        'id': series.pk,
+        'name': series.name,
+    }
+
+
+def _issue_reference(issue):
+    """Return a useful Issue recipient reference."""
+    return {
+        'id': issue.pk,
+        'number': issue.number,
+        'volume': issue.volume,
+        'title': issue.title,
+        'series': _series_reference(issue.series),
+    }
+
+
+def _recipient_reference(recipient_type, recipient):
+    """Return the supported type-specific generic recipient shape."""
+    if recipient is None:
+        return None
+    if recipient_type == 'creator':
+        return {
+            'id': recipient.pk,
+            'name': recipient.gcd_official_name,
+            'sort_name': recipient.sort_name,
+            'disambiguation': recipient.disambiguation,
+        }
+    if recipient_type == 'issue':
+        return _issue_reference(recipient)
+    if recipient_type == 'series':
+        return {
+            'id': recipient.pk,
+            'name': recipient.name,
+            'sort_name': recipient.sort_name,
+            'year_began': recipient.year_began,
+        }
+    if recipient_type == 'story':
+        return {
+            'id': recipient.pk,
+            'title': recipient.title,
+            'feature': recipient.feature,
+            'sequence_number': recipient.sequence_number,
+            'issue': {
+                'id': recipient.issue.pk,
+                'number': recipient.issue.number,
+                'series': _series_reference(recipient.issue.series),
+            },
+        }
+    return None
+
+
+class AwardSeriesNameReferenceSerializer(serializers.Serializer):
+    """Describe the Series identity nested in Issue references."""
+
+    id = serializers.IntegerField()
+    name = serializers.CharField()
+
+
+class AwardCreatorRecipientReferenceSerializer(serializers.Serializer):
+    """Describe a Creator Award recipient."""
+
+    id = serializers.IntegerField()
+    name = serializers.CharField()
+    sort_name = serializers.CharField()
+    disambiguation = serializers.CharField()
+
+
+class AwardIssueRecipientReferenceSerializer(serializers.Serializer):
+    """Describe an Issue Award recipient."""
+
+    id = serializers.IntegerField()
+    number = serializers.CharField()
+    volume = serializers.CharField()
+    title = serializers.CharField()
+    series = AwardSeriesNameReferenceSerializer()
+
+
+class AwardSeriesRecipientReferenceSerializer(serializers.Serializer):
+    """Describe a Series Award recipient."""
+
+    id = serializers.IntegerField()
+    name = serializers.CharField()
+    sort_name = serializers.CharField()
+    year_began = serializers.IntegerField()
+
+
+class AwardStoryIssueReferenceSerializer(serializers.Serializer):
+    """Describe the Issue identity nested in Story references."""
+
+    id = serializers.IntegerField()
+    number = serializers.CharField()
+    series = AwardSeriesNameReferenceSerializer()
+
+
+class AwardStoryRecipientReferenceSerializer(serializers.Serializer):
+    """Describe a Story Award recipient."""
+
+    id = serializers.IntegerField()
+    title = serializers.CharField()
+    feature = serializers.CharField()
+    sequence_number = serializers.IntegerField()
+    issue = AwardStoryIssueReferenceSerializer()
+
+
+class AwardListSerializer(serializers.ModelSerializer):
+    """Serialize trimmed Award list rows."""
+
+    class Meta:
+        """Serializer metadata for Award list fields."""
+
+        model = Award
+        fields = (
+            'id',
+            'name',
+            'created',
+            'modified',
+        )
+
+
+class AwardSerializer(AwardListSerializer):
+    """Serialize complete Award detail rows."""
+
+    class Meta(AwardListSerializer.Meta):
+        """Serializer metadata for Award detail fields."""
+
+        fields = AwardListSerializer.Meta.fields + ('notes',)
+
+
+class AwardRecipientSerializer(serializers.ModelSerializer):
+    """Serialize a received Award with its typed generic recipient."""
+
+    recipient_type = serializers.SerializerMethodField()
+    recipient = serializers.SerializerMethodField()
+    name = serializers.SerializerMethodField()
+    year = serializers.IntegerField(
+        source='award_year',
+        read_only=True,
+        allow_null=True,
+    )
+    year_uncertain = serializers.BooleanField(
+        source='award_year_uncertain',
+        read_only=True,
+    )
+
+    class Meta:
+        """Serializer metadata for received Award rows."""
+
+        model = ReceivedAward
+        fields = (
+            'id',
+            'recipient_type',
+            'recipient',
+            'name',
+            'year',
+            'year_uncertain',
+            'notes',
+            'created',
+            'modified',
+        )
+
+    def get_recipient_type(self, obj) -> str:
+        """Return the stable public name for the generic recipient type."""
+        return obj.content_type.model
+
+    @extend_schema_field(
+        PolymorphicProxySerializer(
+            component_name='AwardRecipientReference',
+            serializers=(
+                AwardCreatorRecipientReferenceSerializer,
+                AwardIssueRecipientReferenceSerializer,
+                AwardSeriesRecipientReferenceSerializer,
+                AwardStoryRecipientReferenceSerializer,
+            ),
+            resource_type_field_name=None,
+        ),
+    )
+    def get_recipient(self, obj):
+        """Return a type-aware generic recipient reference."""
+        return _recipient_reference(
+            self.get_recipient_type(obj),
+            obj.recipient,
+        )
+
+    def get_name(self, obj) -> str:
+        """Return the Received Award display name."""
+        return obj.display_name()

--- a/apps/api_v2/serializers/brand_groups.py
+++ b/apps/api_v2/serializers/brand_groups.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Serializers for v2 brand group endpoints."""
+
+from rest_framework import serializers
+
+from apps.gcd.models import BrandGroup
+
+
+class BrandGroupListSerializer(serializers.ModelSerializer):
+    """Serialize trimmed brand group list rows."""
+
+    parent = serializers.SerializerMethodField()
+
+    class Meta:
+        """Serializer metadata for brand group list fields."""
+
+        model = BrandGroup
+        fields = (
+            'id',
+            'name',
+            'parent',
+            'year_began',
+            'year_ended',
+            'issue_count',
+            'created',
+            'modified',
+        )
+
+    def get_parent(self, obj):
+        """Return the minimal nested parent Publisher reference."""
+        return {
+            'id': obj.parent_id,
+            'name': obj.parent.name,
+        }
+
+
+class BrandGroupSerializer(BrandGroupListSerializer):
+    """Serialize complete brand group detail rows."""
+
+    keywords = serializers.SlugRelatedField(
+        many=True,
+        read_only=True,
+        slug_field='name',
+    )
+    emblems = serializers.SerializerMethodField()
+
+    class Meta(BrandGroupListSerializer.Meta):
+        """Serializer metadata for brand group detail fields."""
+
+        fields = BrandGroupListSerializer.Meta.fields + (
+            'year_began_uncertain',
+            'year_ended_uncertain',
+            'year_overall_began',
+            'year_overall_ended',
+            'year_overall_began_uncertain',
+            'year_overall_ended_uncertain',
+            'url',
+            'notes',
+            'keywords',
+            'emblems',
+        )
+
+    def get_emblems(self, obj):
+        """Return ordered active Brand emblems for this group."""
+        emblems = getattr(obj, 'active_brand_group_emblem_list', None)
+        if emblems is None:
+            emblems = obj.brand_set.filter(deleted=False).order_by(
+                'name',
+                'id',
+            )
+        return [
+            {
+                'id': emblem.pk,
+                'name': emblem.name,
+                'generic': emblem.generic,
+                'year_began': emblem.year_began,
+                'year_ended': emblem.year_ended,
+            }
+            for emblem in emblems
+        ]

--- a/apps/api_v2/serializers/brands.py
+++ b/apps/api_v2/serializers/brands.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Serializers for v2 Brand endpoints."""
+
+from rest_framework import serializers
+
+from apps.gcd.models import Brand, BrandGroup, BrandUse
+
+
+class BrandGroupReferenceSerializer(serializers.ModelSerializer):
+    """Serialize an active Brand Group reference with its parent."""
+
+    parent = serializers.SerializerMethodField()
+
+    class Meta:
+        """Serializer metadata for Brand Group references."""
+
+        model = BrandGroup
+        fields = ('id', 'name', 'parent')
+
+    def get_parent(self, obj):
+        """Return the minimal nested parent Publisher reference."""
+        return {
+            'id': obj.parent_id,
+            'name': obj.parent.name,
+        }
+
+
+class BrandUseSerializer(serializers.ModelSerializer):
+    """Serialize a Brand Use relationship for Brand detail responses."""
+
+    publisher = serializers.SerializerMethodField()
+
+    class Meta:
+        """Serializer metadata for Brand Use fields."""
+
+        model = BrandUse
+        fields = (
+            'id',
+            'publisher',
+            'year_began',
+            'year_ended',
+            'year_began_uncertain',
+            'year_ended_uncertain',
+            'notes',
+            'created',
+            'modified',
+        )
+
+    def get_publisher(self, obj):
+        """Return the minimal nested Publisher reference."""
+        return {
+            'id': obj.publisher_id,
+            'name': obj.publisher.name,
+        }
+
+
+class BrandListSerializer(serializers.ModelSerializer):
+    """Serialize trimmed Brand list rows."""
+
+    class Meta:
+        """Serializer metadata for Brand list fields."""
+
+        model = Brand
+        fields = (
+            'id',
+            'name',
+            'generic',
+            'year_began',
+            'year_ended',
+            'issue_count',
+            'created',
+            'modified',
+        )
+
+
+class BrandSerializer(BrandListSerializer):
+    """Serialize complete Brand detail rows."""
+
+    keywords = serializers.SlugRelatedField(
+        many=True,
+        read_only=True,
+        slug_field='name',
+    )
+    groups = serializers.SerializerMethodField()
+    uses = serializers.SerializerMethodField()
+
+    class Meta(BrandListSerializer.Meta):
+        """Serializer metadata for Brand detail fields."""
+
+        fields = BrandListSerializer.Meta.fields + (
+            'year_began_uncertain',
+            'year_ended_uncertain',
+            'year_overall_began',
+            'year_overall_ended',
+            'year_overall_began_uncertain',
+            'year_overall_ended_uncertain',
+            'url',
+            'notes',
+            'keywords',
+            'groups',
+            'uses',
+        )
+
+    def get_groups(self, obj):
+        """Return ordered active Brand Group references."""
+        groups = getattr(obj, 'active_brand_group_list', None)
+        if groups is None:
+            groups = (
+                obj.group.filter(
+                    deleted=False,
+                    parent__deleted=False,
+                )
+                .select_related('parent')
+                .order_by('parent__name', 'name', 'id')
+            )
+        return BrandGroupReferenceSerializer(groups, many=True).data
+
+    def get_uses(self, obj):
+        """Return ordered Brand Uses tied to active Publishers."""
+        uses = getattr(obj, 'active_brand_use_list', None)
+        if uses is None:
+            uses = (
+                obj.in_use.filter(publisher__deleted=False)
+                .select_related('publisher')
+                .order_by('publisher__name', 'year_began', 'id')
+            )
+        return BrandUseSerializer(uses, many=True).data

--- a/apps/api_v2/serializers/features.py
+++ b/apps/api_v2/serializers/features.py
@@ -1,0 +1,213 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Serializers for v2 Feature endpoints."""
+
+from rest_framework import serializers
+
+from apps.gcd.models import Feature, FeatureLogo
+
+
+def _feature_type_reference(feature_type):
+    """Return a minimal Feature Type reference."""
+    return {
+        'id': feature_type.pk,
+        'name': feature_type.name,
+    }
+
+
+def _related_feature_reference(feature):
+    """Return a related Feature reference for normalized relations."""
+    return {
+        'id': feature.pk,
+        'name': feature.name,
+        'disambiguation': feature.disambiguation,
+        'feature_type': _feature_type_reference(feature.feature_type),
+    }
+
+
+class FeatureLogoSerializer(serializers.ModelSerializer):
+    """Serialize an active Feature Logo reference."""
+
+    class Meta:
+        """Serializer metadata for Feature Logo fields."""
+
+        model = FeatureLogo
+        fields = (
+            'id',
+            'name',
+            'generic',
+            'year_began',
+            'year_ended',
+            'year_began_uncertain',
+            'year_ended_uncertain',
+        )
+
+
+class FeatureTypeReferenceSerializer(serializers.Serializer):
+    """Describe a Feature Type nested reference."""
+
+    id = serializers.IntegerField()
+    name = serializers.CharField()
+
+
+class RelatedFeatureReferenceSerializer(serializers.Serializer):
+    """Describe the other Feature in a normalized relation."""
+
+    id = serializers.IntegerField()
+    name = serializers.CharField()
+    disambiguation = serializers.CharField()
+    feature_type = FeatureTypeReferenceSerializer()
+
+
+class FeatureRelationTypeReferenceSerializer(serializers.Serializer):
+    """Describe a directional Feature Relation Type."""
+
+    id = serializers.IntegerField()
+    name = serializers.CharField()
+    description = serializers.CharField()
+
+
+class NormalizedFeatureRelationSerializer(serializers.Serializer):
+    """Serialize a Feature Relation relative to the requested Feature."""
+
+    id = serializers.IntegerField()
+    direction = serializers.ChoiceField(choices=('outgoing', 'incoming'))
+    relation_type = FeatureRelationTypeReferenceSerializer()
+    feature = RelatedFeatureReferenceSerializer()
+    notes = serializers.CharField()
+
+
+class FeatureListSerializer(serializers.ModelSerializer):
+    """Serialize trimmed Feature list rows."""
+
+    feature_type = serializers.SerializerMethodField()
+    language = serializers.SlugRelatedField(
+        read_only=True,
+        slug_field='code',
+    )
+
+    class Meta:
+        """Serializer metadata for Feature list fields."""
+
+        model = Feature
+        fields = (
+            'id',
+            'name',
+            'sort_name',
+            'disambiguation',
+            'feature_type',
+            'language',
+            'genre',
+            'year_first_published',
+            'created',
+            'modified',
+        )
+
+    def get_feature_type(self, obj):
+        """Return the nested Feature Type reference."""
+        return _feature_type_reference(obj.feature_type)
+
+
+class FeatureSerializer(FeatureListSerializer):
+    """Serialize complete Feature detail rows."""
+
+    keywords = serializers.SlugRelatedField(
+        many=True,
+        read_only=True,
+        slug_field='name',
+    )
+    logos = serializers.SerializerMethodField()
+    relations = serializers.SerializerMethodField()
+
+    class Meta(FeatureListSerializer.Meta):
+        """Serializer metadata for Feature detail fields."""
+
+        fields = FeatureListSerializer.Meta.fields + (
+            'year_first_published_uncertain',
+            'notes',
+            'keywords',
+            'logos',
+            'relations',
+        )
+
+    def get_logos(self, obj):
+        """Return ordered active Feature Logos."""
+        logos = getattr(obj, 'active_feature_logo_list', None)
+        if logos is None:
+            logos = obj.featurelogo_set.filter(deleted=False).order_by(
+                'sort_name',
+                'id',
+            )
+        return FeatureLogoSerializer(logos, many=True).data
+
+    def get_relations(self, obj):
+        """Return one normalized collection for both relation directions."""
+        outgoing = getattr(obj, 'outgoing_feature_relation_list', None)
+        if outgoing is None:
+            outgoing = (
+                obj.to_related_feature.filter(
+                    from_feature__deleted=False,
+                    to_feature__deleted=False,
+                )
+                .select_related('relation_type', 'to_feature__feature_type')
+                .order_by(
+                    'relation_type__name',
+                    'to_feature__sort_name',
+                    'id',
+                )
+            )
+        incoming = getattr(obj, 'incoming_feature_relation_list', None)
+        if incoming is None:
+            incoming = (
+                obj.from_related_feature.filter(
+                    from_feature__deleted=False,
+                    to_feature__deleted=False,
+                )
+                .select_related(
+                    'relation_type',
+                    'from_feature__feature_type',
+                )
+                .order_by(
+                    'relation_type__name',
+                    'from_feature__sort_name',
+                    'id',
+                )
+            )
+
+        relations = [
+            {
+                'id': relation.pk,
+                'direction': 'outgoing',
+                'relation_type': {
+                    'id': relation.relation_type_id,
+                    'name': relation.relation_type.name,
+                    'description': relation.relation_type.description,
+                },
+                'feature': _related_feature_reference(relation.to_feature),
+                'notes': relation.notes,
+            }
+            for relation in outgoing
+        ]
+        relations.extend(
+            {
+                'id': relation.pk,
+                'direction': 'incoming',
+                'relation_type': {
+                    'id': relation.relation_type_id,
+                    'name': relation.relation_type.name,
+                    'description': (
+                        relation.relation_type.reverse_description
+                    ),
+                },
+                'feature': _related_feature_reference(
+                    relation.from_feature,
+                ),
+                'notes': relation.notes,
+            }
+            for relation in incoming
+        )
+        return NormalizedFeatureRelationSerializer(
+            relations,
+            many=True,
+        ).data

--- a/apps/api_v2/serializers/indicia_printers.py
+++ b/apps/api_v2/serializers/indicia_printers.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Serializers for v2 indicia printer endpoints."""
+
+from rest_framework import serializers
+
+from apps.gcd.models import IndiciaPrinter
+
+
+class IndiciaPrinterListSerializer(serializers.ModelSerializer):
+    """Serialize trimmed indicia printer list rows."""
+
+    parent = serializers.SerializerMethodField()
+    country = serializers.SlugRelatedField(
+        read_only=True,
+        slug_field='code',
+    )
+
+    class Meta:
+        """Serializer metadata for indicia printer list fields."""
+
+        model = IndiciaPrinter
+        fields = (
+            'id',
+            'name',
+            'parent',
+            'country',
+            'year_began',
+            'year_ended',
+            'issue_count',
+            'created',
+            'modified',
+        )
+
+    def get_parent(self, obj):
+        """Return the minimal nested parent Printer reference."""
+        return {
+            'id': obj.parent_id,
+            'name': obj.parent.name,
+        }
+
+
+class IndiciaPrinterSerializer(IndiciaPrinterListSerializer):
+    """Serialize complete indicia printer detail rows."""
+
+    keywords = serializers.SlugRelatedField(
+        many=True,
+        read_only=True,
+        slug_field='name',
+    )
+
+    class Meta(IndiciaPrinterListSerializer.Meta):
+        """Serializer metadata for indicia printer detail fields."""
+
+        fields = IndiciaPrinterListSerializer.Meta.fields + (
+            'year_began_uncertain',
+            'year_ended_uncertain',
+            'year_overall_began',
+            'year_overall_ended',
+            'year_overall_began_uncertain',
+            'year_overall_ended_uncertain',
+            'url',
+            'notes',
+            'keywords',
+        )

--- a/apps/api_v2/serializers/indicia_publishers.py
+++ b/apps/api_v2/serializers/indicia_publishers.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Serializers for v2 indicia publisher endpoints."""
+
+from rest_framework import serializers
+
+from apps.gcd.models import IndiciaPublisher
+
+
+class IndiciaPublisherListSerializer(serializers.ModelSerializer):
+    """Serialize trimmed indicia publisher list rows."""
+
+    parent = serializers.SerializerMethodField()
+    country = serializers.SlugRelatedField(
+        read_only=True,
+        slug_field='code',
+    )
+
+    class Meta:
+        """Serializer metadata for indicia publisher list fields."""
+
+        model = IndiciaPublisher
+        fields = (
+            'id',
+            'name',
+            'parent',
+            'country',
+            'is_surrogate',
+            'year_began',
+            'year_ended',
+            'issue_count',
+            'created',
+            'modified',
+        )
+
+    def get_parent(self, obj):
+        """Return the minimal nested parent Publisher reference."""
+        return {
+            'id': obj.parent_id,
+            'name': obj.parent.name,
+        }
+
+
+class IndiciaPublisherSerializer(IndiciaPublisherListSerializer):
+    """Serialize complete indicia publisher detail rows."""
+
+    keywords = serializers.SlugRelatedField(
+        many=True,
+        read_only=True,
+        slug_field='name',
+    )
+
+    class Meta(IndiciaPublisherListSerializer.Meta):
+        """Serializer metadata for indicia publisher detail fields."""
+
+        fields = IndiciaPublisherListSerializer.Meta.fields + (
+            'year_began_uncertain',
+            'year_ended_uncertain',
+            'year_overall_began',
+            'year_overall_ended',
+            'year_overall_began_uncertain',
+            'year_overall_ended_uncertain',
+            'url',
+            'notes',
+            'keywords',
+        )

--- a/apps/api_v2/serializers/series_bonds.py
+++ b/apps/api_v2/serializers/series_bonds.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Serializers for v2 Series Bond endpoints."""
+
+from rest_framework import serializers
+
+from apps.gcd.models import SeriesBond
+
+
+class SeriesBondSeriesReferenceSerializer(serializers.Serializer):
+    """Serialize a Series reference used by Series Bond payloads."""
+
+    id = serializers.IntegerField(read_only=True)
+    name = serializers.CharField(read_only=True)
+    year_began = serializers.IntegerField(read_only=True)
+
+
+class SeriesBondIssueReferenceSerializer(serializers.Serializer):
+    """Serialize an Issue reference used by Series Bond payloads."""
+
+    id = serializers.IntegerField(read_only=True)
+    descriptor = serializers.CharField(
+        source='issue_descriptor',
+        read_only=True,
+    )
+
+
+class SeriesBondTypeReferenceSerializer(serializers.Serializer):
+    """Serialize a Series Bond Type reference."""
+
+    id = serializers.IntegerField(read_only=True)
+    name = serializers.CharField(read_only=True)
+    description = serializers.CharField(read_only=True)
+
+
+class SeriesBondListSerializer(serializers.ModelSerializer):
+    """Serialize trimmed Series Bond list rows."""
+
+    created = serializers.DateTimeField(
+        read_only=True,
+        help_text=(
+            'Persistent creation timestamp. Legacy rows without approved '
+            'revision history use the migration-time timestamp-tracking '
+            'baseline.'
+        ),
+    )
+    modified = serializers.DateTimeField(
+        read_only=True,
+        help_text=(
+            'Persistent last-modified timestamp. Legacy rows without '
+            'approved revision history use the migration-time '
+            'timestamp-tracking baseline.'
+        ),
+    )
+    origin = SeriesBondSeriesReferenceSerializer(read_only=True)
+    origin_issue = SeriesBondIssueReferenceSerializer(
+        allow_null=True,
+        read_only=True,
+    )
+    target = SeriesBondSeriesReferenceSerializer(read_only=True)
+    target_issue = SeriesBondIssueReferenceSerializer(
+        allow_null=True,
+        read_only=True,
+    )
+    bond_type = SeriesBondTypeReferenceSerializer(read_only=True)
+
+    class Meta:
+        """Serializer metadata for Series Bond list fields."""
+
+        model = SeriesBond
+        fields = (
+            'id',
+            'origin',
+            'origin_issue',
+            'target',
+            'target_issue',
+            'bond_type',
+            'created',
+            'modified',
+        )
+
+
+class SeriesBondSerializer(SeriesBondListSerializer):
+    """Serialize complete Series Bond detail rows."""
+
+    class Meta(SeriesBondListSerializer.Meta):
+        """Serializer metadata for Series Bond detail fields."""
+
+        fields = SeriesBondListSerializer.Meta.fields + ('notes',)

--- a/apps/api_v2/tests/test_filters/test_awards.py
+++ b/apps/api_v2/tests/test_filters/test_awards.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for Award and received-award filter sets."""
+
+from datetime import timedelta
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+from django.utils import timezone
+
+from apps.api_v2.filters.awards import (
+    AwardFilterSet,
+    AwardRecipientFilterSet,
+)
+from apps.gcd.models import Award, Creator, ReceivedAward
+
+pytestmark = pytest.mark.django_db
+
+
+def _create_creator(name):
+    """Create a minimal Creator recipient."""
+    return Creator.objects.create(
+        gcd_official_name=name,
+        sort_name=name,
+        disambiguation='',
+        birth_province='',
+        birth_city='',
+        death_province='',
+        death_city='',
+        bio='',
+        notes='',
+    )
+
+
+def _create_received_award(*, award, recipient, year):
+    """Create a received Award for ``recipient``."""
+    return ReceivedAward.objects.create(
+        content_type=ContentType.objects.get_for_model(recipient),
+        object_id=recipient.pk,
+        award=award,
+        award_name='Best Work',
+        award_year=year,
+        notes='',
+    )
+
+
+def test_award_filter_matches_name_icontains():
+    """The Award name filter uses case-insensitive containment."""
+    matching = Award.objects.create(name='Eisner Awards', notes='')
+    Award.objects.create(name='Harvey Awards', notes='')
+
+    queryset = AwardFilterSet(
+        {'name': 'EISNER'},
+        queryset=Award.objects.all(),
+    ).qs
+
+    assert list(queryset) == [matching]
+
+
+def test_award_filter_matches_modified_range():
+    """Award timestamp filters support delta-style queries."""
+    older = Award.objects.create(name='Older Award', notes='')
+    newer = Award.objects.create(name='Newer Award', notes='')
+    now = timezone.now()
+    Award.objects.filter(pk=older.pk).update(modified=now - timedelta(days=2))
+    Award.objects.filter(pk=newer.pk).update(modified=now - timedelta(hours=1))
+
+    queryset = AwardFilterSet(
+        {'modified__gt': (now - timedelta(days=1)).isoformat()},
+        queryset=Award.objects.all(),
+    ).qs
+
+    assert list(queryset) == [newer]
+
+
+def test_award_recipient_filter_matches_type_and_year():
+    """Recipient type and Award year filters combine exactly."""
+    award = Award.objects.create(name='Eisner Awards', notes='')
+    creator = _create_creator('Test Creator')
+    matching = _create_received_award(
+        award=award,
+        recipient=creator,
+        year=1989,
+    )
+    _create_received_award(
+        award=award,
+        recipient=creator,
+        year=1990,
+    )
+
+    queryset = AwardRecipientFilterSet(
+        {
+            'recipient_type': 'creator',
+            'award_year': '1989',
+        },
+        queryset=ReceivedAward.objects.all(),
+    ).qs
+
+    assert list(queryset) == [matching]
+
+
+def test_award_recipient_filter_matches_created_range():
+    """Received Award timestamp ranges support bounded queries."""
+    award = Award.objects.create(name='Eisner Awards', notes='')
+    creator = _create_creator('Test Creator')
+    older = _create_received_award(
+        award=award,
+        recipient=creator,
+        year=1989,
+    )
+    newer = _create_received_award(
+        award=award,
+        recipient=creator,
+        year=1990,
+    )
+    now = timezone.now()
+    ReceivedAward.objects.filter(pk=older.pk).update(
+        created=now - timedelta(days=2),
+    )
+    ReceivedAward.objects.filter(pk=newer.pk).update(
+        created=now - timedelta(hours=1),
+    )
+
+    queryset = AwardRecipientFilterSet(
+        {'created__lte': (now - timedelta(days=1)).isoformat()},
+        queryset=ReceivedAward.objects.all(),
+    ).qs
+
+    assert list(queryset) == [older]

--- a/apps/api_v2/tests/test_filters/test_brand_groups.py
+++ b/apps/api_v2/tests/test_filters/test_brand_groups.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for the brand group filter set."""
+
+from datetime import timedelta
+
+from django.utils import timezone
+
+from apps.api_v2.filters.brand_groups import BrandGroupFilterSet
+from apps.gcd.models import BrandGroup, Publisher
+
+
+def _create_brand_group(
+    *,
+    publisher,
+    name,
+    year_began=1950,
+    year_ended=None,
+):
+    """Create a minimal brand group row for filter tests."""
+    return BrandGroup.objects.create(
+        name=name,
+        year_began=year_began,
+        year_ended=year_ended,
+        notes='',
+        parent=publisher,
+    )
+
+
+def _set_timestamps(obj, *, created, modified):
+    """Persist explicit created/modified timestamps for filter tests."""
+    BrandGroup.objects.filter(pk=obj.pk).update(
+        created=created,
+        modified=modified,
+    )
+    obj.refresh_from_db()
+
+
+def test_brand_group_filter_matches_name_icontains(publisher):
+    """The name filter uses case-insensitive containment."""
+    matching = _create_brand_group(
+        publisher=publisher,
+        name='Marvel Comics Group',
+    )
+    _create_brand_group(
+        publisher=publisher,
+        name='National Periodical Publications',
+    )
+
+    queryset = BrandGroupFilterSet(
+        {'name': 'marvel comics'},
+        queryset=BrandGroup.objects.all(),
+    ).qs
+
+    assert list(queryset) == [matching]
+
+
+def test_brand_group_filter_matches_exact_fields(publisher, country):
+    """Parent and exact year filters narrow brand group results."""
+    other_parent = Publisher.objects.create(
+        name='Other Publisher',
+        year_began=1940,
+        notes='',
+        country=country,
+    )
+    matching = _create_brand_group(
+        publisher=publisher,
+        name='Matching Group',
+        year_began=1960,
+        year_ended=1980,
+    )
+    _create_brand_group(
+        publisher=other_parent,
+        name='Wrong Parent',
+        year_began=1960,
+        year_ended=1980,
+    )
+    _create_brand_group(
+        publisher=publisher,
+        name='Wrong Years',
+        year_began=1970,
+        year_ended=1990,
+    )
+
+    queryset = BrandGroupFilterSet(
+        {
+            'parent': str(publisher.pk),
+            'year_began': '1960',
+            'year_ended': '1980',
+        },
+        queryset=BrandGroup.objects.all(),
+    ).qs
+
+    assert list(queryset) == [matching]
+
+
+def test_brand_group_filter_matches_modified_range(publisher):
+    """Modified range filters support delta-style sync queries."""
+    older = _create_brand_group(
+        publisher=publisher,
+        name='Older Group',
+    )
+    newer = _create_brand_group(
+        publisher=publisher,
+        name='Newer Group',
+    )
+    now = timezone.now()
+    _set_timestamps(
+        older,
+        created=now - timedelta(days=3),
+        modified=now - timedelta(days=2),
+    )
+    _set_timestamps(
+        newer,
+        created=now - timedelta(days=1),
+        modified=now - timedelta(hours=1),
+    )
+
+    queryset = BrandGroupFilterSet(
+        {'modified__gt': (now - timedelta(days=1)).isoformat()},
+        queryset=BrandGroup.objects.all(),
+    ).qs
+
+    assert list(queryset) == [newer]
+
+
+def test_brand_group_filter_matches_created_range(publisher):
+    """Created range filters support bounded brand group queries."""
+    older = _create_brand_group(
+        publisher=publisher,
+        name='Older Group',
+    )
+    newer = _create_brand_group(
+        publisher=publisher,
+        name='Newer Group',
+    )
+    now = timezone.now()
+    older_created = now - timedelta(days=3)
+    newer_created = now - timedelta(hours=1)
+    _set_timestamps(
+        older,
+        created=older_created,
+        modified=older_created,
+    )
+    _set_timestamps(
+        newer,
+        created=newer_created,
+        modified=newer_created,
+    )
+
+    queryset = BrandGroupFilterSet(
+        {'created__lte': (now - timedelta(days=1)).isoformat()},
+        queryset=BrandGroup.objects.all(),
+    ).qs
+
+    assert list(queryset) == [older]

--- a/apps/api_v2/tests/test_filters/test_brands.py
+++ b/apps/api_v2/tests/test_filters/test_brands.py
@@ -1,0 +1,236 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for the brand filter set."""
+
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+
+from apps.api_v2.filters.brands import BrandFilterSet
+from apps.gcd.models import Brand, BrandGroup, BrandUse, Publisher
+
+pytestmark = pytest.mark.django_db
+
+
+def _create_brand(
+    *,
+    name,
+    generic=False,
+    year_began=1950,
+    year_ended=None,
+):
+    """Create a minimal Brand row for filter tests."""
+    return Brand.objects.create(
+        name=name,
+        generic=generic,
+        year_began=year_began,
+        year_ended=year_ended,
+        notes='',
+    )
+
+
+def _create_brand_group(*, publisher, name, deleted=False):
+    """Create a minimal Brand Group row for relationship filters."""
+    return BrandGroup.objects.create(
+        name=name,
+        year_began=1950,
+        notes='',
+        parent=publisher,
+        deleted=deleted,
+    )
+
+
+def _set_timestamps(obj, *, created, modified):
+    """Persist explicit created/modified timestamps for filter tests."""
+    Brand.objects.filter(pk=obj.pk).update(
+        created=created,
+        modified=modified,
+    )
+    obj.refresh_from_db()
+
+
+def test_brand_filter_matches_name_icontains():
+    """The name filter uses case-insensitive containment."""
+    matching = _create_brand(name='Marvel Comics')
+    _create_brand(name='National Periodical Publications')
+
+    queryset = BrandFilterSet(
+        {'name': 'marvel'},
+        queryset=Brand.objects.all(),
+    ).qs
+
+    assert list(queryset) == [matching]
+
+
+def test_brand_filter_matches_generic_and_exact_years():
+    """Generic and exact year filters narrow Brand results."""
+    matching = _create_brand(
+        name='Matching Brand',
+        generic=True,
+        year_began=1960,
+        year_ended=1980,
+    )
+    _create_brand(
+        name='Wrong Generic Flag',
+        year_began=1960,
+        year_ended=1980,
+    )
+    _create_brand(
+        name='Wrong Years',
+        generic=True,
+        year_began=1970,
+        year_ended=1990,
+    )
+
+    queryset = BrandFilterSet(
+        {
+            'generic': 'true',
+            'year_began': '1960',
+            'year_ended': '1980',
+        },
+        queryset=Brand.objects.all(),
+    ).qs
+
+    assert list(queryset) == [matching]
+
+
+def test_brand_relationship_filters_return_distinct_results(
+    publisher,
+    country,
+):
+    """Group and publisher joins never duplicate matching Brands."""
+    brand_group = _create_brand_group(
+        publisher=publisher,
+        name='Matching Group',
+    )
+    other_group = _create_brand_group(
+        publisher=publisher,
+        name='Other Group',
+    )
+    other_publisher = Publisher.objects.create(
+        name='Other Publisher',
+        year_began=1940,
+        notes='',
+        country=country,
+    )
+    matching = _create_brand(name='Matching Brand')
+    matching.group.add(brand_group, other_group)
+    BrandUse.objects.create(
+        emblem=matching,
+        publisher=publisher,
+        year_began=1960,
+        notes='First use',
+    )
+    BrandUse.objects.create(
+        emblem=matching,
+        publisher=publisher,
+        year_began=1970,
+        notes='Second use',
+    )
+    wrong_publisher = _create_brand(name='Wrong Publisher')
+    wrong_publisher.group.add(brand_group)
+    BrandUse.objects.create(
+        emblem=wrong_publisher,
+        publisher=other_publisher,
+        notes='',
+    )
+
+    queryset = BrandFilterSet(
+        {
+            'group': str(brand_group.pk),
+            'publisher': str(publisher.pk),
+        },
+        queryset=Brand.objects.all(),
+    ).qs
+
+    assert list(queryset) == [matching]
+
+
+def test_brand_relationship_filters_ignore_deleted_relations(
+    publisher,
+    country,
+):
+    """Deleted groups and publishers cannot expose Brands through filters."""
+    deleted_group = _create_brand_group(
+        publisher=publisher,
+        name='Deleted Group',
+        deleted=True,
+    )
+    deleted_publisher = Publisher.objects.create(
+        name='Deleted Publisher',
+        year_began=1940,
+        notes='',
+        country=country,
+        deleted=True,
+    )
+    brand = _create_brand(name='Hidden Relationship Brand')
+    brand.group.add(deleted_group)
+    BrandUse.objects.create(
+        emblem=brand,
+        publisher=deleted_publisher,
+        notes='',
+    )
+
+    group_queryset = BrandFilterSet(
+        {'group': str(deleted_group.pk)},
+        queryset=Brand.objects.all(),
+    ).qs
+    publisher_queryset = BrandFilterSet(
+        {'publisher': str(deleted_publisher.pk)},
+        queryset=Brand.objects.all(),
+    ).qs
+
+    assert list(group_queryset) == []
+    assert list(publisher_queryset) == []
+
+
+def test_brand_filter_matches_modified_range():
+    """Modified range filters support delta-style sync queries."""
+    older = _create_brand(name='Older Brand')
+    newer = _create_brand(name='Newer Brand')
+    now = timezone.now()
+    _set_timestamps(
+        older,
+        created=now - timedelta(days=3),
+        modified=now - timedelta(days=2),
+    )
+    _set_timestamps(
+        newer,
+        created=now - timedelta(days=1),
+        modified=now - timedelta(hours=1),
+    )
+
+    queryset = BrandFilterSet(
+        {'modified__gt': (now - timedelta(days=1)).isoformat()},
+        queryset=Brand.objects.all(),
+    ).qs
+
+    assert list(queryset) == [newer]
+
+
+def test_brand_filter_matches_created_range():
+    """Created range filters support bounded Brand queries."""
+    older = _create_brand(name='Older Brand')
+    newer = _create_brand(name='Newer Brand')
+    now = timezone.now()
+    older_created = now - timedelta(days=3)
+    newer_created = now - timedelta(hours=1)
+    _set_timestamps(
+        older,
+        created=older_created,
+        modified=older_created,
+    )
+    _set_timestamps(
+        newer,
+        created=newer_created,
+        modified=newer_created,
+    )
+
+    queryset = BrandFilterSet(
+        {'created__lte': (now - timedelta(days=1)).isoformat()},
+        queryset=Brand.objects.all(),
+    ).qs
+
+    assert list(queryset) == [older]

--- a/apps/api_v2/tests/test_filters/test_features.py
+++ b/apps/api_v2/tests/test_filters/test_features.py
@@ -1,0 +1,202 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for the Feature filter set."""
+
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+
+from apps.api_v2.filters.features import FeatureFilterSet
+from apps.gcd.models import Feature, FeatureType
+from apps.stddata.models import Language
+
+pytestmark = pytest.mark.django_db
+
+
+def _create_feature(
+    *,
+    language,
+    feature_type,
+    name,
+    genre='superhero',
+    year_first_published=1950,
+):
+    """Create a minimal Feature row for filter tests."""
+    return Feature.objects.create(
+        name=name,
+        sort_name=name,
+        disambiguation='',
+        genre=genre,
+        language=language,
+        feature_type=feature_type,
+        year_first_published=year_first_published,
+        notes='',
+    )
+
+
+def _set_timestamps(obj, *, created, modified):
+    """Persist explicit created/modified timestamps for filter tests."""
+    Feature.objects.filter(pk=obj.pk).update(
+        created=created,
+        modified=modified,
+    )
+    obj.refresh_from_db()
+
+
+def test_feature_filter_matches_name_icontains(language):
+    """The name filter uses case-insensitive containment."""
+    feature_type = FeatureType.objects.create(name='Character')
+    matching = _create_feature(
+        language=language,
+        feature_type=feature_type,
+        name='Amazing Spider-Man',
+    )
+    _create_feature(
+        language=language,
+        feature_type=feature_type,
+        name='Fantastic Four',
+    )
+
+    queryset = FeatureFilterSet(
+        {'name': 'spider'},
+        queryset=Feature.objects.all(),
+    ).qs
+
+    assert list(queryset) == [matching]
+
+
+def test_feature_filter_matches_type_language_genre_and_year(language):
+    """Type, language, genre, and exact year filters narrow results."""
+    character_type = FeatureType.objects.create(name='Character')
+    location_type = FeatureType.objects.create(name='Location')
+    other_language = Language.objects.create(
+        code='yy',
+        name='Other Language',
+    )
+    matching = _create_feature(
+        language=language,
+        feature_type=character_type,
+        name='Matching Feature',
+        genre='Science Fiction; Superhero',
+        year_first_published=1960,
+    )
+    _create_feature(
+        language=language,
+        feature_type=location_type,
+        name='Wrong Type',
+        genre='Science Fiction; Superhero',
+        year_first_published=1960,
+    )
+    _create_feature(
+        language=other_language,
+        feature_type=character_type,
+        name='Wrong Language',
+        genre='Science Fiction; Superhero',
+        year_first_published=1960,
+    )
+    _create_feature(
+        language=language,
+        feature_type=character_type,
+        name='Wrong Genre',
+        genre='Western',
+        year_first_published=1960,
+    )
+
+    queryset = FeatureFilterSet(
+        {
+            'feature_type': str(character_type.pk),
+            'language': language.code,
+            'genre': 'science fiction',
+            'year_first_published': '1960',
+        },
+        queryset=Feature.objects.all(),
+    ).qs
+
+    assert list(queryset) == [matching]
+
+
+def test_feature_filter_returns_none_for_unknown_language(language):
+    """Unknown public language codes return an empty queryset."""
+    feature_type = FeatureType.objects.create(name='Character')
+    _create_feature(
+        language=language,
+        feature_type=feature_type,
+        name='Known Language Feature',
+    )
+
+    queryset = FeatureFilterSet(
+        {'language': 'not-a-code'},
+        queryset=Feature.objects.all(),
+    ).qs
+
+    assert list(queryset) == []
+
+
+def test_feature_filter_matches_modified_range(language):
+    """Modified range filters support delta-style sync queries."""
+    feature_type = FeatureType.objects.create(name='Character')
+    older = _create_feature(
+        language=language,
+        feature_type=feature_type,
+        name='Older Feature',
+    )
+    newer = _create_feature(
+        language=language,
+        feature_type=feature_type,
+        name='Newer Feature',
+    )
+    now = timezone.now()
+    _set_timestamps(
+        older,
+        created=now - timedelta(days=3),
+        modified=now - timedelta(days=2),
+    )
+    _set_timestamps(
+        newer,
+        created=now - timedelta(days=1),
+        modified=now - timedelta(hours=1),
+    )
+
+    queryset = FeatureFilterSet(
+        {'modified__gt': (now - timedelta(days=1)).isoformat()},
+        queryset=Feature.objects.all(),
+    ).qs
+
+    assert list(queryset) == [newer]
+
+
+def test_feature_filter_matches_created_range(language):
+    """Created range filters support bounded Feature queries."""
+    feature_type = FeatureType.objects.create(name='Character')
+    older = _create_feature(
+        language=language,
+        feature_type=feature_type,
+        name='Older Feature',
+    )
+    newer = _create_feature(
+        language=language,
+        feature_type=feature_type,
+        name='Newer Feature',
+    )
+    now = timezone.now()
+    older_created = now - timedelta(days=3)
+    newer_created = now - timedelta(hours=1)
+    _set_timestamps(
+        older,
+        created=older_created,
+        modified=older_created,
+    )
+    _set_timestamps(
+        newer,
+        created=newer_created,
+        modified=newer_created,
+    )
+
+    queryset = FeatureFilterSet(
+        {'created__lte': (now - timedelta(days=1)).isoformat()},
+        queryset=Feature.objects.all(),
+    ).qs
+
+    assert list(queryset) == [older]

--- a/apps/api_v2/tests/test_filters/test_indicia_printers.py
+++ b/apps/api_v2/tests/test_filters/test_indicia_printers.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for the indicia printer filter set."""
+
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+
+from apps.api_v2.filters.indicia_printers import IndiciaPrinterFilterSet
+from apps.gcd.models import IndiciaPrinter, Printer
+from apps.stddata.models import Country
+
+
+@pytest.fixture
+def printer(db, country):
+    """Return a saved Printer tied to the shared country."""
+    return Printer.objects.create(
+        name='Test Printer',
+        year_began=1950,
+        notes='',
+        country=country,
+    )
+
+
+@pytest.fixture
+def other_country(db):
+    """Return a second country for indicia printer filter tests."""
+    obj, _ = Country.objects.get_or_create(
+        code='yy',
+        defaults={'name': 'Other Country'},
+    )
+    return obj
+
+
+def _create_indicia_printer(
+    *,
+    printer,
+    country,
+    name,
+    year_began=1950,
+    year_ended=None,
+):
+    """Create a minimal indicia printer row for filter tests."""
+    return IndiciaPrinter.objects.create(
+        name=name,
+        year_began=year_began,
+        year_ended=year_ended,
+        notes='',
+        parent=printer,
+        country=country,
+    )
+
+
+def _set_timestamps(obj, *, created, modified):
+    """Persist explicit created/modified timestamps for filter tests."""
+    IndiciaPrinter.objects.filter(pk=obj.pk).update(
+        created=created,
+        modified=modified,
+    )
+    obj.refresh_from_db()
+
+
+def test_indicia_printer_filter_matches_name_icontains(printer, country):
+    """The name filter uses case-insensitive containment."""
+    matching = _create_indicia_printer(
+        printer=printer,
+        country=country,
+        name='Quebecor Printing',
+    )
+    _create_indicia_printer(
+        printer=printer,
+        country=country,
+        name='World Color Press',
+    )
+
+    queryset = IndiciaPrinterFilterSet(
+        {'name': 'quebecor'},
+        queryset=IndiciaPrinter.objects.all(),
+    ).qs
+
+    assert list(queryset) == [matching]
+
+
+def test_indicia_printer_filter_matches_exact_fields(
+    printer,
+    country,
+    other_country,
+):
+    """Parent, country, and year filters narrow results correctly."""
+    other_parent = Printer.objects.create(
+        name='Other Printer',
+        year_began=1940,
+        notes='',
+        country=country,
+    )
+    matching = _create_indicia_printer(
+        printer=printer,
+        country=country,
+        name='Matching Plant',
+        year_began=1960,
+        year_ended=1980,
+    )
+    _create_indicia_printer(
+        printer=other_parent,
+        country=country,
+        name='Wrong Parent',
+        year_began=1960,
+        year_ended=1980,
+    )
+    _create_indicia_printer(
+        printer=printer,
+        country=other_country,
+        name='Wrong Country',
+        year_began=1960,
+        year_ended=1980,
+    )
+    _create_indicia_printer(
+        printer=printer,
+        country=country,
+        name='Wrong Year',
+        year_began=1961,
+        year_ended=1980,
+    )
+
+    queryset = IndiciaPrinterFilterSet(
+        {
+            'parent': str(printer.pk),
+            'country': country.code,
+            'year_began': '1960',
+            'year_ended': '1980',
+        },
+        queryset=IndiciaPrinter.objects.all(),
+    ).qs
+
+    assert list(queryset) == [matching]
+
+
+def test_indicia_printer_filter_matches_modified_range(printer, country):
+    """Modified range filters support delta-style sync queries."""
+    older = _create_indicia_printer(
+        printer=printer,
+        country=country,
+        name='Older Plant',
+    )
+    newer = _create_indicia_printer(
+        printer=printer,
+        country=country,
+        name='Newer Plant',
+    )
+    now = timezone.now()
+    _set_timestamps(
+        older,
+        created=now - timedelta(days=3),
+        modified=now - timedelta(days=2),
+    )
+    _set_timestamps(
+        newer,
+        created=now - timedelta(days=1),
+        modified=now - timedelta(hours=1),
+    )
+
+    queryset = IndiciaPrinterFilterSet(
+        {'modified__gt': (now - timedelta(days=1)).isoformat()},
+        queryset=IndiciaPrinter.objects.all(),
+    ).qs
+
+    assert list(queryset) == [newer]
+
+
+def test_indicia_printer_filter_matches_created_range(printer, country):
+    """Created range filters support bounded indicia printer queries."""
+    older = _create_indicia_printer(
+        printer=printer,
+        country=country,
+        name='Older Plant',
+    )
+    newer = _create_indicia_printer(
+        printer=printer,
+        country=country,
+        name='Newer Plant',
+    )
+    now = timezone.now()
+    older_created = now - timedelta(days=3)
+    newer_created = now - timedelta(hours=1)
+    _set_timestamps(
+        older,
+        created=older_created,
+        modified=older_created,
+    )
+    _set_timestamps(
+        newer,
+        created=newer_created,
+        modified=newer_created,
+    )
+
+    queryset = IndiciaPrinterFilterSet(
+        {'created__lte': (now - timedelta(days=1)).isoformat()},
+        queryset=IndiciaPrinter.objects.all(),
+    ).qs
+
+    assert list(queryset) == [older]

--- a/apps/api_v2/tests/test_filters/test_indicia_publishers.py
+++ b/apps/api_v2/tests/test_filters/test_indicia_publishers.py
@@ -1,0 +1,209 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for the indicia publisher filter set."""
+
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+
+from apps.api_v2.filters.indicia_publishers import (
+    IndiciaPublisherFilterSet,
+)
+from apps.gcd.models import IndiciaPublisher, Publisher
+from apps.stddata.models import Country
+
+
+@pytest.fixture
+def other_country(db):
+    """Return a second country for indicia publisher filter tests."""
+    obj, _ = Country.objects.get_or_create(
+        code='yy',
+        defaults={'name': 'Other Country'},
+    )
+    return obj
+
+
+def _create_indicia_publisher(
+    *,
+    publisher,
+    country,
+    name,
+    year_began=1950,
+    year_ended=None,
+    is_surrogate=False,
+):
+    """Create a minimal indicia publisher row for filter tests."""
+    return IndiciaPublisher.objects.create(
+        name=name,
+        year_began=year_began,
+        year_ended=year_ended,
+        notes='',
+        parent=publisher,
+        country=country,
+        is_surrogate=is_surrogate,
+    )
+
+
+def _set_timestamps(obj, *, created, modified):
+    """Persist explicit created/modified timestamps for filter tests."""
+    IndiciaPublisher.objects.filter(pk=obj.pk).update(
+        created=created,
+        modified=modified,
+    )
+    obj.refresh_from_db()
+
+
+def test_indicia_publisher_filter_matches_name_icontains(
+    publisher,
+    country,
+):
+    """The name filter uses case-insensitive containment."""
+    matching = _create_indicia_publisher(
+        publisher=publisher,
+        country=country,
+        name='Marvel Comics Group',
+    )
+    _create_indicia_publisher(
+        publisher=publisher,
+        country=country,
+        name='National Periodical Publications',
+    )
+
+    queryset = IndiciaPublisherFilterSet(
+        {'name': 'marvel comics'},
+        queryset=IndiciaPublisher.objects.all(),
+    ).qs
+
+    assert list(queryset) == [matching]
+
+
+def test_indicia_publisher_filter_matches_exact_fields(
+    publisher,
+    country,
+    other_country,
+):
+    """Parent, country, surrogate, and year filters narrow results."""
+    other_parent = Publisher.objects.create(
+        name='Other Publisher',
+        year_began=1940,
+        notes='',
+        country=country,
+    )
+    matching = _create_indicia_publisher(
+        publisher=publisher,
+        country=country,
+        name='Matching Imprint',
+        year_began=1960,
+        year_ended=1980,
+        is_surrogate=True,
+    )
+    _create_indicia_publisher(
+        publisher=other_parent,
+        country=country,
+        name='Wrong Parent',
+        year_began=1960,
+        year_ended=1980,
+        is_surrogate=True,
+    )
+    _create_indicia_publisher(
+        publisher=publisher,
+        country=other_country,
+        name='Wrong Country',
+        year_began=1960,
+        year_ended=1980,
+        is_surrogate=True,
+    )
+    _create_indicia_publisher(
+        publisher=publisher,
+        country=country,
+        name='Wrong Surrogate Flag',
+        year_began=1960,
+        year_ended=1980,
+    )
+
+    queryset = IndiciaPublisherFilterSet(
+        {
+            'parent': str(publisher.pk),
+            'country': country.code,
+            'is_surrogate': 'true',
+            'year_began': '1960',
+            'year_ended': '1980',
+        },
+        queryset=IndiciaPublisher.objects.all(),
+    ).qs
+
+    assert list(queryset) == [matching]
+
+
+def test_indicia_publisher_filter_matches_modified_range(
+    publisher,
+    country,
+):
+    """Modified range filters support delta-style sync queries."""
+    older = _create_indicia_publisher(
+        publisher=publisher,
+        country=country,
+        name='Older Imprint',
+    )
+    newer = _create_indicia_publisher(
+        publisher=publisher,
+        country=country,
+        name='Newer Imprint',
+    )
+    now = timezone.now()
+    _set_timestamps(
+        older,
+        created=now - timedelta(days=3),
+        modified=now - timedelta(days=2),
+    )
+    _set_timestamps(
+        newer,
+        created=now - timedelta(days=1),
+        modified=now - timedelta(hours=1),
+    )
+
+    queryset = IndiciaPublisherFilterSet(
+        {'modified__gt': (now - timedelta(days=1)).isoformat()},
+        queryset=IndiciaPublisher.objects.all(),
+    ).qs
+
+    assert list(queryset) == [newer]
+
+
+def test_indicia_publisher_filter_matches_created_range(
+    publisher,
+    country,
+):
+    """Created range filters support bounded indicia publisher queries."""
+    older = _create_indicia_publisher(
+        publisher=publisher,
+        country=country,
+        name='Older Imprint',
+    )
+    newer = _create_indicia_publisher(
+        publisher=publisher,
+        country=country,
+        name='Newer Imprint',
+    )
+    now = timezone.now()
+    older_created = now - timedelta(days=3)
+    newer_created = now - timedelta(hours=1)
+    _set_timestamps(
+        older,
+        created=older_created,
+        modified=older_created,
+    )
+    _set_timestamps(
+        newer,
+        created=newer_created,
+        modified=newer_created,
+    )
+
+    queryset = IndiciaPublisherFilterSet(
+        {'created__lte': (now - timedelta(days=1)).isoformat()},
+        queryset=IndiciaPublisher.objects.all(),
+    ).qs
+
+    assert list(queryset) == [older]

--- a/apps/api_v2/tests/test_filters/test_series_bonds.py
+++ b/apps/api_v2/tests/test_filters/test_series_bonds.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for the Series Bond filter set."""
+
+from datetime import timedelta
+
+from django.utils import timezone
+
+from apps.api_v2.filters.series_bonds import SeriesBondFilterSet
+from apps.gcd.models import Issue, Series, SeriesBond, SeriesBondType
+
+
+def _create_series(series, *, name, year_began):
+    """Create a Series sharing the fixture Series' reference data."""
+    return Series.objects.create(
+        name=name,
+        sort_name=name,
+        year_began=year_began,
+        publication_dates=f'{year_began} - present',
+        notes='',
+        tracking_notes='',
+        country=series.country,
+        language=series.language,
+        publisher=series.publisher,
+    )
+
+
+def _create_issue(series, *, number, sort_code):
+    """Create a minimal Issue for Series Bond filter tests."""
+    return Issue.objects.create(
+        number=number,
+        title='',
+        volume='',
+        isbn='',
+        valid_isbn='',
+        variant_name='',
+        barcode='',
+        publication_date='',
+        key_date='',
+        on_sale_date='',
+        sort_code=sort_code,
+        indicia_frequency='',
+        price='',
+        editing='',
+        notes='',
+        indicia_printer_sourced_by='',
+        series=series,
+    )
+
+
+def _create_bond_type(name, description):
+    """Create a Series Bond Type for filter tests."""
+    return SeriesBondType.objects.create(
+        name=name,
+        description=description,
+        notes='',
+    )
+
+
+def _create_bond(
+    origin,
+    target,
+    bond_type,
+    *,
+    origin_issue=None,
+    target_issue=None,
+):
+    """Create a Series Bond for filter tests."""
+    return SeriesBond.objects.create(
+        origin=origin,
+        origin_issue=origin_issue,
+        target=target,
+        target_issue=target_issue,
+        bond_type=bond_type,
+        notes='',
+    )
+
+
+def _set_timestamps(bond, *, created, modified):
+    """Persist explicit Series Bond timestamps for filter tests."""
+    SeriesBond.objects.filter(pk=bond.pk).update(
+        created=created,
+        modified=modified,
+    )
+    bond.refresh_from_db()
+
+
+def test_series_bond_filter_matches_relationship_ids(series, issue):
+    """Relationship filters combine using direct foreign-key ids."""
+    target = _create_series(series, name='Target Series', year_began=2000)
+    other_target = _create_series(
+        series,
+        name='Other Target Series',
+        year_began=2010,
+    )
+    target_issue = _create_issue(target, number='1', sort_code=1)
+    other_target_issue = _create_issue(
+        other_target,
+        number='1',
+        sort_code=1,
+    )
+    continues = _create_bond_type('continues', 'Continues at')
+    other_type = _create_bond_type('related', 'Related to')
+    matching = _create_bond(
+        series,
+        target,
+        continues,
+        origin_issue=issue,
+        target_issue=target_issue,
+    )
+    _create_bond(
+        series,
+        other_target,
+        other_type,
+        origin_issue=issue,
+        target_issue=other_target_issue,
+    )
+
+    queryset = SeriesBondFilterSet(
+        {
+            'origin': str(series.pk),
+            'origin_issue': str(issue.pk),
+            'target': str(target.pk),
+            'target_issue': str(target_issue.pk),
+            'bond_type': str(continues.pk),
+        },
+        queryset=SeriesBond.objects.all(),
+    ).qs
+
+    assert list(queryset) == [matching]
+
+
+def test_series_bond_filter_matches_modified_range(series):
+    """Modified ranges support delta-style Series Bond queries."""
+    target = _create_series(series, name='Target Series', year_began=2000)
+    bond_type = _create_bond_type('continues', 'Continues at')
+    older = _create_bond(series, target, bond_type)
+    newer = _create_bond(target, series, bond_type)
+    now = timezone.now()
+    _set_timestamps(
+        older,
+        created=now - timedelta(days=3),
+        modified=now - timedelta(days=2),
+    )
+    _set_timestamps(
+        newer,
+        created=now - timedelta(days=1),
+        modified=now - timedelta(hours=1),
+    )
+
+    queryset = SeriesBondFilterSet(
+        {'modified__gt': (now - timedelta(days=1)).isoformat()},
+        queryset=SeriesBond.objects.all(),
+    ).qs
+
+    assert list(queryset) == [newer]
+
+
+def test_series_bond_filter_matches_created_range(series):
+    """Created ranges support bounded Series Bond queries."""
+    target = _create_series(series, name='Target Series', year_began=2000)
+    bond_type = _create_bond_type('continues', 'Continues at')
+    older = _create_bond(series, target, bond_type)
+    newer = _create_bond(target, series, bond_type)
+    now = timezone.now()
+    older_created = now - timedelta(days=3)
+    newer_created = now - timedelta(hours=1)
+    _set_timestamps(
+        older,
+        created=older_created,
+        modified=older_created,
+    )
+    _set_timestamps(
+        newer,
+        created=newer_created,
+        modified=newer_created,
+    )
+
+    queryset = SeriesBondFilterSet(
+        {'created__lte': (now - timedelta(days=1)).isoformat()},
+        queryset=SeriesBond.objects.all(),
+    ).qs
+
+    assert list(queryset) == [older]

--- a/apps/api_v2/tests/test_migrations/test_series_bond_timestamps.py
+++ b/apps/api_v2/tests/test_migrations/test_series_bond_timestamps.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Migration tests for persistent Series Bond timestamps."""
+
+from datetime import datetime, timezone
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
+
+from apps.gcd.models import Series, SeriesBond, SeriesBondType
+from apps.oi.models import CTYPES, Changeset, SeriesBondRevision
+
+
+def _create_target_series(series):
+    """Create a target Series sharing the fixture reference data."""
+    return Series.objects.create(
+        name='Target Series',
+        sort_name='Target Series',
+        year_began=2000,
+        publication_dates='2000 - present',
+        notes='',
+        tracking_notes='',
+        country=series.country,
+        language=series.language,
+        publisher=series.publisher,
+    )
+
+
+def _create_revision(bond, user, *, state, name):
+    """Create a Series Bond revision in the requested changeset state."""
+    changeset = Changeset.objects.create(
+        state=state,
+        indexer=user,
+        change_type=CTYPES['series_bond'],
+    )
+    return SeriesBondRevision.objects.create(
+        changeset=changeset,
+        series_bond=bond,
+        origin=bond.origin,
+        target=bond.target,
+        bond_type=bond.bond_type,
+        notes=name,
+    )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_series_bond_timestamp_migration_uses_history_or_shared_baseline(
+    series,
+):
+    """Approved history wins while missing history receives one baseline."""
+    target = _create_target_series(series)
+    bond_type = SeriesBondType.objects.create(
+        name='continues',
+        description='Continues at',
+        notes='',
+    )
+    historical_bond = SeriesBond.objects.create(
+        origin=series,
+        target=target,
+        bond_type=bond_type,
+        notes='',
+    )
+    baseline_bond = SeriesBond.objects.create(
+        origin=target,
+        target=series,
+        bond_type=bond_type,
+        notes='',
+    )
+    user = get_user_model().objects.create_user(username='bond_migrator')
+    earliest = _create_revision(
+        historical_bond,
+        user,
+        state=5,
+        name='earliest',
+    )
+    latest = _create_revision(
+        historical_bond,
+        user,
+        state=5,
+        name='latest',
+    )
+    ignored = _create_revision(
+        historical_bond,
+        user,
+        state=1,
+        name='unapproved',
+    )
+    earliest_created = datetime(2010, 1, 1, tzinfo=timezone.utc)
+    earliest_modified = datetime(2010, 1, 2, tzinfo=timezone.utc)
+    latest_created = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    latest_modified = datetime(2020, 1, 2, tzinfo=timezone.utc)
+    ignored_created = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    SeriesBondRevision.objects.filter(pk=earliest.pk).update(
+        created=earliest_created,
+        modified=earliest_modified,
+    )
+    SeriesBondRevision.objects.filter(pk=latest.pk).update(
+        created=latest_created,
+        modified=latest_modified,
+    )
+    SeriesBondRevision.objects.filter(pk=ignored.pk).update(
+        created=ignored_created,
+        modified=ignored_created,
+    )
+
+    executor = MigrationExecutor(connection)
+    latest_targets = executor.loader.graph.leaf_nodes()
+    previous_targets = [
+        ('gcd', '0073_merge_api_v2_beta'),
+        ('oi', '0062_add_character_order'),
+    ]
+
+    try:
+        executor.migrate(previous_targets)
+        executor = MigrationExecutor(connection)
+        executor.migrate([('gcd', '0074_series_bond_timestamps')])
+        migrated_apps = executor.loader.project_state(
+            [('gcd', '0074_series_bond_timestamps')]
+        ).apps
+        migrated_bond = migrated_apps.get_model('gcd', 'SeriesBond')
+        historical = migrated_bond.objects.get(pk=historical_bond.pk)
+        baseline = migrated_bond.objects.get(pk=baseline_bond.pk)
+
+        assert historical.created == earliest_created
+        assert historical.modified == latest_modified
+        assert baseline.created == baseline.modified
+        assert baseline.created > ignored_created
+    finally:
+        executor = MigrationExecutor(connection)
+        executor.migrate(latest_targets)

--- a/apps/api_v2/tests/test_performance/test_awards.py
+++ b/apps/api_v2/tests/test_performance/test_awards.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Performance tests for Award and recipient endpoints."""
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+
+from apps.gcd.models import Award, Creator, ReceivedAward, Story, StoryType
+
+pytestmark = pytest.mark.django_db
+
+
+def _create_creator(name):
+    """Create a minimal Creator recipient."""
+    return Creator.objects.create(
+        gcd_official_name=name,
+        sort_name=name,
+        disambiguation='',
+        birth_province='',
+        birth_city='',
+        death_province='',
+        death_city='',
+        bio='',
+        notes='',
+    )
+
+
+def _create_story(issue, number):
+    """Create a minimal Story recipient."""
+    story_type, _ = StoryType.objects.get_or_create(
+        name='comic story',
+        defaults={'sort_code': 19},
+    )
+    return Story.objects.create(
+        title=f'Story {number}',
+        feature='',
+        sequence_number=number,
+        script='',
+        pencils='',
+        inks='',
+        colors='',
+        letters='',
+        editing='',
+        job_number='',
+        genre='',
+        characters='',
+        synopsis='',
+        first_line='',
+        reprint_notes='',
+        notes='',
+        issue=issue,
+        type=story_type,
+    )
+
+
+def _create_received_award(*, award, recipient, number):
+    """Create a received Award for a generic recipient."""
+    return ReceivedAward.objects.create(
+        content_type=ContentType.objects.get_for_model(recipient),
+        object_id=recipient.pk,
+        award=award,
+        award_name=f'Best Work {number}',
+        award_year=1980 + number,
+        notes='',
+    )
+
+
+def test_award_list_and_detail_query_counts(api_client):
+    """Award roots stay on fixed list and detail query budgets."""
+    award = Award.objects.create(name='Eisner Awards', notes='')
+
+    with CaptureQueriesContext(connection) as list_context:
+        list_response = api_client.get(reverse('award-list'))
+    with CaptureQueriesContext(connection) as detail_context:
+        detail_response = api_client.get(
+            reverse('award-detail', kwargs={'pk': award.pk}),
+        )
+
+    assert list_response.status_code == 200
+    assert detail_response.status_code == 200
+    assert len(list_context) == 3
+    assert len(detail_context) == 2
+
+
+def test_award_recipient_query_count_is_row_count_independent(
+    api_client,
+    issue,
+    series,
+):
+    """Generic recipients use one bounded query per supported model type."""
+    award = Award.objects.create(name='Eisner Awards', notes='')
+    recipients = []
+    for number in range(1, 3):
+        recipients.extend(
+            (
+                _create_creator(f'Creator {number}'),
+                issue,
+                series,
+                _create_story(issue, number),
+            ),
+        )
+    for number, recipient in enumerate(recipients, start=1):
+        _create_received_award(
+            award=award,
+            recipient=recipient,
+            number=number,
+        )
+
+    with CaptureQueriesContext(connection) as context:
+        response = api_client.get(
+            reverse('award-recipients', kwargs={'pk': award.pk}),
+        )
+
+    assert response.status_code == 200
+    assert response.data['count'] == 8
+    assert len(response.data['results']) == 8
+    assert {row['recipient_type'] for row in response.data['results']} == {
+        'creator',
+        'issue',
+        'series',
+        'story',
+    }
+    assert len(context) == 8

--- a/apps/api_v2/tests/test_performance/test_brand_groups.py
+++ b/apps/api_v2/tests/test_performance/test_brand_groups.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Performance tests for brand group endpoints."""
+
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+
+from apps.gcd.models import Brand, BrandGroup
+
+
+def _create_brand_group(*, publisher, name):
+    """Create a minimal brand group row for performance tests."""
+    return BrandGroup.objects.create(
+        name=name,
+        year_began=1950,
+        notes='',
+        parent=publisher,
+    )
+
+
+def _create_emblems(brand_group, *, count):
+    """Attach ``count`` active emblems to ``brand_group``."""
+    for number in range(count):
+        emblem = Brand.objects.create(
+            name=f'Emblem {number:03d}',
+            year_began=1950,
+            notes='',
+        )
+        emblem.group.add(brand_group)
+
+
+def test_brand_group_list_query_count(api_client, publisher):
+    """The brand group list stays on its query budget."""
+    _create_brand_group(publisher=publisher, name='Alpha Group')
+    _create_brand_group(publisher=publisher, name='Beta Group')
+
+    with CaptureQueriesContext(connection) as context:
+        response = api_client.get(reverse('brand-group-list'))
+
+    assert response.status_code == 200
+    assert len(context) == 3
+
+
+def test_brand_group_detail_query_count_is_emblem_count_independent(
+    api_client,
+    publisher,
+):
+    """Detail serialization uses one bounded emblem prefetch query."""
+    brand_group = _create_brand_group(
+        publisher=publisher,
+        name='Detail Group',
+    )
+    brand_group.keywords.add('detail')
+    _create_emblems(brand_group, count=8)
+
+    with CaptureQueriesContext(connection) as context:
+        response = api_client.get(
+            reverse(
+                'brand-group-detail',
+                kwargs={'pk': brand_group.pk},
+            ),
+        )
+
+    assert response.status_code == 200
+    assert len(response.data['emblems']) == 8
+    assert len(context) == 4

--- a/apps/api_v2/tests/test_performance/test_brands.py
+++ b/apps/api_v2/tests/test_performance/test_brands.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Performance tests for Brand endpoints."""
+
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+
+from apps.gcd.models import Brand, BrandGroup, BrandUse
+
+
+def _create_brand(*, name):
+    """Create a minimal Brand row for performance tests."""
+    return Brand.objects.create(
+        name=name,
+        year_began=1950,
+        notes='',
+    )
+
+
+def _create_relationships(brand, *, publisher, count):
+    """Attach ``count`` groups and Brand Uses to ``brand``."""
+    for number in range(count):
+        group = BrandGroup.objects.create(
+            name=f'Group {number:03d}',
+            year_began=1950,
+            notes='',
+            parent=publisher,
+        )
+        brand.group.add(group)
+        BrandUse.objects.create(
+            emblem=brand,
+            publisher=publisher,
+            year_began=1950 + number,
+            notes='',
+        )
+
+
+def test_brand_list_query_count(api_client, db):
+    """The Brand list stays on its query budget."""
+    _create_brand(name='Alpha Brand')
+    _create_brand(name='Beta Brand')
+
+    with CaptureQueriesContext(connection) as context:
+        response = api_client.get(reverse('brand-list'))
+
+    assert response.status_code == 200
+    assert len(context) == 3
+
+
+def test_brand_detail_query_count_is_relationship_count_independent(
+    api_client,
+    publisher,
+):
+    """Detail serialization uses bounded relationship prefetches."""
+    brand = _create_brand(name='Detail Brand')
+    brand.keywords.add('detail')
+    _create_relationships(brand, publisher=publisher, count=8)
+
+    with CaptureQueriesContext(connection) as context:
+        response = api_client.get(
+            reverse('brand-detail', kwargs={'pk': brand.pk}),
+        )
+
+    assert response.status_code == 200
+    assert len(response.data['groups']) == 8
+    assert len(response.data['uses']) == 8
+    assert len(context) == 5

--- a/apps/api_v2/tests/test_performance/test_features.py
+++ b/apps/api_v2/tests/test_performance/test_features.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Performance tests for Feature endpoints."""
+
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+
+from apps.gcd.models import (
+    Feature,
+    FeatureLogo,
+    FeatureRelation,
+    FeatureRelationType,
+    FeatureType,
+)
+
+
+def _create_feature(*, language, feature_type, name):
+    """Create a minimal Feature row for performance tests."""
+    return Feature.objects.create(
+        name=name,
+        sort_name=name,
+        disambiguation='',
+        genre='superhero',
+        language=language,
+        feature_type=feature_type,
+        year_first_published=1950,
+        notes='',
+    )
+
+
+def _create_relationships(feature, *, language, feature_type, count):
+    """Attach logos plus incoming and outgoing relations to ``feature``."""
+    relation_type = FeatureRelationType.objects.create(
+        name='alternate_version',
+        description='is an alternate version of',
+        reverse_description='has alternate version',
+    )
+    for number in range(count):
+        logo = FeatureLogo.objects.create(
+            name=f'Logo {number:03d}',
+            sort_name=f'Logo {number:03d}',
+            notes='',
+        )
+        logo.feature.add(feature)
+        outgoing_target = _create_feature(
+            language=language,
+            feature_type=feature_type,
+            name=f'Outgoing {number:03d}',
+        )
+        incoming_source = _create_feature(
+            language=language,
+            feature_type=feature_type,
+            name=f'Incoming {number:03d}',
+        )
+        FeatureRelation.objects.create(
+            from_feature=feature,
+            to_feature=outgoing_target,
+            relation_type=relation_type,
+            notes='',
+        )
+        FeatureRelation.objects.create(
+            from_feature=incoming_source,
+            to_feature=feature,
+            relation_type=relation_type,
+            notes='',
+        )
+
+
+def test_feature_list_query_count(api_client, language):
+    """The Feature list stays on its query budget."""
+    feature_type = FeatureType.objects.create(name='Character')
+    _create_feature(
+        language=language,
+        feature_type=feature_type,
+        name='Alpha Feature',
+    )
+    _create_feature(
+        language=language,
+        feature_type=feature_type,
+        name='Beta Feature',
+    )
+
+    with CaptureQueriesContext(connection) as context:
+        response = api_client.get(reverse('feature-list'))
+
+    assert response.status_code == 200
+    assert len(context) == 3
+
+
+def test_feature_detail_query_count_is_relationship_count_independent(
+    api_client,
+    language,
+):
+    """Detail serialization uses bounded logo and relation prefetches."""
+    feature_type = FeatureType.objects.create(name='Character')
+    feature = _create_feature(
+        language=language,
+        feature_type=feature_type,
+        name='Detail Feature',
+    )
+    feature.keywords.add('detail')
+    _create_relationships(
+        feature,
+        language=language,
+        feature_type=feature_type,
+        count=8,
+    )
+
+    with CaptureQueriesContext(connection) as context:
+        response = api_client.get(
+            reverse('feature-detail', kwargs={'pk': feature.pk}),
+        )
+
+    assert response.status_code == 200
+    assert len(response.data['logos']) == 8
+    assert len(response.data['relations']) == 16
+    assert len(context) == 6

--- a/apps/api_v2/tests/test_performance/test_indicia_printers.py
+++ b/apps/api_v2/tests/test_performance/test_indicia_printers.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Performance tests for indicia printer endpoints."""
+
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+
+from apps.gcd.models import IndiciaPrinter, Printer
+
+
+def _create_printer(country):
+    """Create a parent Printer for performance tests."""
+    return Printer.objects.create(
+        name='Test Printer',
+        year_began=1950,
+        notes='',
+        country=country,
+    )
+
+
+def _create_indicia_printer(*, printer, country, name):
+    """Create a minimal indicia printer row for performance tests."""
+    return IndiciaPrinter.objects.create(
+        name=name,
+        year_began=1950,
+        notes='',
+        parent=printer,
+        country=country,
+    )
+
+
+def test_indicia_printer_list_query_count(api_client, country):
+    """The indicia printer list stays on its query budget."""
+    printer = _create_printer(country)
+    _create_indicia_printer(
+        printer=printer,
+        country=country,
+        name='Alpha Plant',
+    )
+    _create_indicia_printer(
+        printer=printer,
+        country=country,
+        name='Beta Plant',
+    )
+
+    with CaptureQueriesContext(connection) as context:
+        response = api_client.get(reverse('indicia-printer-list'))
+
+    assert response.status_code == 200
+    assert len(context) == 3
+
+
+def test_indicia_printer_detail_query_count(api_client, country):
+    """The detail endpoint avoids lazy-loading regressions."""
+    printer = _create_printer(country)
+    indicia_printer = _create_indicia_printer(
+        printer=printer,
+        country=country,
+        name='Detail Plant',
+    )
+    indicia_printer.keywords.add('detail')
+
+    with CaptureQueriesContext(connection) as context:
+        response = api_client.get(
+            reverse(
+                'indicia-printer-detail',
+                kwargs={'pk': indicia_printer.pk},
+            ),
+        )
+
+    assert response.status_code == 200
+    assert len(context) == 3

--- a/apps/api_v2/tests/test_performance/test_indicia_publishers.py
+++ b/apps/api_v2/tests/test_performance/test_indicia_publishers.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Performance tests for indicia publisher endpoints."""
+
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+
+from apps.gcd.models import IndiciaPublisher
+
+
+def _create_indicia_publisher(*, publisher, country, name):
+    """Create a minimal indicia publisher row for performance tests."""
+    return IndiciaPublisher.objects.create(
+        name=name,
+        year_began=1950,
+        notes='',
+        parent=publisher,
+        country=country,
+    )
+
+
+def test_indicia_publisher_list_query_count(
+    api_client,
+    publisher,
+    country,
+):
+    """The indicia publisher list stays on its query budget."""
+    _create_indicia_publisher(
+        publisher=publisher,
+        country=country,
+        name='Alpha Imprint',
+    )
+    _create_indicia_publisher(
+        publisher=publisher,
+        country=country,
+        name='Beta Imprint',
+    )
+
+    with CaptureQueriesContext(connection) as context:
+        response = api_client.get(reverse('indicia-publisher-list'))
+
+    assert response.status_code == 200
+    assert len(context) == 3
+
+
+def test_indicia_publisher_detail_query_count(
+    api_client,
+    publisher,
+    country,
+):
+    """The detail endpoint avoids lazy-loading regressions."""
+    indicia_publisher = _create_indicia_publisher(
+        publisher=publisher,
+        country=country,
+        name='Detail Imprint',
+    )
+    indicia_publisher.keywords.add('detail')
+
+    with CaptureQueriesContext(connection) as context:
+        response = api_client.get(
+            reverse(
+                'indicia-publisher-detail',
+                kwargs={'pk': indicia_publisher.pk},
+            ),
+        )
+
+    assert response.status_code == 200
+    assert len(context) == 3

--- a/apps/api_v2/tests/test_performance/test_series_bonds.py
+++ b/apps/api_v2/tests/test_performance/test_series_bonds.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Performance tests for Series Bond endpoints."""
+
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+
+from apps.gcd.models import Series, SeriesBond, SeriesBondType
+
+
+def _create_target_series(series, *, name, year_began):
+    """Create a Series sharing the fixture Series' reference data."""
+    return Series.objects.create(
+        name=name,
+        sort_name=name,
+        year_began=year_began,
+        publication_dates=f'{year_began} - present',
+        notes='',
+        tracking_notes='',
+        country=series.country,
+        language=series.language,
+        publisher=series.publisher,
+    )
+
+
+def _create_bond(origin, target, bond_type, *, origin_issue=None):
+    """Create a Series Bond for performance tests."""
+    return SeriesBond.objects.create(
+        origin=origin,
+        origin_issue=origin_issue,
+        target=target,
+        target_issue=None,
+        bond_type=bond_type,
+        notes='',
+    )
+
+
+def test_series_bond_list_query_count(api_client, series, issue):
+    """The Series Bond list stays on the expected query budget."""
+    target = _create_target_series(
+        series,
+        name='Target Series',
+        year_began=2000,
+    )
+    other_target = _create_target_series(
+        series,
+        name='Other Target Series',
+        year_began=2010,
+    )
+    bond_type = SeriesBondType.objects.create(
+        name='continues',
+        description='Continues at',
+        notes='',
+    )
+    _create_bond(series, target, bond_type, origin_issue=issue)
+    _create_bond(series, other_target, bond_type, origin_issue=issue)
+
+    with CaptureQueriesContext(connection) as context:
+        response = api_client.get(reverse('series-bond-list'))
+
+    assert response.status_code == 200
+    assert len(context) == 3
+
+
+def test_series_bond_detail_query_count(api_client, series, issue):
+    """The Series Bond detail avoids lazy-loading regressions."""
+    target = _create_target_series(
+        series,
+        name='Target Series',
+        year_began=2000,
+    )
+    bond_type = SeriesBondType.objects.create(
+        name='continues',
+        description='Continues at',
+        notes='',
+    )
+    bond = _create_bond(
+        series,
+        target,
+        bond_type,
+        origin_issue=issue,
+    )
+
+    with CaptureQueriesContext(connection) as context:
+        response = api_client.get(
+            reverse('series-bond-detail', kwargs={'pk': bond.pk}),
+        )
+
+    assert response.status_code == 200
+    assert len(context) == 2

--- a/apps/api_v2/tests/test_serializers/test_awards.py
+++ b/apps/api_v2/tests/test_serializers/test_awards.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for Award and received-award serializers."""
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+
+from apps.api_v2.serializers.awards import (
+    AwardListSerializer,
+    AwardRecipientSerializer,
+    AwardSerializer,
+)
+from apps.gcd.models import Award, Creator, ReceivedAward, Story, StoryType
+
+pytestmark = pytest.mark.django_db
+
+
+def _create_creator(name):
+    """Create a minimal Creator recipient."""
+    return Creator.objects.create(
+        gcd_official_name=name,
+        sort_name=f'{name}, Sort',
+        disambiguation='Test identity',
+        birth_province='',
+        birth_city='',
+        death_province='',
+        death_city='',
+        bio='',
+        notes='',
+    )
+
+
+def _create_story(issue):
+    """Create a minimal Story recipient."""
+    story_type, _ = StoryType.objects.get_or_create(
+        name='comic story',
+        defaults={'sort_code': 19},
+    )
+    return Story.objects.create(
+        title='Award-Winning Story',
+        feature='The Feature',
+        sequence_number=1,
+        script='',
+        pencils='',
+        inks='',
+        colors='',
+        letters='',
+        editing='',
+        job_number='',
+        genre='',
+        characters='',
+        synopsis='',
+        first_line='',
+        reprint_notes='',
+        notes='',
+        issue=issue,
+        type=story_type,
+    )
+
+
+def _create_received_award(
+    *,
+    award,
+    recipient,
+    name,
+    year,
+    uncertain=False,
+):
+    """Create a received Award for a generic recipient."""
+    return ReceivedAward.objects.create(
+        content_type=ContentType.objects.get_for_model(recipient),
+        object_id=recipient.pk,
+        award=award,
+        award_name=name,
+        award_year=year,
+        award_year_uncertain=uncertain,
+        notes=f'{name} notes',
+    )
+
+
+def test_award_serializers_expose_trimmed_list_and_full_detail_contracts():
+    """Award list rows stay trimmed while detail adds notes."""
+    award = Award.objects.create(
+        name='Eisner Awards',
+        notes='Award notes',
+    )
+
+    list_data = AwardListSerializer(award).data
+    detail_data = AwardSerializer(award).data
+
+    assert set(list_data) == {
+        'id',
+        'name',
+        'created',
+        'modified',
+    }
+    assert list_data['name'] == 'Eisner Awards'
+    assert set(detail_data) == set(list_data) | {'notes'}
+    assert detail_data['notes'] == 'Award notes'
+
+
+def test_award_recipient_serializer_emits_typed_recipient_objects(
+    issue,
+    series,
+):
+    """Each supported generic recipient has a useful stable shape."""
+    award = Award.objects.create(name='Eisner Awards', notes='')
+    creator = _create_creator('Jane Doe')
+    story = _create_story(issue)
+    rows = [
+        _create_received_award(
+            award=award,
+            recipient=creator,
+            name='Best Creator',
+            year=1989,
+        ),
+        _create_received_award(
+            award=award,
+            recipient=issue,
+            name='Best Issue',
+            year=1990,
+        ),
+        _create_received_award(
+            award=award,
+            recipient=series,
+            name='Best Series',
+            year=1991,
+        ),
+        _create_received_award(
+            award=award,
+            recipient=story,
+            name='Best Story',
+            year=1992,
+            uncertain=True,
+        ),
+    ]
+
+    data = AwardRecipientSerializer(rows, many=True).data
+
+    assert set(data[0]) == {
+        'id',
+        'recipient_type',
+        'recipient',
+        'name',
+        'year',
+        'year_uncertain',
+        'notes',
+        'created',
+        'modified',
+    }
+    assert data[0]['recipient_type'] == 'creator'
+    assert data[0]['recipient'] == {
+        'id': creator.pk,
+        'name': 'Jane Doe',
+        'sort_name': 'Jane Doe, Sort',
+        'disambiguation': 'Test identity',
+    }
+    assert data[1]['recipient_type'] == 'issue'
+    assert data[1]['recipient'] == {
+        'id': issue.pk,
+        'number': '1',
+        'volume': '',
+        'title': '',
+        'series': {
+            'id': series.pk,
+            'name': 'Test Series',
+        },
+    }
+    assert data[2]['recipient_type'] == 'series'
+    assert data[2]['recipient'] == {
+        'id': series.pk,
+        'name': 'Test Series',
+        'sort_name': 'Test Series',
+        'year_began': 1990,
+    }
+    assert data[3]['recipient_type'] == 'story'
+    assert data[3]['recipient'] == {
+        'id': story.pk,
+        'title': 'Award-Winning Story',
+        'feature': 'The Feature',
+        'sequence_number': 1,
+        'issue': {
+            'id': issue.pk,
+            'number': '1',
+            'series': {
+                'id': series.pk,
+                'name': 'Test Series',
+            },
+        },
+    }
+    assert data[3]['name'] == 'Best Story'
+    assert data[3]['year'] == 1992
+    assert data[3]['year_uncertain'] is True
+    assert data[3]['notes'] == 'Best Story notes'

--- a/apps/api_v2/tests/test_serializers/test_brand_groups.py
+++ b/apps/api_v2/tests/test_serializers/test_brand_groups.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for the brand group serializers."""
+
+from apps.api_v2.serializers.brand_groups import (
+    BrandGroupListSerializer,
+    BrandGroupSerializer,
+)
+from apps.gcd.models import Brand, BrandGroup
+
+
+def _create_brand_group(publisher):
+    """Create a brand group with complete contract data."""
+    brand_group = BrandGroup.objects.create(
+        name='Test Brand Group',
+        year_began=1960,
+        year_ended=1980,
+        year_began_uncertain=True,
+        year_ended_uncertain=False,
+        year_overall_began=1955,
+        year_overall_ended=1985,
+        year_overall_began_uncertain=False,
+        year_overall_ended_uncertain=True,
+        notes='Brand group notes',
+        url='https://example.com/brand-group/',
+        parent=publisher,
+        issue_count=42,
+    )
+    brand_group.keywords.add('alpha', 'beta')
+    return brand_group
+
+
+def _create_emblem(
+    brand_group,
+    *,
+    name,
+    generic=False,
+    deleted=False,
+    year_began=1970,
+    year_ended=None,
+):
+    """Create a Brand attached as an emblem of ``brand_group``."""
+    emblem = Brand.objects.create(
+        name=name,
+        generic=generic,
+        year_began=year_began,
+        year_ended=year_ended,
+        notes='',
+        deleted=deleted,
+    )
+    emblem.group.add(brand_group)
+    return emblem
+
+
+def test_brand_group_list_serializer_exposes_trimmed_contract(publisher):
+    """List rows include identity, browse, count, and timestamp fields."""
+    brand_group = _create_brand_group(publisher)
+
+    data = BrandGroupListSerializer(brand_group).data
+
+    assert set(data) == {
+        'id',
+        'name',
+        'parent',
+        'year_began',
+        'year_ended',
+        'issue_count',
+        'created',
+        'modified',
+    }
+    assert data['id'] == brand_group.pk
+    assert data['name'] == brand_group.name
+    assert data['parent'] == {
+        'id': publisher.pk,
+        'name': publisher.name,
+    }
+    assert data['year_began'] == 1960
+    assert data['year_ended'] == 1980
+    assert data['issue_count'] == 42
+    assert data['created']
+    assert data['modified']
+
+
+def test_brand_group_detail_serializer_exposes_full_contract(publisher):
+    """Detail rows add descriptive fields and ordered active emblems."""
+    brand_group = _create_brand_group(publisher)
+    beta = _create_emblem(
+        brand_group,
+        name='Beta Emblem',
+        generic=True,
+        year_began=1975,
+        year_ended=1980,
+    )
+    alpha = _create_emblem(
+        brand_group,
+        name='Alpha Emblem',
+        year_began=1965,
+        year_ended=1970,
+    )
+    _create_emblem(
+        brand_group,
+        name='Deleted Emblem',
+        deleted=True,
+    )
+
+    data = BrandGroupSerializer(brand_group).data
+
+    assert set(data) == {
+        'id',
+        'name',
+        'parent',
+        'year_began',
+        'year_ended',
+        'issue_count',
+        'created',
+        'modified',
+        'year_began_uncertain',
+        'year_ended_uncertain',
+        'year_overall_began',
+        'year_overall_ended',
+        'year_overall_began_uncertain',
+        'year_overall_ended_uncertain',
+        'url',
+        'notes',
+        'keywords',
+        'emblems',
+    }
+    assert data['parent'] == {
+        'id': publisher.pk,
+        'name': publisher.name,
+    }
+    assert data['year_began_uncertain'] is True
+    assert data['year_ended_uncertain'] is False
+    assert data['year_overall_began'] == 1955
+    assert data['year_overall_ended'] == 1985
+    assert data['year_overall_began_uncertain'] is False
+    assert data['year_overall_ended_uncertain'] is True
+    assert data['url'] == 'https://example.com/brand-group/'
+    assert data['notes'] == 'Brand group notes'
+    assert set(data['keywords']) == {'alpha', 'beta'}
+    assert data['emblems'] == [
+        {
+            'id': alpha.pk,
+            'name': 'Alpha Emblem',
+            'generic': False,
+            'year_began': 1965,
+            'year_ended': 1970,
+        },
+        {
+            'id': beta.pk,
+            'name': 'Beta Emblem',
+            'generic': True,
+            'year_began': 1975,
+            'year_ended': 1980,
+        },
+    ]

--- a/apps/api_v2/tests/test_serializers/test_brands.py
+++ b/apps/api_v2/tests/test_serializers/test_brands.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for the Brand serializers."""
+
+import pytest
+
+from apps.api_v2.serializers.brands import (
+    BrandListSerializer,
+    BrandSerializer,
+)
+from apps.gcd.models import Brand, BrandGroup, BrandUse, Publisher
+
+pytestmark = pytest.mark.django_db
+
+
+def _create_brand():
+    """Create a Brand with complete contract data."""
+    brand = Brand.objects.create(
+        name='Test Brand',
+        generic=True,
+        year_began=1960,
+        year_ended=1980,
+        year_began_uncertain=True,
+        year_ended_uncertain=False,
+        year_overall_began=1955,
+        year_overall_ended=1985,
+        year_overall_began_uncertain=False,
+        year_overall_ended_uncertain=True,
+        notes='Brand notes',
+        url='https://example.com/brand/',
+        issue_count=42,
+    )
+    brand.keywords.add('alpha', 'beta')
+    return brand
+
+
+def _create_brand_group(*, publisher, name, deleted=False):
+    """Create a Brand Group for nested relationship tests."""
+    return BrandGroup.objects.create(
+        name=name,
+        year_began=1950,
+        notes='',
+        parent=publisher,
+        deleted=deleted,
+    )
+
+
+def test_brand_list_serializer_exposes_trimmed_contract():
+    """List rows include identity, browse, count, and timestamp fields."""
+    brand = _create_brand()
+
+    data = BrandListSerializer(brand).data
+
+    assert set(data) == {
+        'id',
+        'name',
+        'generic',
+        'year_began',
+        'year_ended',
+        'issue_count',
+        'created',
+        'modified',
+    }
+    assert data['id'] == brand.pk
+    assert data['name'] == brand.name
+    assert data['generic'] is True
+    assert data['year_began'] == 1960
+    assert data['year_ended'] == 1980
+    assert data['issue_count'] == 42
+    assert data['created']
+    assert data['modified']
+
+
+def test_brand_detail_serializer_exposes_full_contract(
+    publisher,
+    country,
+):
+    """Detail rows add descriptive fields, groups, and Brand Uses."""
+    brand = _create_brand()
+    alpha_publisher = Publisher.objects.create(
+        name='Alpha Publisher',
+        year_began=1940,
+        notes='',
+        country=country,
+    )
+    deleted_publisher = Publisher.objects.create(
+        name='Deleted Publisher',
+        year_began=1940,
+        notes='',
+        country=country,
+        deleted=True,
+    )
+    alpha_group = _create_brand_group(
+        publisher=alpha_publisher,
+        name='Alpha Group',
+    )
+    beta_group = _create_brand_group(
+        publisher=publisher,
+        name='Beta Group',
+    )
+    deleted_group = _create_brand_group(
+        publisher=publisher,
+        name='Deleted Group',
+        deleted=True,
+    )
+    brand.group.add(beta_group, deleted_group, alpha_group)
+    alpha_use = BrandUse.objects.create(
+        emblem=brand,
+        publisher=alpha_publisher,
+        year_began=1970,
+        year_ended=1975,
+        year_began_uncertain=True,
+        year_ended_uncertain=False,
+        notes='Alpha use',
+    )
+    test_use = BrandUse.objects.create(
+        emblem=brand,
+        publisher=publisher,
+        year_began=1960,
+        year_ended=1965,
+        year_began_uncertain=False,
+        year_ended_uncertain=True,
+        notes='Test use',
+    )
+    BrandUse.objects.create(
+        emblem=brand,
+        publisher=deleted_publisher,
+        notes='Deleted publisher use',
+    )
+
+    data = BrandSerializer(brand).data
+
+    assert set(data) == {
+        'id',
+        'name',
+        'generic',
+        'year_began',
+        'year_ended',
+        'issue_count',
+        'created',
+        'modified',
+        'year_began_uncertain',
+        'year_ended_uncertain',
+        'year_overall_began',
+        'year_overall_ended',
+        'year_overall_began_uncertain',
+        'year_overall_ended_uncertain',
+        'url',
+        'notes',
+        'keywords',
+        'groups',
+        'uses',
+    }
+    assert data['year_began_uncertain'] is True
+    assert data['year_ended_uncertain'] is False
+    assert data['year_overall_began'] == 1955
+    assert data['year_overall_ended'] == 1985
+    assert data['year_overall_began_uncertain'] is False
+    assert data['year_overall_ended_uncertain'] is True
+    assert data['url'] == 'https://example.com/brand/'
+    assert data['notes'] == 'Brand notes'
+    assert set(data['keywords']) == {'alpha', 'beta'}
+    assert data['groups'] == [
+        {
+            'id': alpha_group.pk,
+            'name': 'Alpha Group',
+            'parent': {
+                'id': alpha_publisher.pk,
+                'name': 'Alpha Publisher',
+            },
+        },
+        {
+            'id': beta_group.pk,
+            'name': 'Beta Group',
+            'parent': {
+                'id': publisher.pk,
+                'name': publisher.name,
+            },
+        },
+    ]
+    assert [use['id'] for use in data['uses']] == [
+        alpha_use.pk,
+        test_use.pk,
+    ]
+    assert set(data['uses'][0]) == {
+        'id',
+        'publisher',
+        'year_began',
+        'year_ended',
+        'year_began_uncertain',
+        'year_ended_uncertain',
+        'notes',
+        'created',
+        'modified',
+    }
+    assert data['uses'][0]['publisher'] == {
+        'id': alpha_publisher.pk,
+        'name': 'Alpha Publisher',
+    }
+    assert data['uses'][0]['year_began'] == 1970
+    assert data['uses'][0]['year_ended'] == 1975
+    assert data['uses'][0]['year_began_uncertain'] is True
+    assert data['uses'][0]['year_ended_uncertain'] is False
+    assert data['uses'][0]['notes'] == 'Alpha use'
+    assert data['uses'][0]['created']
+    assert data['uses'][0]['modified']

--- a/apps/api_v2/tests/test_serializers/test_features.py
+++ b/apps/api_v2/tests/test_serializers/test_features.py
@@ -1,0 +1,259 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for the Feature serializers."""
+
+import pytest
+
+from apps.api_v2.serializers.features import (
+    FeatureListSerializer,
+    FeatureSerializer,
+)
+from apps.gcd.models import (
+    Feature,
+    FeatureLogo,
+    FeatureRelation,
+    FeatureRelationType,
+    FeatureType,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def _create_feature(
+    *,
+    language,
+    feature_type,
+    name,
+    sort_name=None,
+    deleted=False,
+):
+    """Create a Feature with complete root contract data."""
+    return Feature.objects.create(
+        name=name,
+        sort_name=sort_name or name,
+        disambiguation='Earth-Prime',
+        genre='Science Fiction; Superhero',
+        language=language,
+        feature_type=feature_type,
+        year_first_published=1960,
+        year_first_published_uncertain=True,
+        notes='Feature notes',
+        deleted=deleted,
+    )
+
+
+def _create_logo(
+    feature,
+    *,
+    name,
+    sort_name,
+    generic=False,
+    deleted=False,
+):
+    """Create a Feature Logo attached to ``feature``."""
+    logo = FeatureLogo.objects.create(
+        name=name,
+        sort_name=sort_name,
+        generic=generic,
+        year_began=1970,
+        year_ended=1980,
+        year_began_uncertain=True,
+        year_ended_uncertain=False,
+        notes='',
+        deleted=deleted,
+    )
+    logo.feature.add(feature)
+    return logo
+
+
+def test_feature_list_serializer_exposes_trimmed_contract(language):
+    """List rows include identity, classification, and timestamps."""
+    feature_type = FeatureType.objects.create(name='Character')
+    feature = _create_feature(
+        language=language,
+        feature_type=feature_type,
+        name='Test Feature',
+        sort_name='Feature, Test',
+    )
+
+    data = FeatureListSerializer(feature).data
+
+    assert set(data) == {
+        'id',
+        'name',
+        'sort_name',
+        'disambiguation',
+        'feature_type',
+        'language',
+        'genre',
+        'year_first_published',
+        'created',
+        'modified',
+    }
+    assert data['id'] == feature.pk
+    assert data['name'] == 'Test Feature'
+    assert data['sort_name'] == 'Feature, Test'
+    assert data['disambiguation'] == 'Earth-Prime'
+    assert data['feature_type'] == {
+        'id': feature_type.pk,
+        'name': 'Character',
+    }
+    assert data['language'] == language.code
+    assert data['genre'] == 'Science Fiction; Superhero'
+    assert data['year_first_published'] == 1960
+    assert data['created']
+    assert data['modified']
+
+
+def test_feature_detail_serializer_normalizes_active_relationships(language):
+    """Detail rows normalize active logos and both relation directions."""
+    character_type = FeatureType.objects.create(name='Character')
+    location_type = FeatureType.objects.create(name='Location')
+    relation_type = FeatureRelationType.objects.create(
+        name='alternate_version',
+        description='is an alternate version of',
+        reverse_description='has alternate version',
+    )
+    feature = _create_feature(
+        language=language,
+        feature_type=character_type,
+        name='Main Feature',
+    )
+    feature.keywords.add('alpha', 'beta')
+    beta_logo = _create_logo(
+        feature,
+        name='Beta Logo',
+        sort_name='Beta Logo',
+        generic=True,
+    )
+    alpha_logo = _create_logo(
+        feature,
+        name='Alpha Logo',
+        sort_name='Alpha Logo',
+    )
+    _create_logo(
+        feature,
+        name='Deleted Logo',
+        sort_name='Deleted Logo',
+        deleted=True,
+    )
+    outgoing_target = _create_feature(
+        language=language,
+        feature_type=location_type,
+        name='Outgoing Target',
+        sort_name='Target, Outgoing',
+    )
+    incoming_source = _create_feature(
+        language=language,
+        feature_type=character_type,
+        name='Incoming Source',
+        sort_name='Source, Incoming',
+    )
+    deleted_target = _create_feature(
+        language=language,
+        feature_type=location_type,
+        name='Deleted Target',
+        deleted=True,
+    )
+    outgoing = FeatureRelation.objects.create(
+        from_feature=feature,
+        to_feature=outgoing_target,
+        relation_type=relation_type,
+        notes='Outgoing notes',
+    )
+    incoming = FeatureRelation.objects.create(
+        from_feature=incoming_source,
+        to_feature=feature,
+        relation_type=relation_type,
+        notes='Incoming notes',
+    )
+    FeatureRelation.objects.create(
+        from_feature=feature,
+        to_feature=deleted_target,
+        relation_type=relation_type,
+        notes='Deleted target notes',
+    )
+
+    data = FeatureSerializer(feature).data
+
+    assert set(data) == {
+        'id',
+        'name',
+        'sort_name',
+        'disambiguation',
+        'feature_type',
+        'language',
+        'genre',
+        'year_first_published',
+        'created',
+        'modified',
+        'year_first_published_uncertain',
+        'notes',
+        'keywords',
+        'logos',
+        'relations',
+    }
+    assert data['year_first_published_uncertain'] is True
+    assert data['notes'] == 'Feature notes'
+    assert set(data['keywords']) == {'alpha', 'beta'}
+    assert data['logos'] == [
+        {
+            'id': alpha_logo.pk,
+            'name': 'Alpha Logo',
+            'generic': False,
+            'year_began': 1970,
+            'year_ended': 1980,
+            'year_began_uncertain': True,
+            'year_ended_uncertain': False,
+        },
+        {
+            'id': beta_logo.pk,
+            'name': 'Beta Logo',
+            'generic': True,
+            'year_began': 1970,
+            'year_ended': 1980,
+            'year_began_uncertain': True,
+            'year_ended_uncertain': False,
+        },
+    ]
+    assert data['relations'] == [
+        {
+            'id': outgoing.pk,
+            'direction': 'outgoing',
+            'relation_type': {
+                'id': relation_type.pk,
+                'name': 'alternate_version',
+                'description': 'is an alternate version of',
+            },
+            'feature': {
+                'id': outgoing_target.pk,
+                'name': 'Outgoing Target',
+                'disambiguation': 'Earth-Prime',
+                'feature_type': {
+                    'id': location_type.pk,
+                    'name': 'Location',
+                },
+            },
+            'notes': 'Outgoing notes',
+        },
+        {
+            'id': incoming.pk,
+            'direction': 'incoming',
+            'relation_type': {
+                'id': relation_type.pk,
+                'name': 'alternate_version',
+                'description': 'has alternate version',
+            },
+            'feature': {
+                'id': incoming_source.pk,
+                'name': 'Incoming Source',
+                'disambiguation': 'Earth-Prime',
+                'feature_type': {
+                    'id': character_type.pk,
+                    'name': 'Character',
+                },
+            },
+            'notes': 'Incoming notes',
+        },
+    ]

--- a/apps/api_v2/tests/test_serializers/test_indicia_printers.py
+++ b/apps/api_v2/tests/test_serializers/test_indicia_printers.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for the indicia printer serializers."""
+
+from apps.api_v2.serializers.indicia_printers import (
+    IndiciaPrinterListSerializer,
+    IndiciaPrinterSerializer,
+)
+from apps.gcd.models import IndiciaPrinter, Printer
+
+
+def _create_printer(country):
+    """Create a parent Printer for serializer tests."""
+    return Printer.objects.create(
+        name='Test Printer',
+        year_began=1950,
+        notes='',
+        country=country,
+    )
+
+
+def _create_indicia_printer(printer, country):
+    """Create an indicia printer with complete contract data."""
+    indicia_printer = IndiciaPrinter.objects.create(
+        name='Test Indicia Printer',
+        year_began=1960,
+        year_ended=1980,
+        year_began_uncertain=True,
+        year_ended_uncertain=False,
+        year_overall_began=1955,
+        year_overall_ended=1985,
+        year_overall_began_uncertain=False,
+        year_overall_ended_uncertain=True,
+        notes='Indicia printer notes',
+        url='https://example.com/indicia-printer/',
+        parent=printer,
+        country=country,
+        issue_count=42,
+    )
+    indicia_printer.keywords.add('alpha', 'beta')
+    return indicia_printer
+
+
+def test_indicia_printer_list_serializer_exposes_trimmed_contract(
+    country,
+):
+    """List rows include identity, browse, count, and timestamp fields."""
+    printer = _create_printer(country)
+    indicia_printer = _create_indicia_printer(printer, country)
+
+    data = IndiciaPrinterListSerializer(indicia_printer).data
+
+    assert set(data) == {
+        'id',
+        'name',
+        'parent',
+        'country',
+        'year_began',
+        'year_ended',
+        'issue_count',
+        'created',
+        'modified',
+    }
+    assert data['id'] == indicia_printer.pk
+    assert data['name'] == indicia_printer.name
+    assert data['parent'] == {
+        'id': printer.pk,
+        'name': printer.name,
+    }
+    assert data['country'] == country.code
+    assert data['year_began'] == 1960
+    assert data['year_ended'] == 1980
+    assert data['issue_count'] == 42
+    assert data['created']
+    assert data['modified']
+
+
+def test_indicia_printer_detail_serializer_exposes_full_contract(country):
+    """Detail rows add uncertainty, overall-year, and descriptive fields."""
+    printer = _create_printer(country)
+    indicia_printer = _create_indicia_printer(printer, country)
+
+    data = IndiciaPrinterSerializer(indicia_printer).data
+
+    assert set(data) == {
+        'id',
+        'name',
+        'parent',
+        'country',
+        'year_began',
+        'year_ended',
+        'issue_count',
+        'created',
+        'modified',
+        'year_began_uncertain',
+        'year_ended_uncertain',
+        'year_overall_began',
+        'year_overall_ended',
+        'year_overall_began_uncertain',
+        'year_overall_ended_uncertain',
+        'url',
+        'notes',
+        'keywords',
+    }
+    assert data['parent'] == {
+        'id': printer.pk,
+        'name': printer.name,
+    }
+    assert data['country'] == country.code
+    assert data['year_began_uncertain'] is True
+    assert data['year_ended_uncertain'] is False
+    assert data['year_overall_began'] == 1955
+    assert data['year_overall_ended'] == 1985
+    assert data['year_overall_began_uncertain'] is False
+    assert data['year_overall_ended_uncertain'] is True
+    assert data['url'] == 'https://example.com/indicia-printer/'
+    assert data['notes'] == 'Indicia printer notes'
+    assert set(data['keywords']) == {'alpha', 'beta'}

--- a/apps/api_v2/tests/test_serializers/test_indicia_publishers.py
+++ b/apps/api_v2/tests/test_serializers/test_indicia_publishers.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for the indicia publisher serializers."""
+
+from apps.api_v2.serializers.indicia_publishers import (
+    IndiciaPublisherListSerializer,
+    IndiciaPublisherSerializer,
+)
+from apps.gcd.models import IndiciaPublisher
+
+
+def _create_indicia_publisher(publisher, country):
+    """Create an indicia publisher with complete contract data."""
+    indicia_publisher = IndiciaPublisher.objects.create(
+        name='Test Indicia Publisher',
+        year_began=1960,
+        year_ended=1980,
+        year_began_uncertain=True,
+        year_ended_uncertain=False,
+        year_overall_began=1955,
+        year_overall_ended=1985,
+        year_overall_began_uncertain=False,
+        year_overall_ended_uncertain=True,
+        notes='Indicia publisher notes',
+        url='https://example.com/indicia-publisher/',
+        parent=publisher,
+        country=country,
+        is_surrogate=True,
+        issue_count=42,
+    )
+    indicia_publisher.keywords.add('alpha', 'beta')
+    return indicia_publisher
+
+
+def test_indicia_publisher_list_serializer_exposes_trimmed_contract(
+    publisher,
+    country,
+):
+    """List rows include identity, browse, count, and timestamp fields."""
+    indicia_publisher = _create_indicia_publisher(publisher, country)
+
+    data = IndiciaPublisherListSerializer(indicia_publisher).data
+
+    assert set(data) == {
+        'id',
+        'name',
+        'parent',
+        'country',
+        'is_surrogate',
+        'year_began',
+        'year_ended',
+        'issue_count',
+        'created',
+        'modified',
+    }
+    assert data['id'] == indicia_publisher.pk
+    assert data['name'] == indicia_publisher.name
+    assert data['parent'] == {
+        'id': publisher.pk,
+        'name': publisher.name,
+    }
+    assert data['country'] == country.code
+    assert data['is_surrogate'] is True
+    assert data['year_began'] == 1960
+    assert data['year_ended'] == 1980
+    assert data['issue_count'] == 42
+    assert data['created']
+    assert data['modified']
+
+
+def test_indicia_publisher_detail_serializer_exposes_full_contract(
+    publisher,
+    country,
+):
+    """Detail rows add uncertainty, overall-year, and descriptive fields."""
+    indicia_publisher = _create_indicia_publisher(publisher, country)
+
+    data = IndiciaPublisherSerializer(indicia_publisher).data
+
+    assert set(data) == {
+        'id',
+        'name',
+        'parent',
+        'country',
+        'is_surrogate',
+        'year_began',
+        'year_ended',
+        'issue_count',
+        'created',
+        'modified',
+        'year_began_uncertain',
+        'year_ended_uncertain',
+        'year_overall_began',
+        'year_overall_ended',
+        'year_overall_began_uncertain',
+        'year_overall_ended_uncertain',
+        'url',
+        'notes',
+        'keywords',
+    }
+    assert data['parent'] == {
+        'id': publisher.pk,
+        'name': publisher.name,
+    }
+    assert data['country'] == country.code
+    assert data['year_began_uncertain'] is True
+    assert data['year_ended_uncertain'] is False
+    assert data['year_overall_began'] == 1955
+    assert data['year_overall_ended'] == 1985
+    assert data['year_overall_began_uncertain'] is False
+    assert data['year_overall_ended_uncertain'] is True
+    assert data['url'] == 'https://example.com/indicia-publisher/'
+    assert data['notes'] == 'Indicia publisher notes'
+    assert set(data['keywords']) == {'alpha', 'beta'}

--- a/apps/api_v2/tests/test_serializers/test_series_bonds.py
+++ b/apps/api_v2/tests/test_serializers/test_series_bonds.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for the Series Bond serializers."""
+
+from datetime import timedelta
+
+from django.utils import timezone
+
+from apps.api_v2.serializers.series_bonds import (
+    SeriesBondListSerializer,
+    SeriesBondSerializer,
+)
+from apps.gcd.models import Issue, Series, SeriesBond, SeriesBondType
+
+
+def _create_series(series, *, name, year_began):
+    """Create a Series sharing the fixture Series' reference data."""
+    return Series.objects.create(
+        name=name,
+        sort_name=name,
+        year_began=year_began,
+        publication_dates=f'{year_began} - present',
+        notes='',
+        tracking_notes='',
+        country=series.country,
+        language=series.language,
+        publisher=series.publisher,
+    )
+
+
+def _create_issue(series, *, number, sort_code):
+    """Create a minimal Issue for Series Bond serializer tests."""
+    return Issue.objects.create(
+        number=number,
+        title='',
+        volume='',
+        isbn='',
+        valid_isbn='',
+        variant_name='',
+        barcode='',
+        publication_date='',
+        key_date='',
+        on_sale_date='',
+        sort_code=sort_code,
+        indicia_frequency='',
+        price='',
+        editing='',
+        notes='',
+        indicia_printer_sourced_by='',
+        series=series,
+    )
+
+
+def _create_bond(series, issue, *, include_issues=True):
+    """Create a complete Series Bond serializer fixture."""
+    target = _create_series(series, name='Target Series', year_began=2000)
+    target_issue = _create_issue(target, number='1', sort_code=1)
+    bond_type = SeriesBondType.objects.create(
+        name='continues',
+        description='Continues at',
+        notes='',
+    )
+    bond = SeriesBond.objects.create(
+        origin=series,
+        origin_issue=issue if include_issues else None,
+        target=target,
+        target_issue=target_issue if include_issues else None,
+        bond_type=bond_type,
+        notes='The numbering continues in the target Series.',
+    )
+    return bond, target, target_issue, bond_type
+
+
+def test_series_bond_list_serializer_exposes_trimmed_contract(series, issue):
+    """List rows include useful references and persistent timestamps."""
+    bond, target, target_issue, bond_type = _create_bond(series, issue)
+
+    data = SeriesBondListSerializer(bond).data
+
+    assert set(data) == {
+        'id',
+        'origin',
+        'origin_issue',
+        'target',
+        'target_issue',
+        'bond_type',
+        'created',
+        'modified',
+    }
+    assert data['origin'] == {
+        'id': series.pk,
+        'name': 'Test Series',
+        'year_began': 1990,
+    }
+    assert data['origin_issue'] == {
+        'id': issue.pk,
+        'descriptor': issue.issue_descriptor,
+    }
+    assert data['target'] == {
+        'id': target.pk,
+        'name': 'Target Series',
+        'year_began': 2000,
+    }
+    assert data['target_issue'] == {
+        'id': target_issue.pk,
+        'descriptor': target_issue.issue_descriptor,
+    }
+    assert data['bond_type'] == {
+        'id': bond_type.pk,
+        'name': 'continues',
+        'description': 'Continues at',
+    }
+    assert data['created']
+    assert data['modified']
+    assert 'notes' not in data
+    assert 'reserved' not in data
+
+
+def test_series_bond_detail_serializer_adds_notes_and_handles_null_issues(
+    series,
+    issue,
+):
+    """Detail rows add notes and preserve nullable Issue references."""
+    bond, _target, _target_issue, _bond_type = _create_bond(
+        series,
+        issue,
+        include_issues=False,
+    )
+
+    data = SeriesBondSerializer(bond).data
+
+    assert set(data) == {
+        'id',
+        'origin',
+        'origin_issue',
+        'target',
+        'target_issue',
+        'bond_type',
+        'created',
+        'modified',
+        'notes',
+    }
+    assert data['origin_issue'] is None
+    assert data['target_issue'] is None
+    assert data['notes'] == 'The numbering continues in the target Series.'
+    assert 'reserved' not in data
+
+
+def test_series_bond_save_updates_persistent_modified_timestamp(series):
+    """Saving an existing Series Bond advances its stored timestamp."""
+    bond, _target, _target_issue, _bond_type = _create_bond(
+        series,
+        None,
+        include_issues=False,
+    )
+    old_modified = timezone.now() - timedelta(days=1)
+    SeriesBond.objects.filter(pk=bond.pk).update(modified=old_modified)
+    bond.refresh_from_db()
+    bond.notes = 'Updated notes.'
+
+    bond.save()
+    bond.refresh_from_db()
+
+    assert bond.modified > old_modified

--- a/apps/api_v2/tests/test_url_dispatch.py
+++ b/apps/api_v2/tests/test_url_dispatch.py
@@ -112,6 +112,7 @@ SPRINT_3_ROUTE_SPECS = (
 )
 SPRINT_4_ROUTE_SPECS = (
     ('brand-group-list', '/api/v2/brand-groups/'),
+    ('brand-list', '/api/v2/brands/'),
     ('indicia-publisher-list', '/api/v2/indicia-publishers/'),
     ('indicia-printer-list', '/api/v2/indicia-printers/'),
 )
@@ -354,6 +355,8 @@ def test_schema_includes_sprint_4_routes_on_www_surface(
     assert _schema_paths(response) >= {
         '/api/v2/brand-groups/',
         '/api/v2/brand-groups/{id}/',
+        '/api/v2/brands/',
+        '/api/v2/brands/{id}/',
         '/api/v2/indicia-publishers/',
         '/api/v2/indicia-publishers/{id}/',
         '/api/v2/indicia-printers/',
@@ -427,6 +430,8 @@ def test_schema_excludes_sprint_4_routes_on_my_surface(
         {
             '/api/v2/brand-groups/',
             '/api/v2/brand-groups/{id}/',
+            '/api/v2/brands/',
+            '/api/v2/brands/{id}/',
             '/api/v2/indicia-publishers/',
             '/api/v2/indicia-publishers/{id}/',
             '/api/v2/indicia-printers/',

--- a/apps/api_v2/tests/test_url_dispatch.py
+++ b/apps/api_v2/tests/test_url_dispatch.py
@@ -111,6 +111,7 @@ SPRINT_3_ROUTE_SPECS = (
     ('story-arc-list', '/api/v2/story-arcs/'),
 )
 SPRINT_4_ROUTE_SPECS = (
+    ('award-list', '/api/v2/awards/'),
     ('brand-group-list', '/api/v2/brand-groups/'),
     ('brand-list', '/api/v2/brands/'),
     ('feature-list', '/api/v2/features/'),
@@ -354,6 +355,9 @@ def test_schema_includes_sprint_4_routes_on_www_surface(
 
     assert response.status_code == 200
     assert _schema_paths(response) >= {
+        '/api/v2/awards/',
+        '/api/v2/awards/{id}/',
+        '/api/v2/awards/{id}/recipients/',
         '/api/v2/brand-groups/',
         '/api/v2/brand-groups/{id}/',
         '/api/v2/brands/',
@@ -364,6 +368,42 @@ def test_schema_includes_sprint_4_routes_on_www_surface(
         '/api/v2/indicia-publishers/{id}/',
         '/api/v2/indicia-printers/',
         '/api/v2/indicia-printers/{id}/',
+    }
+
+
+@pytest.mark.django_db
+@override_settings(MYCOMICS=False)
+def test_award_recipient_schema_describes_paginated_typed_objects(
+    client,
+    restore_v2_urlconf,
+):
+    """The Award recipient action documents its page and object variants."""
+    _reload_v2_urlconf()
+
+    response = client.get('/api/v2/schema/', {'format': 'json'})
+
+    assert response.status_code == 200
+    schema = json.loads(response.content)
+    response_schema = schema['paths']['/api/v2/awards/{id}/recipients/'][
+        'get'
+    ]['responses']['200']['content']['application/json']['schema']
+    components = schema['components']['schemas']
+    recipient_schema = components['AwardRecipient']['properties']['recipient']
+
+    assert response_schema == {
+        '$ref': '#/components/schemas/PaginatedAwardRecipientList',
+    }
+    assert recipient_schema['allOf'] == [
+        {'$ref': '#/components/schemas/AwardRecipientReference'},
+    ]
+    assert recipient_schema['readOnly'] is True
+    assert {
+        item['$ref'] for item in components['AwardRecipientReference']['oneOf']
+    } == {
+        '#/components/schemas/AwardCreatorRecipientReference',
+        '#/components/schemas/AwardIssueRecipientReference',
+        '#/components/schemas/AwardSeriesRecipientReference',
+        '#/components/schemas/AwardStoryRecipientReference',
     }
 
 
@@ -431,6 +471,9 @@ def test_schema_excludes_sprint_4_routes_on_my_surface(
     assert response.status_code == 200
     assert _schema_paths(response).isdisjoint(
         {
+            '/api/v2/awards/',
+            '/api/v2/awards/{id}/',
+            '/api/v2/awards/{id}/recipients/',
             '/api/v2/brand-groups/',
             '/api/v2/brand-groups/{id}/',
             '/api/v2/brands/',

--- a/apps/api_v2/tests/test_url_dispatch.py
+++ b/apps/api_v2/tests/test_url_dispatch.py
@@ -112,6 +112,7 @@ SPRINT_3_ROUTE_SPECS = (
 )
 SPRINT_4_ROUTE_SPECS = (
     ('indicia-publisher-list', '/api/v2/indicia-publishers/'),
+    ('indicia-printer-list', '/api/v2/indicia-printers/'),
 )
 
 
@@ -352,6 +353,8 @@ def test_schema_includes_sprint_4_routes_on_www_surface(
     assert _schema_paths(response) >= {
         '/api/v2/indicia-publishers/',
         '/api/v2/indicia-publishers/{id}/',
+        '/api/v2/indicia-printers/',
+        '/api/v2/indicia-printers/{id}/',
     }
 
 
@@ -421,5 +424,7 @@ def test_schema_excludes_sprint_4_routes_on_my_surface(
         {
             '/api/v2/indicia-publishers/',
             '/api/v2/indicia-publishers/{id}/',
+            '/api/v2/indicia-printers/',
+            '/api/v2/indicia-printers/{id}/',
         },
     )

--- a/apps/api_v2/tests/test_url_dispatch.py
+++ b/apps/api_v2/tests/test_url_dispatch.py
@@ -110,6 +110,9 @@ SPRINT_3_ROUTE_SPECS = (
     ('reprint-list', '/api/v2/reprints/'),
     ('story-arc-list', '/api/v2/story-arcs/'),
 )
+SPRINT_4_ROUTE_SPECS = (
+    ('indicia-publisher-list', '/api/v2/indicia-publishers/'),
+)
 
 
 def _schema_paths(response):
@@ -232,6 +235,26 @@ def test_sprint_3_routes_stay_absent_on_my_surface(restore_v2_urlconf):
             reverse(route_name)
 
 
+@override_settings(MYCOMICS=False)
+def test_sprint_4_routes_resolve_on_www_surface(restore_v2_urlconf):
+    """Sprint 4 routes resolve on the public-data surface."""
+    _reload_v2_urlconf()
+
+    for route_name, expected_path in SPRINT_4_ROUTE_SPECS:
+        assert reverse(route_name) == expected_path
+        _assert_v2_api_policy(resolve(expected_path).func.cls)
+
+
+@override_settings(MYCOMICS=True)
+def test_sprint_4_routes_stay_absent_on_my_surface(restore_v2_urlconf):
+    """Sprint 4 routes are not mounted on the my surface."""
+    _reload_v2_urlconf()
+
+    for route_name, _expected_path in SPRINT_4_ROUTE_SPECS:
+        with pytest.raises(NoReverseMatch):
+            reverse(route_name)
+
+
 @pytest.mark.django_db
 @override_settings(MYCOMICS=False)
 def test_schema_and_docs_load_on_www_surface(client, restore_v2_urlconf):
@@ -315,6 +338,24 @@ def test_schema_includes_sprint_3_routes_on_www_surface(
 
 
 @pytest.mark.django_db
+@override_settings(MYCOMICS=False)
+def test_schema_includes_sprint_4_routes_on_www_surface(
+    client,
+    restore_v2_urlconf,
+):
+    """The public schema documents implemented Sprint 4 routes."""
+    _reload_v2_urlconf()
+
+    response = client.get('/api/v2/schema/', {'format': 'json'})
+
+    assert response.status_code == 200
+    assert _schema_paths(response) >= {
+        '/api/v2/indicia-publishers/',
+        '/api/v2/indicia-publishers/{id}/',
+    }
+
+
+@pytest.mark.django_db
 @override_settings(MYCOMICS=True)
 def test_schema_excludes_sprint_2_public_routes_on_my_surface(
     client,
@@ -360,5 +401,25 @@ def test_schema_excludes_sprint_3_routes_on_my_surface(
             '/api/v2/reprints/{id}/',
             '/api/v2/story-arcs/',
             '/api/v2/story-arcs/{id}/',
+        },
+    )
+
+
+@pytest.mark.django_db
+@override_settings(MYCOMICS=True)
+def test_schema_excludes_sprint_4_routes_on_my_surface(
+    client,
+    restore_v2_urlconf,
+):
+    """The my schema omits implemented Sprint 4 routes."""
+    _reload_v2_urlconf()
+
+    response = client.get('/api/v2/schema/', {'format': 'json'})
+
+    assert response.status_code == 200
+    assert _schema_paths(response).isdisjoint(
+        {
+            '/api/v2/indicia-publishers/',
+            '/api/v2/indicia-publishers/{id}/',
         },
     )

--- a/apps/api_v2/tests/test_url_dispatch.py
+++ b/apps/api_v2/tests/test_url_dispatch.py
@@ -111,6 +111,7 @@ SPRINT_3_ROUTE_SPECS = (
     ('story-arc-list', '/api/v2/story-arcs/'),
 )
 SPRINT_4_ROUTE_SPECS = (
+    ('brand-group-list', '/api/v2/brand-groups/'),
     ('indicia-publisher-list', '/api/v2/indicia-publishers/'),
     ('indicia-printer-list', '/api/v2/indicia-printers/'),
 )
@@ -351,6 +352,8 @@ def test_schema_includes_sprint_4_routes_on_www_surface(
 
     assert response.status_code == 200
     assert _schema_paths(response) >= {
+        '/api/v2/brand-groups/',
+        '/api/v2/brand-groups/{id}/',
         '/api/v2/indicia-publishers/',
         '/api/v2/indicia-publishers/{id}/',
         '/api/v2/indicia-printers/',
@@ -422,6 +425,8 @@ def test_schema_excludes_sprint_4_routes_on_my_surface(
     assert response.status_code == 200
     assert _schema_paths(response).isdisjoint(
         {
+            '/api/v2/brand-groups/',
+            '/api/v2/brand-groups/{id}/',
             '/api/v2/indicia-publishers/',
             '/api/v2/indicia-publishers/{id}/',
             '/api/v2/indicia-printers/',

--- a/apps/api_v2/tests/test_url_dispatch.py
+++ b/apps/api_v2/tests/test_url_dispatch.py
@@ -113,6 +113,7 @@ SPRINT_3_ROUTE_SPECS = (
 SPRINT_4_ROUTE_SPECS = (
     ('brand-group-list', '/api/v2/brand-groups/'),
     ('brand-list', '/api/v2/brands/'),
+    ('feature-list', '/api/v2/features/'),
     ('indicia-publisher-list', '/api/v2/indicia-publishers/'),
     ('indicia-printer-list', '/api/v2/indicia-printers/'),
 )
@@ -357,6 +358,8 @@ def test_schema_includes_sprint_4_routes_on_www_surface(
         '/api/v2/brand-groups/{id}/',
         '/api/v2/brands/',
         '/api/v2/brands/{id}/',
+        '/api/v2/features/',
+        '/api/v2/features/{id}/',
         '/api/v2/indicia-publishers/',
         '/api/v2/indicia-publishers/{id}/',
         '/api/v2/indicia-printers/',
@@ -432,6 +435,8 @@ def test_schema_excludes_sprint_4_routes_on_my_surface(
             '/api/v2/brand-groups/{id}/',
             '/api/v2/brands/',
             '/api/v2/brands/{id}/',
+            '/api/v2/features/',
+            '/api/v2/features/{id}/',
             '/api/v2/indicia-publishers/',
             '/api/v2/indicia-publishers/{id}/',
             '/api/v2/indicia-printers/',

--- a/apps/api_v2/tests/test_url_dispatch.py
+++ b/apps/api_v2/tests/test_url_dispatch.py
@@ -117,6 +117,7 @@ SPRINT_4_ROUTE_SPECS = (
     ('feature-list', '/api/v2/features/'),
     ('indicia-publisher-list', '/api/v2/indicia-publishers/'),
     ('indicia-printer-list', '/api/v2/indicia-printers/'),
+    ('series-bond-list', '/api/v2/series-bonds/'),
 )
 
 
@@ -368,7 +369,35 @@ def test_schema_includes_sprint_4_routes_on_www_surface(
         '/api/v2/indicia-publishers/{id}/',
         '/api/v2/indicia-printers/',
         '/api/v2/indicia-printers/{id}/',
+        '/api/v2/series-bonds/',
+        '/api/v2/series-bonds/{id}/',
     }
+
+
+@pytest.mark.django_db
+@override_settings(MYCOMICS=False)
+def test_series_bond_schema_documents_legacy_timestamp_baseline(
+    client,
+    restore_v2_urlconf,
+):
+    """Series Bond timestamps explain the legacy-row backfill policy."""
+    _reload_v2_urlconf()
+
+    response = client.get('/api/v2/schema/', {'format': 'json'})
+
+    assert response.status_code == 200
+    schema = json.loads(response.content)
+    properties = schema['components']['schemas']['SeriesBondList'][
+        'properties'
+    ]
+    assert (
+        'migration-time timestamp-tracking baseline'
+        in properties['created']['description']
+    )
+    assert (
+        'migration-time timestamp-tracking baseline'
+        in properties['modified']['description']
+    )
 
 
 @pytest.mark.django_db
@@ -484,5 +513,7 @@ def test_schema_excludes_sprint_4_routes_on_my_surface(
             '/api/v2/indicia-publishers/{id}/',
             '/api/v2/indicia-printers/',
             '/api/v2/indicia-printers/{id}/',
+            '/api/v2/series-bonds/',
+            '/api/v2/series-bonds/{id}/',
         },
     )

--- a/apps/api_v2/tests/test_views/test_awards.py
+++ b/apps/api_v2/tests/test_views/test_awards.py
@@ -1,0 +1,249 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for Award and paginated recipient endpoints."""
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
+
+from apps.gcd.models import Award, Creator, ReceivedAward
+
+pytestmark = pytest.mark.django_db
+
+
+def _create_creator(name, *, deleted=False):
+    """Create a minimal Creator recipient."""
+    return Creator.objects.create(
+        gcd_official_name=name,
+        sort_name=name,
+        disambiguation='',
+        birth_province='',
+        birth_city='',
+        death_province='',
+        death_city='',
+        bio='',
+        notes='',
+        deleted=deleted,
+    )
+
+
+def _create_received_award(
+    *,
+    award,
+    recipient,
+    name='Best Work',
+    year=1989,
+    deleted=False,
+):
+    """Create a received Award for a generic recipient."""
+    return ReceivedAward.objects.create(
+        content_type=ContentType.objects.get_for_model(recipient),
+        object_id=recipient.pk,
+        award=award,
+        award_name=name,
+        award_year=year,
+        notes='',
+        deleted=deleted,
+    )
+
+
+def test_award_list_and_detail_return_expected_contract(api_client):
+    """Award routes are anonymous, paginated, and list/detail aware."""
+    award = Award.objects.create(
+        name='Eisner Awards',
+        notes='Award notes',
+    )
+
+    list_response = api_client.get(reverse('award-list'))
+    detail_response = api_client.get(
+        reverse('award-detail', kwargs={'pk': award.pk}),
+    )
+
+    assert list_response.status_code == 200
+    assert list_response.data['count'] == 1
+    assert list_response.data['results'][0]['id'] == award.pk
+    assert 'notes' not in list_response.data['results'][0]
+    assert detail_response.status_code == 200
+    assert detail_response.data['id'] == award.pk
+    assert detail_response.data['notes'] == 'Award notes'
+    assert 'recipients' not in detail_response.data
+
+
+def test_award_list_applies_name_filter(api_client):
+    """Award list query parameters use the public filter contract."""
+    matching = Award.objects.create(name='Eisner Awards', notes='')
+    Award.objects.create(name='Harvey Awards', notes='')
+
+    response = api_client.get(reverse('award-list'), {'name': 'eisner'})
+
+    assert response.status_code == 200
+    assert response.data['count'] == 1
+    assert response.data['results'][0]['id'] == matching.pk
+
+
+def test_award_endpoints_hide_soft_deleted_awards(api_client):
+    """Soft-deleted Awards disappear from list and detail routes."""
+    Award.objects.create(name='Visible Award', notes='')
+    deleted = Award.objects.create(
+        name='Deleted Award',
+        notes='',
+        deleted=True,
+    )
+
+    list_response = api_client.get(reverse('award-list'))
+    detail_response = api_client.get(
+        reverse('award-detail', kwargs={'pk': deleted.pk}),
+    )
+
+    assert list_response.status_code == 200
+    assert list_response.data['count'] == 1
+    assert detail_response.status_code == 404
+
+
+def test_award_recipients_are_paginated_and_hide_deleted_rows(api_client):
+    """The recipient action returns a standard page of active rows."""
+    award = Award.objects.create(name='Eisner Awards', notes='')
+    creator = _create_creator('Jane Doe')
+    first = _create_received_award(
+        award=award,
+        recipient=creator,
+        name='Best Creator',
+        year=1989,
+    )
+    _create_received_award(
+        award=award,
+        recipient=creator,
+        name='Best Writer',
+        year=1990,
+    )
+    _create_received_award(
+        award=award,
+        recipient=creator,
+        name='Deleted Award',
+        year=1991,
+        deleted=True,
+    )
+    _create_received_award(
+        award=award,
+        recipient=_create_creator('Deleted Creator', deleted=True),
+        name='Deleted Recipient',
+        year=1992,
+    )
+
+    response = api_client.get(
+        reverse('award-recipients', kwargs={'pk': award.pk}),
+        {'page_size': 1},
+    )
+
+    assert response.status_code == 200
+    assert response.data['count'] == 2
+    assert response.data['next'] is not None
+    assert response.data['previous'] is None
+    assert len(response.data['results']) == 1
+    assert response.data['results'][0]['id'] == first.pk
+    assert response.data['results'][0]['recipient_type'] == 'creator'
+    assert response.data['results'][0]['recipient']['id'] == creator.pk
+
+
+def test_award_recipients_apply_type_and_year_filters(api_client, issue):
+    """Recipient filters combine type and exact Award year."""
+    award = Award.objects.create(name='Eisner Awards', notes='')
+    creator = _create_creator('Jane Doe')
+    matching = _create_received_award(
+        award=award,
+        recipient=creator,
+        name='Best Creator',
+        year=1989,
+    )
+    _create_received_award(
+        award=award,
+        recipient=creator,
+        name='Wrong Year',
+        year=1990,
+    )
+    _create_received_award(
+        award=award,
+        recipient=issue,
+        name='Wrong Type',
+        year=1989,
+    )
+
+    response = api_client.get(
+        reverse('award-recipients', kwargs={'pk': award.pk}),
+        {
+            'recipient_type': 'creator',
+            'award_year': '1989',
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.data['count'] == 1
+    assert response.data['results'][0]['id'] == matching.pk
+
+
+def test_award_recipients_reject_unknown_recipient_type(api_client):
+    """Unsupported recipient types return a filter validation error."""
+    award = Award.objects.create(name='Eisner Awards', notes='')
+
+    response = api_client.get(
+        reverse('award-recipients', kwargs={'pk': award.pk}),
+        {'recipient_type': 'publisher'},
+    )
+
+    assert response.status_code == 400
+
+
+def test_award_and_recipient_routes_support_conditional_requests(api_client):
+    """Award roots and recipient pages expose independent validators."""
+    award = Award.objects.create(name='Eisner Awards', notes='')
+    recipient = _create_received_award(
+        award=award,
+        recipient=_create_creator('Jane Doe'),
+    )
+
+    list_response = api_client.get(reverse('award-list'))
+    recipient_response = api_client.get(
+        reverse('award-recipients', kwargs={'pk': award.pk}),
+    )
+
+    assert list_response.status_code == 200
+    assert 'ETag' in list_response
+    assert 'Last-Modified' in list_response
+    assert recipient_response.status_code == 200
+    assert recipient_response.data['results'][0]['id'] == recipient.pk
+    assert 'ETag' in recipient_response
+    assert 'Last-Modified' in recipient_response
+
+    cached_list = api_client.get(
+        reverse('award-list'),
+        HTTP_IF_NONE_MATCH=list_response['ETag'],
+    )
+    cached_recipients = api_client.get(
+        reverse('award-recipients', kwargs={'pk': award.pk}),
+        HTTP_IF_NONE_MATCH=recipient_response['ETag'],
+    )
+
+    assert cached_list.status_code == 304
+    assert cached_recipients.status_code == 304
+
+
+def test_empty_award_recipient_page_supports_etag(api_client):
+    """Awards without recipients still expose a stable page validator."""
+    award = Award.objects.create(name='Empty Award', notes='')
+
+    response = api_client.get(
+        reverse('award-recipients', kwargs={'pk': award.pk}),
+    )
+
+    assert response.status_code == 200
+    assert response.data['count'] == 0
+    assert response.data['results'] == []
+    assert 'ETag' in response
+
+    cached_response = api_client.get(
+        reverse('award-recipients', kwargs={'pk': award.pk}),
+        HTTP_IF_NONE_MATCH=response['ETag'],
+    )
+
+    assert cached_response.status_code == 304

--- a/apps/api_v2/tests/test_views/test_awards.py
+++ b/apps/api_v2/tests/test_views/test_awards.py
@@ -7,6 +7,7 @@ import pytest
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 
+from apps.api_v2.serializers.awards import AwardRecipientSerializer
 from apps.gcd.models import Award, Creator, ReceivedAward
 
 pytestmark = pytest.mark.django_db
@@ -144,6 +145,36 @@ def test_award_recipients_are_paginated_and_hide_deleted_rows(api_client):
     assert response.data['results'][0]['id'] == first.pk
     assert response.data['results'][0]['recipient_type'] == 'creator'
     assert response.data['results'][0]['recipient']['id'] == creator.pk
+
+
+def test_award_recipient_serializer_receives_view_context(
+    api_client,
+    monkeypatch,
+):
+    """The recipient action uses DRF's context-aware serializer factory."""
+    award = Award.objects.create(name='Eisner Awards', notes='')
+    _create_received_award(
+        award=award,
+        recipient=_create_creator('Jane Doe'),
+    )
+    original = AwardRecipientSerializer.to_representation
+
+    def assert_view_context(serializer, instance):
+        assert 'request' in serializer.context
+        assert 'view' in serializer.context
+        return original(serializer, instance)
+
+    monkeypatch.setattr(
+        AwardRecipientSerializer,
+        'to_representation',
+        assert_view_context,
+    )
+
+    response = api_client.get(
+        reverse('award-recipients', kwargs={'pk': award.pk}),
+    )
+
+    assert response.status_code == 200
 
 
 def test_award_recipients_apply_type_and_year_filters(api_client, issue):

--- a/apps/api_v2/tests/test_views/test_brand_groups.py
+++ b/apps/api_v2/tests/test_views/test_brand_groups.py
@@ -1,0 +1,245 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for the brand group v2 endpoints."""
+
+from django.urls import reverse
+
+from apps.gcd.models import Brand, BrandGroup, Publisher
+
+
+def _create_brand_group(
+    *,
+    publisher,
+    name='Test Brand Group',
+    year_began=1960,
+    year_ended=None,
+    deleted=False,
+):
+    """Create a minimal brand group row for view tests."""
+    return BrandGroup.objects.create(
+        name=name,
+        year_began=year_began,
+        year_ended=year_ended,
+        notes='',
+        parent=publisher,
+        deleted=deleted,
+    )
+
+
+def _create_emblem(
+    brand_group,
+    *,
+    name,
+    generic=False,
+    deleted=False,
+):
+    """Create a Brand attached as an emblem of ``brand_group``."""
+    emblem = Brand.objects.create(
+        name=name,
+        generic=generic,
+        year_began=1970,
+        notes='',
+        deleted=deleted,
+    )
+    emblem.group.add(brand_group)
+    return emblem
+
+
+def test_brand_group_list_returns_paginated_results(
+    api_client,
+    publisher,
+):
+    """The list endpoint is anonymous, paginated, and trimmed."""
+    brand_group = _create_brand_group(publisher=publisher)
+
+    response = api_client.get(reverse('brand-group-list'))
+
+    assert response.status_code == 200
+    assert response.data['count'] == 1
+    assert response.data['next'] is None
+    assert response.data['previous'] is None
+    assert len(response.data['results']) == 1
+    result = response.data['results'][0]
+    assert result['id'] == brand_group.pk
+    assert result['parent'] == {
+        'id': publisher.pk,
+        'name': publisher.name,
+    }
+    assert 'notes' not in result
+    assert 'keywords' not in result
+    assert 'emblems' not in result
+
+
+def test_brand_group_detail_returns_expected_payload(
+    authenticated_client,
+    publisher,
+):
+    """The detail endpoint returns descriptive fields and active emblems."""
+    brand_group = _create_brand_group(publisher=publisher)
+    brand_group.year_began_uncertain = True
+    brand_group.year_overall_began = 1955
+    brand_group.year_overall_ended = 1985
+    brand_group.year_overall_ended_uncertain = True
+    brand_group.url = 'https://example.com/group/'
+    brand_group.notes = 'Detail notes'
+    brand_group.issue_count = 21
+    brand_group.save()
+    brand_group.keywords.add('alpha', 'beta')
+    beta = _create_emblem(
+        brand_group,
+        name='Beta Emblem',
+        generic=True,
+    )
+    alpha = _create_emblem(brand_group, name='Alpha Emblem')
+    _create_emblem(
+        brand_group,
+        name='Deleted Emblem',
+        deleted=True,
+    )
+
+    response = authenticated_client.get(
+        reverse(
+            'brand-group-detail',
+            kwargs={'pk': brand_group.pk},
+        ),
+    )
+
+    assert response.status_code == 200
+    assert response.data['id'] == brand_group.pk
+    assert response.data['parent'] == {
+        'id': publisher.pk,
+        'name': publisher.name,
+    }
+    assert response.data['year_began_uncertain'] is True
+    assert response.data['year_overall_began'] == 1955
+    assert response.data['year_overall_ended'] == 1985
+    assert response.data['year_overall_ended_uncertain'] is True
+    assert response.data['url'] == 'https://example.com/group/'
+    assert response.data['notes'] == 'Detail notes'
+    assert response.data['issue_count'] == 21
+    assert set(response.data['keywords']) == {'alpha', 'beta'}
+    assert [emblem['id'] for emblem in response.data['emblems']] == [
+        alpha.pk,
+        beta.pk,
+    ]
+
+
+def test_brand_group_list_applies_filter_query_params(
+    authenticated_client,
+    publisher,
+    country,
+):
+    """The list endpoint applies the complete filter contract."""
+    other_parent = Publisher.objects.create(
+        name='Other Publisher',
+        year_began=1940,
+        notes='',
+        country=country,
+    )
+    matching = _create_brand_group(
+        publisher=publisher,
+        name='Marvel Comics Group',
+        year_began=1960,
+        year_ended=1980,
+    )
+    _create_brand_group(
+        publisher=other_parent,
+        name='Different Group',
+        year_began=1940,
+    )
+
+    response = authenticated_client.get(
+        reverse('brand-group-list'),
+        {
+            'name': 'marvel',
+            'parent': str(publisher.pk),
+            'year_began': '1960',
+            'year_ended': '1980',
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.data['count'] == 1
+    assert response.data['results'][0]['id'] == matching.pk
+
+
+def test_brand_group_endpoints_hide_soft_deleted_records(
+    api_client,
+    publisher,
+):
+    """Soft-deleted rows disappear from list and detail responses."""
+    visible = _create_brand_group(
+        publisher=publisher,
+        name='Visible Group',
+    )
+    deleted = _create_brand_group(
+        publisher=publisher,
+        name='Deleted Group',
+        deleted=True,
+    )
+
+    list_response = api_client.get(reverse('brand-group-list'))
+    detail_response = api_client.get(
+        reverse(
+            'brand-group-detail',
+            kwargs={'pk': deleted.pk},
+        ),
+    )
+
+    assert list_response.status_code == 200
+    assert list_response.data['count'] == 1
+    assert list_response.data['results'][0]['id'] == visible.pk
+    assert detail_response.status_code == 404
+
+
+def test_brand_group_list_returns_304_for_if_modified_since(
+    authenticated_client,
+    publisher,
+):
+    """List responses support Last-Modified cache validation."""
+    _create_brand_group(publisher=publisher)
+
+    response = authenticated_client.get(reverse('brand-group-list'))
+
+    assert response.status_code == 200
+    assert 'Last-Modified' in response
+    assert 'ETag' in response
+
+    cached_response = authenticated_client.get(
+        reverse('brand-group-list'),
+        HTTP_IF_MODIFIED_SINCE=response['Last-Modified'],
+    )
+
+    assert cached_response.status_code == 304
+    assert cached_response.content == b''
+
+
+def test_brand_group_detail_returns_304_for_if_none_match(
+    authenticated_client,
+    publisher,
+):
+    """Detail responses support ETag cache validation."""
+    brand_group = _create_brand_group(publisher=publisher)
+
+    response = authenticated_client.get(
+        reverse(
+            'brand-group-detail',
+            kwargs={'pk': brand_group.pk},
+        ),
+    )
+
+    assert response.status_code == 200
+    assert 'Last-Modified' in response
+    assert 'ETag' in response
+
+    cached_response = authenticated_client.get(
+        reverse(
+            'brand-group-detail',
+            kwargs={'pk': brand_group.pk},
+        ),
+        HTTP_IF_NONE_MATCH=response['ETag'],
+    )
+
+    assert cached_response.status_code == 304
+    assert cached_response.content == b''

--- a/apps/api_v2/tests/test_views/test_brands.py
+++ b/apps/api_v2/tests/test_views/test_brands.py
@@ -1,0 +1,251 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for the Brand v2 endpoints."""
+
+from django.urls import reverse
+
+from apps.gcd.models import Brand, BrandGroup, BrandUse, Publisher
+
+
+def _create_brand(
+    *,
+    name='Test Brand',
+    generic=False,
+    year_began=1960,
+    year_ended=None,
+    deleted=False,
+):
+    """Create a minimal Brand row for view tests."""
+    return Brand.objects.create(
+        name=name,
+        generic=generic,
+        year_began=year_began,
+        year_ended=year_ended,
+        notes='',
+        deleted=deleted,
+    )
+
+
+def _create_brand_group(*, publisher, name, deleted=False):
+    """Create a Brand Group for view relationship tests."""
+    return BrandGroup.objects.create(
+        name=name,
+        year_began=1950,
+        notes='',
+        parent=publisher,
+        deleted=deleted,
+    )
+
+
+def test_brand_list_returns_paginated_results(api_client, db):
+    """The list endpoint is anonymous, paginated, and trimmed."""
+    brand = _create_brand(generic=True)
+
+    response = api_client.get(reverse('brand-list'))
+
+    assert response.status_code == 200
+    assert response.data['count'] == 1
+    assert response.data['next'] is None
+    assert response.data['previous'] is None
+    assert len(response.data['results']) == 1
+    result = response.data['results'][0]
+    assert result['id'] == brand.pk
+    assert result['generic'] is True
+    assert 'notes' not in result
+    assert 'keywords' not in result
+    assert 'groups' not in result
+    assert 'uses' not in result
+
+
+def test_brand_detail_returns_expected_payload(
+    authenticated_client,
+    publisher,
+    country,
+):
+    """The detail endpoint returns descriptive and relationship fields."""
+    brand = _create_brand(generic=True)
+    brand.year_began_uncertain = True
+    brand.year_overall_began = 1955
+    brand.year_overall_ended = 1985
+    brand.year_overall_ended_uncertain = True
+    brand.url = 'https://example.com/brand/'
+    brand.notes = 'Detail notes'
+    brand.issue_count = 21
+    brand.save()
+    brand.keywords.add('alpha', 'beta')
+    alpha_publisher = Publisher.objects.create(
+        name='Alpha Publisher',
+        year_began=1940,
+        notes='',
+        country=country,
+    )
+    deleted_publisher = Publisher.objects.create(
+        name='Deleted Publisher',
+        year_began=1940,
+        notes='',
+        country=country,
+        deleted=True,
+    )
+    alpha_group = _create_brand_group(
+        publisher=alpha_publisher,
+        name='Alpha Group',
+    )
+    beta_group = _create_brand_group(
+        publisher=publisher,
+        name='Beta Group',
+    )
+    deleted_group = _create_brand_group(
+        publisher=publisher,
+        name='Deleted Group',
+        deleted=True,
+    )
+    brand.group.add(beta_group, deleted_group, alpha_group)
+    alpha_use = BrandUse.objects.create(
+        emblem=brand,
+        publisher=alpha_publisher,
+        year_began=1970,
+        notes='Alpha use',
+    )
+    test_use = BrandUse.objects.create(
+        emblem=brand,
+        publisher=publisher,
+        year_began=1960,
+        notes='Test use',
+    )
+    BrandUse.objects.create(
+        emblem=brand,
+        publisher=deleted_publisher,
+        notes='Deleted publisher use',
+    )
+
+    response = authenticated_client.get(
+        reverse('brand-detail', kwargs={'pk': brand.pk}),
+    )
+
+    assert response.status_code == 200
+    assert response.data['id'] == brand.pk
+    assert response.data['generic'] is True
+    assert response.data['year_began_uncertain'] is True
+    assert response.data['year_overall_began'] == 1955
+    assert response.data['year_overall_ended'] == 1985
+    assert response.data['year_overall_ended_uncertain'] is True
+    assert response.data['url'] == 'https://example.com/brand/'
+    assert response.data['notes'] == 'Detail notes'
+    assert response.data['issue_count'] == 21
+    assert set(response.data['keywords']) == {'alpha', 'beta'}
+    assert [group['id'] for group in response.data['groups']] == [
+        alpha_group.pk,
+        beta_group.pk,
+    ]
+    assert [use['id'] for use in response.data['uses']] == [
+        alpha_use.pk,
+        test_use.pk,
+    ]
+
+
+def test_brand_list_applies_distinct_relationship_filters(
+    authenticated_client,
+    publisher,
+):
+    """The list endpoint applies all filters without duplicate Brands."""
+    brand_group = _create_brand_group(
+        publisher=publisher,
+        name='Marvel Group',
+    )
+    matching = _create_brand(
+        name='Marvel Comics',
+        generic=True,
+        year_began=1960,
+        year_ended=1980,
+    )
+    matching.group.add(brand_group)
+    BrandUse.objects.create(
+        emblem=matching,
+        publisher=publisher,
+        year_began=1960,
+        notes='',
+    )
+    BrandUse.objects.create(
+        emblem=matching,
+        publisher=publisher,
+        year_began=1970,
+        notes='',
+    )
+    _create_brand(name='Different Brand', year_began=1940)
+
+    response = authenticated_client.get(
+        reverse('brand-list'),
+        {
+            'name': 'marvel',
+            'generic': 'true',
+            'group': str(brand_group.pk),
+            'publisher': str(publisher.pk),
+            'year_began': '1960',
+            'year_ended': '1980',
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.data['count'] == 1
+    assert response.data['results'][0]['id'] == matching.pk
+
+
+def test_brand_endpoints_hide_soft_deleted_records(api_client, db):
+    """Soft-deleted rows disappear from list and detail responses."""
+    visible = _create_brand(name='Visible Brand')
+    deleted = _create_brand(name='Deleted Brand', deleted=True)
+
+    list_response = api_client.get(reverse('brand-list'))
+    detail_response = api_client.get(
+        reverse('brand-detail', kwargs={'pk': deleted.pk}),
+    )
+
+    assert list_response.status_code == 200
+    assert list_response.data['count'] == 1
+    assert list_response.data['results'][0]['id'] == visible.pk
+    assert detail_response.status_code == 404
+
+
+def test_brand_list_returns_304_for_if_modified_since(
+    authenticated_client,
+):
+    """List responses support Last-Modified cache validation."""
+    _create_brand()
+
+    response = authenticated_client.get(reverse('brand-list'))
+
+    assert response.status_code == 200
+    assert 'Last-Modified' in response
+    assert 'ETag' in response
+
+    cached_response = authenticated_client.get(
+        reverse('brand-list'),
+        HTTP_IF_MODIFIED_SINCE=response['Last-Modified'],
+    )
+
+    assert cached_response.status_code == 304
+    assert cached_response.content == b''
+
+
+def test_brand_detail_returns_304_for_if_none_match(
+    authenticated_client,
+):
+    """Detail responses support ETag cache validation."""
+    brand = _create_brand()
+
+    response = authenticated_client.get(
+        reverse('brand-detail', kwargs={'pk': brand.pk}),
+    )
+
+    assert response.status_code == 200
+    assert 'Last-Modified' in response
+    assert 'ETag' in response
+
+    cached_response = authenticated_client.get(
+        reverse('brand-detail', kwargs={'pk': brand.pk}),
+        HTTP_IF_NONE_MATCH=response['ETag'],
+    )
+
+    assert cached_response.status_code == 304
+    assert cached_response.content == b''

--- a/apps/api_v2/tests/test_views/test_features.py
+++ b/apps/api_v2/tests/test_views/test_features.py
@@ -1,0 +1,273 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for the Feature v2 endpoints."""
+
+from django.urls import reverse
+
+from apps.gcd.models import (
+    Feature,
+    FeatureLogo,
+    FeatureRelation,
+    FeatureRelationType,
+    FeatureType,
+)
+from apps.stddata.models import Language
+
+
+def _create_feature(
+    *,
+    language,
+    feature_type,
+    name='Test Feature',
+    genre='superhero',
+    year_first_published=1960,
+    deleted=False,
+):
+    """Create a minimal Feature row for view tests."""
+    return Feature.objects.create(
+        name=name,
+        sort_name=name,
+        disambiguation='',
+        genre=genre,
+        language=language,
+        feature_type=feature_type,
+        year_first_published=year_first_published,
+        notes='',
+        deleted=deleted,
+    )
+
+
+def _create_logo(feature, *, name, deleted=False):
+    """Create a Feature Logo attached to ``feature``."""
+    logo = FeatureLogo.objects.create(
+        name=name,
+        sort_name=name,
+        generic=False,
+        year_began=1970,
+        notes='',
+        deleted=deleted,
+    )
+    logo.feature.add(feature)
+    return logo
+
+
+def test_feature_list_returns_paginated_results(api_client, language):
+    """The list endpoint is anonymous, paginated, and trimmed."""
+    feature_type = FeatureType.objects.create(name='Character')
+    feature = _create_feature(
+        language=language,
+        feature_type=feature_type,
+    )
+
+    response = api_client.get(reverse('feature-list'))
+
+    assert response.status_code == 200
+    assert response.data['count'] == 1
+    assert response.data['next'] is None
+    assert response.data['previous'] is None
+    assert len(response.data['results']) == 1
+    result = response.data['results'][0]
+    assert result['id'] == feature.pk
+    assert result['feature_type'] == {
+        'id': feature_type.pk,
+        'name': 'Character',
+    }
+    assert result['language'] == language.code
+    assert 'notes' not in result
+    assert 'keywords' not in result
+    assert 'logos' not in result
+    assert 'relations' not in result
+
+
+def test_feature_detail_returns_normalized_relationships(
+    authenticated_client,
+    language,
+):
+    """The detail endpoint merges active relation directions explicitly."""
+    character_type = FeatureType.objects.create(name='Character')
+    relation_type = FeatureRelationType.objects.create(
+        name='translation',
+        description='is translated to',
+        reverse_description='is translated from',
+    )
+    feature = _create_feature(
+        language=language,
+        feature_type=character_type,
+    )
+    feature.year_first_published_uncertain = True
+    feature.notes = 'Detail notes'
+    feature.save()
+    feature.keywords.add('alpha', 'beta')
+    logo = _create_logo(feature, name='Active Logo')
+    _create_logo(feature, name='Deleted Logo', deleted=True)
+    outgoing_target = _create_feature(
+        language=language,
+        feature_type=character_type,
+        name='Outgoing Target',
+    )
+    incoming_source = _create_feature(
+        language=language,
+        feature_type=character_type,
+        name='Incoming Source',
+    )
+    outgoing = FeatureRelation.objects.create(
+        from_feature=feature,
+        to_feature=outgoing_target,
+        relation_type=relation_type,
+        notes='Outgoing notes',
+    )
+    incoming = FeatureRelation.objects.create(
+        from_feature=incoming_source,
+        to_feature=feature,
+        relation_type=relation_type,
+        notes='Incoming notes',
+    )
+
+    response = authenticated_client.get(
+        reverse('feature-detail', kwargs={'pk': feature.pk}),
+    )
+
+    assert response.status_code == 200
+    assert response.data['id'] == feature.pk
+    assert response.data['year_first_published_uncertain'] is True
+    assert response.data['notes'] == 'Detail notes'
+    assert set(response.data['keywords']) == {'alpha', 'beta'}
+    assert [item['id'] for item in response.data['logos']] == [logo.pk]
+    assert [item['id'] for item in response.data['relations']] == [
+        outgoing.pk,
+        incoming.pk,
+    ]
+    assert [item['direction'] for item in response.data['relations']] == [
+        'outgoing',
+        'incoming',
+    ]
+    assert [
+        item['relation_type']['description']
+        for item in response.data['relations']
+    ] == [
+        'is translated to',
+        'is translated from',
+    ]
+
+
+def test_feature_list_applies_filter_query_params(
+    authenticated_client,
+    language,
+):
+    """The list endpoint applies the complete Feature filter contract."""
+    character_type = FeatureType.objects.create(name='Character')
+    location_type = FeatureType.objects.create(name='Location')
+    other_language = Language.objects.create(
+        code='yy',
+        name='Other Language',
+    )
+    matching = _create_feature(
+        language=language,
+        feature_type=character_type,
+        name='Amazing Spider-Man',
+        genre='Science Fiction; Superhero',
+        year_first_published=1960,
+    )
+    _create_feature(
+        language=other_language,
+        feature_type=location_type,
+        name='Different Feature',
+        genre='Western',
+        year_first_published=1940,
+    )
+
+    response = authenticated_client.get(
+        reverse('feature-list'),
+        {
+            'name': 'spider',
+            'feature_type': str(character_type.pk),
+            'language': language.code,
+            'genre': 'science fiction',
+            'year_first_published': '1960',
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.data['count'] == 1
+    assert response.data['results'][0]['id'] == matching.pk
+
+
+def test_feature_endpoints_hide_soft_deleted_records(
+    api_client,
+    language,
+):
+    """Soft-deleted rows disappear from list and detail responses."""
+    feature_type = FeatureType.objects.create(name='Character')
+    visible = _create_feature(
+        language=language,
+        feature_type=feature_type,
+        name='Visible Feature',
+    )
+    deleted = _create_feature(
+        language=language,
+        feature_type=feature_type,
+        name='Deleted Feature',
+        deleted=True,
+    )
+
+    list_response = api_client.get(reverse('feature-list'))
+    detail_response = api_client.get(
+        reverse('feature-detail', kwargs={'pk': deleted.pk}),
+    )
+
+    assert list_response.status_code == 200
+    assert list_response.data['count'] == 1
+    assert list_response.data['results'][0]['id'] == visible.pk
+    assert detail_response.status_code == 404
+
+
+def test_feature_list_returns_304_for_if_modified_since(
+    authenticated_client,
+    language,
+):
+    """List responses support Last-Modified cache validation."""
+    feature_type = FeatureType.objects.create(name='Character')
+    _create_feature(language=language, feature_type=feature_type)
+
+    response = authenticated_client.get(reverse('feature-list'))
+
+    assert response.status_code == 200
+    assert 'Last-Modified' in response
+    assert 'ETag' in response
+
+    cached_response = authenticated_client.get(
+        reverse('feature-list'),
+        HTTP_IF_MODIFIED_SINCE=response['Last-Modified'],
+    )
+
+    assert cached_response.status_code == 304
+    assert cached_response.content == b''
+
+
+def test_feature_detail_returns_304_for_if_none_match(
+    authenticated_client,
+    language,
+):
+    """Detail responses support ETag cache validation."""
+    feature_type = FeatureType.objects.create(name='Character')
+    feature = _create_feature(
+        language=language,
+        feature_type=feature_type,
+    )
+
+    response = authenticated_client.get(
+        reverse('feature-detail', kwargs={'pk': feature.pk}),
+    )
+
+    assert response.status_code == 200
+    assert 'Last-Modified' in response
+    assert 'ETag' in response
+
+    cached_response = authenticated_client.get(
+        reverse('feature-detail', kwargs={'pk': feature.pk}),
+        HTTP_IF_NONE_MATCH=response['ETag'],
+    )
+
+    assert cached_response.status_code == 304
+    assert cached_response.content == b''

--- a/apps/api_v2/tests/test_views/test_indicia_printers.py
+++ b/apps/api_v2/tests/test_views/test_indicia_printers.py
@@ -1,0 +1,260 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for the indicia printer v2 endpoints."""
+
+import pytest
+from django.urls import reverse
+
+from apps.gcd.models import IndiciaPrinter, Printer
+from apps.stddata.models import Country
+
+
+@pytest.fixture
+def printer(db, country):
+    """Return a saved Printer tied to the shared country."""
+    return Printer.objects.create(
+        name='Test Printer',
+        year_began=1950,
+        notes='',
+        country=country,
+    )
+
+
+@pytest.fixture
+def other_country(db):
+    """Return a second country for indicia printer view tests."""
+    obj, _ = Country.objects.get_or_create(
+        code='yy',
+        defaults={'name': 'Other Country'},
+    )
+    return obj
+
+
+def _create_indicia_printer(
+    *,
+    printer,
+    country,
+    name='Test Indicia Printer',
+    year_began=1960,
+    year_ended=None,
+    deleted=False,
+):
+    """Create a minimal indicia printer row for view tests."""
+    return IndiciaPrinter.objects.create(
+        name=name,
+        year_began=year_began,
+        year_ended=year_ended,
+        notes='',
+        parent=printer,
+        country=country,
+        deleted=deleted,
+    )
+
+
+def test_indicia_printer_list_returns_paginated_results(
+    api_client,
+    printer,
+    country,
+):
+    """The list endpoint is anonymous, paginated, and trimmed."""
+    indicia_printer = _create_indicia_printer(
+        printer=printer,
+        country=country,
+    )
+
+    response = api_client.get(reverse('indicia-printer-list'))
+
+    assert response.status_code == 200
+    assert response.data['count'] == 1
+    assert response.data['next'] is None
+    assert response.data['previous'] is None
+    assert len(response.data['results']) == 1
+    result = response.data['results'][0]
+    assert result['id'] == indicia_printer.pk
+    assert result['parent'] == {
+        'id': printer.pk,
+        'name': printer.name,
+    }
+    assert result['country'] == country.code
+    assert 'notes' not in result
+    assert 'keywords' not in result
+
+
+def test_indicia_printer_detail_returns_expected_payload(
+    authenticated_client,
+    printer,
+    country,
+):
+    """The detail endpoint returns descriptive and uncertainty fields."""
+    indicia_printer = _create_indicia_printer(
+        printer=printer,
+        country=country,
+    )
+    indicia_printer.year_began_uncertain = True
+    indicia_printer.year_overall_began = 1955
+    indicia_printer.year_overall_ended = 1985
+    indicia_printer.year_overall_ended_uncertain = True
+    indicia_printer.url = 'https://example.com/plant/'
+    indicia_printer.notes = 'Detail notes'
+    indicia_printer.issue_count = 21
+    indicia_printer.save()
+    indicia_printer.keywords.add('alpha', 'beta')
+
+    response = authenticated_client.get(
+        reverse(
+            'indicia-printer-detail',
+            kwargs={'pk': indicia_printer.pk},
+        ),
+    )
+
+    assert response.status_code == 200
+    assert response.data['id'] == indicia_printer.pk
+    assert response.data['parent'] == {
+        'id': printer.pk,
+        'name': printer.name,
+    }
+    assert response.data['country'] == country.code
+    assert response.data['year_began_uncertain'] is True
+    assert response.data['year_overall_began'] == 1955
+    assert response.data['year_overall_ended'] == 1985
+    assert response.data['year_overall_ended_uncertain'] is True
+    assert response.data['url'] == 'https://example.com/plant/'
+    assert response.data['notes'] == 'Detail notes'
+    assert response.data['issue_count'] == 21
+    assert set(response.data['keywords']) == {'alpha', 'beta'}
+
+
+def test_indicia_printer_list_applies_filter_query_params(
+    authenticated_client,
+    printer,
+    country,
+    other_country,
+):
+    """The list endpoint applies the complete filter contract."""
+    other_parent = Printer.objects.create(
+        name='Other Printer',
+        year_began=1940,
+        notes='',
+        country=country,
+    )
+    matching = _create_indicia_printer(
+        printer=printer,
+        country=country,
+        name='Quebecor Printing',
+        year_began=1960,
+        year_ended=1980,
+    )
+    _create_indicia_printer(
+        printer=other_parent,
+        country=other_country,
+        name='Different Plant',
+        year_began=1940,
+    )
+
+    response = authenticated_client.get(
+        reverse('indicia-printer-list'),
+        {
+            'name': 'quebecor',
+            'parent': str(printer.pk),
+            'country': country.code,
+            'year_began': '1960',
+            'year_ended': '1980',
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.data['count'] == 1
+    assert response.data['results'][0]['id'] == matching.pk
+
+
+def test_indicia_printer_endpoints_hide_soft_deleted_records(
+    api_client,
+    printer,
+    country,
+):
+    """Soft-deleted rows disappear from list and detail responses."""
+    visible = _create_indicia_printer(
+        printer=printer,
+        country=country,
+        name='Visible Plant',
+    )
+    deleted = _create_indicia_printer(
+        printer=printer,
+        country=country,
+        name='Deleted Plant',
+        deleted=True,
+    )
+
+    list_response = api_client.get(reverse('indicia-printer-list'))
+    detail_response = api_client.get(
+        reverse(
+            'indicia-printer-detail',
+            kwargs={'pk': deleted.pk},
+        ),
+    )
+
+    assert list_response.status_code == 200
+    assert list_response.data['count'] == 1
+    assert list_response.data['results'][0]['id'] == visible.pk
+    assert detail_response.status_code == 404
+
+
+def test_indicia_printer_list_returns_304_for_if_modified_since(
+    authenticated_client,
+    printer,
+    country,
+):
+    """List responses support Last-Modified cache validation."""
+    _create_indicia_printer(
+        printer=printer,
+        country=country,
+    )
+
+    response = authenticated_client.get(reverse('indicia-printer-list'))
+
+    assert response.status_code == 200
+    assert 'Last-Modified' in response
+    assert 'ETag' in response
+
+    cached_response = authenticated_client.get(
+        reverse('indicia-printer-list'),
+        HTTP_IF_MODIFIED_SINCE=response['Last-Modified'],
+    )
+
+    assert cached_response.status_code == 304
+    assert cached_response.content == b''
+
+
+def test_indicia_printer_detail_returns_304_for_if_none_match(
+    authenticated_client,
+    printer,
+    country,
+):
+    """Detail responses support ETag cache validation."""
+    indicia_printer = _create_indicia_printer(
+        printer=printer,
+        country=country,
+    )
+
+    response = authenticated_client.get(
+        reverse(
+            'indicia-printer-detail',
+            kwargs={'pk': indicia_printer.pk},
+        ),
+    )
+
+    assert response.status_code == 200
+    assert 'Last-Modified' in response
+    assert 'ETag' in response
+
+    cached_response = authenticated_client.get(
+        reverse(
+            'indicia-printer-detail',
+            kwargs={'pk': indicia_printer.pk},
+        ),
+        HTTP_IF_NONE_MATCH=response['ETag'],
+    )
+
+    assert cached_response.status_code == 304
+    assert cached_response.content == b''

--- a/apps/api_v2/tests/test_views/test_indicia_publishers.py
+++ b/apps/api_v2/tests/test_views/test_indicia_publishers.py
@@ -1,0 +1,255 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for the indicia publisher v2 endpoints."""
+
+import pytest
+from django.urls import reverse
+
+from apps.gcd.models import IndiciaPublisher, Publisher
+from apps.stddata.models import Country
+
+
+@pytest.fixture
+def other_country(db):
+    """Return a second country for indicia publisher view tests."""
+    obj, _ = Country.objects.get_or_create(
+        code='yy',
+        defaults={'name': 'Other Country'},
+    )
+    return obj
+
+
+def _create_indicia_publisher(
+    *,
+    publisher,
+    country,
+    name='Test Indicia Publisher',
+    year_began=1960,
+    year_ended=None,
+    is_surrogate=False,
+    deleted=False,
+):
+    """Create a minimal indicia publisher row for view tests."""
+    return IndiciaPublisher.objects.create(
+        name=name,
+        year_began=year_began,
+        year_ended=year_ended,
+        notes='',
+        parent=publisher,
+        country=country,
+        is_surrogate=is_surrogate,
+        deleted=deleted,
+    )
+
+
+def test_indicia_publisher_list_returns_paginated_results(
+    api_client,
+    publisher,
+    country,
+):
+    """The list endpoint is anonymous, paginated, and trimmed."""
+    indicia_publisher = _create_indicia_publisher(
+        publisher=publisher,
+        country=country,
+    )
+
+    response = api_client.get(reverse('indicia-publisher-list'))
+
+    assert response.status_code == 200
+    assert response.data['count'] == 1
+    assert response.data['next'] is None
+    assert response.data['previous'] is None
+    assert len(response.data['results']) == 1
+    result = response.data['results'][0]
+    assert result['id'] == indicia_publisher.pk
+    assert result['parent'] == {
+        'id': publisher.pk,
+        'name': publisher.name,
+    }
+    assert result['country'] == country.code
+    assert 'notes' not in result
+    assert 'keywords' not in result
+
+
+def test_indicia_publisher_detail_returns_expected_payload(
+    authenticated_client,
+    publisher,
+    country,
+):
+    """The detail endpoint returns descriptive and uncertainty fields."""
+    indicia_publisher = _create_indicia_publisher(
+        publisher=publisher,
+        country=country,
+        is_surrogate=True,
+    )
+    indicia_publisher.year_began_uncertain = True
+    indicia_publisher.year_overall_began = 1955
+    indicia_publisher.year_overall_ended = 1985
+    indicia_publisher.year_overall_ended_uncertain = True
+    indicia_publisher.url = 'https://example.com/imprint/'
+    indicia_publisher.notes = 'Detail notes'
+    indicia_publisher.issue_count = 21
+    indicia_publisher.save()
+    indicia_publisher.keywords.add('alpha', 'beta')
+
+    response = authenticated_client.get(
+        reverse(
+            'indicia-publisher-detail',
+            kwargs={'pk': indicia_publisher.pk},
+        ),
+    )
+
+    assert response.status_code == 200
+    assert response.data['id'] == indicia_publisher.pk
+    assert response.data['parent'] == {
+        'id': publisher.pk,
+        'name': publisher.name,
+    }
+    assert response.data['country'] == country.code
+    assert response.data['is_surrogate'] is True
+    assert response.data['year_began_uncertain'] is True
+    assert response.data['year_overall_began'] == 1955
+    assert response.data['year_overall_ended'] == 1985
+    assert response.data['year_overall_ended_uncertain'] is True
+    assert response.data['url'] == 'https://example.com/imprint/'
+    assert response.data['notes'] == 'Detail notes'
+    assert response.data['issue_count'] == 21
+    assert set(response.data['keywords']) == {'alpha', 'beta'}
+
+
+def test_indicia_publisher_list_applies_filter_query_params(
+    authenticated_client,
+    publisher,
+    country,
+    other_country,
+):
+    """The list endpoint applies the complete filter contract."""
+    other_parent = Publisher.objects.create(
+        name='Other Publisher',
+        year_began=1940,
+        notes='',
+        country=country,
+    )
+    matching = _create_indicia_publisher(
+        publisher=publisher,
+        country=country,
+        name='Marvel Comics Group',
+        year_began=1960,
+        year_ended=1980,
+        is_surrogate=True,
+    )
+    _create_indicia_publisher(
+        publisher=other_parent,
+        country=other_country,
+        name='Different Imprint',
+        year_began=1940,
+    )
+
+    response = authenticated_client.get(
+        reverse('indicia-publisher-list'),
+        {
+            'name': 'marvel',
+            'parent': str(publisher.pk),
+            'country': country.code,
+            'is_surrogate': 'true',
+            'year_began': '1960',
+            'year_ended': '1980',
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.data['count'] == 1
+    assert response.data['results'][0]['id'] == matching.pk
+
+
+def test_indicia_publisher_endpoints_hide_soft_deleted_records(
+    api_client,
+    publisher,
+    country,
+):
+    """Soft-deleted rows disappear from list and detail responses."""
+    visible = _create_indicia_publisher(
+        publisher=publisher,
+        country=country,
+        name='Visible Imprint',
+    )
+    deleted = _create_indicia_publisher(
+        publisher=publisher,
+        country=country,
+        name='Deleted Imprint',
+        deleted=True,
+    )
+
+    list_response = api_client.get(reverse('indicia-publisher-list'))
+    detail_response = api_client.get(
+        reverse(
+            'indicia-publisher-detail',
+            kwargs={'pk': deleted.pk},
+        ),
+    )
+
+    assert list_response.status_code == 200
+    assert list_response.data['count'] == 1
+    assert list_response.data['results'][0]['id'] == visible.pk
+    assert detail_response.status_code == 404
+
+
+def test_indicia_publisher_list_returns_304_for_if_modified_since(
+    authenticated_client,
+    publisher,
+    country,
+):
+    """List responses support Last-Modified cache validation."""
+    _create_indicia_publisher(
+        publisher=publisher,
+        country=country,
+    )
+
+    response = authenticated_client.get(reverse('indicia-publisher-list'))
+
+    assert response.status_code == 200
+    assert 'Last-Modified' in response
+    assert 'ETag' in response
+
+    cached_response = authenticated_client.get(
+        reverse('indicia-publisher-list'),
+        HTTP_IF_MODIFIED_SINCE=response['Last-Modified'],
+    )
+
+    assert cached_response.status_code == 304
+    assert cached_response.content == b''
+
+
+def test_indicia_publisher_detail_returns_304_for_if_none_match(
+    authenticated_client,
+    publisher,
+    country,
+):
+    """Detail responses support ETag cache validation."""
+    indicia_publisher = _create_indicia_publisher(
+        publisher=publisher,
+        country=country,
+    )
+
+    response = authenticated_client.get(
+        reverse(
+            'indicia-publisher-detail',
+            kwargs={'pk': indicia_publisher.pk},
+        ),
+    )
+
+    assert response.status_code == 200
+    assert 'Last-Modified' in response
+    assert 'ETag' in response
+
+    cached_response = authenticated_client.get(
+        reverse(
+            'indicia-publisher-detail',
+            kwargs={'pk': indicia_publisher.pk},
+        ),
+        HTTP_IF_NONE_MATCH=response['ETag'],
+    )
+
+    assert cached_response.status_code == 304
+    assert cached_response.content == b''

--- a/apps/api_v2/tests/test_views/test_series_bonds.py
+++ b/apps/api_v2/tests/test_views/test_series_bonds.py
@@ -1,0 +1,220 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for the Series Bond v2 endpoints."""
+
+from django.urls import reverse
+
+from apps.gcd.models import Issue, Series, SeriesBond, SeriesBondType
+
+
+def _create_series(series, *, name, year_began):
+    """Create a Series sharing the fixture Series' reference data."""
+    return Series.objects.create(
+        name=name,
+        sort_name=name,
+        year_began=year_began,
+        publication_dates=f'{year_began} - present',
+        notes='',
+        tracking_notes='',
+        country=series.country,
+        language=series.language,
+        publisher=series.publisher,
+    )
+
+
+def _create_issue(series, *, number, sort_code):
+    """Create a minimal Issue for Series Bond view tests."""
+    return Issue.objects.create(
+        number=number,
+        title='',
+        volume='',
+        isbn='',
+        valid_isbn='',
+        variant_name='',
+        barcode='',
+        publication_date='',
+        key_date='',
+        on_sale_date='',
+        sort_code=sort_code,
+        indicia_frequency='',
+        price='',
+        editing='',
+        notes='',
+        indicia_printer_sourced_by='',
+        series=series,
+    )
+
+
+def _create_bond(series, issue, *, reserved=False):
+    """Create a complete Series Bond view fixture."""
+    target = _create_series(series, name='Target Series', year_began=2000)
+    target_issue = _create_issue(target, number='1', sort_code=1)
+    bond_type = SeriesBondType.objects.create(
+        name='continues',
+        description='Continues at',
+        notes='',
+    )
+    bond = SeriesBond.objects.create(
+        origin=series,
+        origin_issue=issue,
+        target=target,
+        target_issue=target_issue,
+        bond_type=bond_type,
+        notes='The numbering continues in the target Series.',
+        reserved=reserved,
+    )
+    return bond, target, target_issue, bond_type
+
+
+def test_series_bond_list_returns_paginated_results(api_client, series, issue):
+    """The list endpoint is anonymous, paginated, and trimmed."""
+    bond, target, _target_issue, _bond_type = _create_bond(series, issue)
+
+    response = api_client.get(reverse('series-bond-list'))
+
+    assert response.status_code == 200
+    assert response.data['count'] == 1
+    assert response.data['next'] is None
+    assert response.data['previous'] is None
+    assert len(response.data['results']) == 1
+    result = response.data['results'][0]
+    assert result['id'] == bond.pk
+    assert result['origin']['id'] == series.pk
+    assert result['target']['id'] == target.pk
+    assert 'notes' not in result
+    assert 'reserved' not in result
+
+
+def test_series_bond_detail_returns_expected_payload(
+    authenticated_client,
+    series,
+    issue,
+):
+    """The detail endpoint returns complete Series Bond data."""
+    bond, target, target_issue, bond_type = _create_bond(series, issue)
+
+    response = authenticated_client.get(
+        reverse('series-bond-detail', kwargs={'pk': bond.pk}),
+    )
+
+    assert response.status_code == 200
+    assert response.data['id'] == bond.pk
+    assert response.data['origin'] == {
+        'id': series.pk,
+        'name': 'Test Series',
+        'year_began': 1990,
+    }
+    assert response.data['target'] == {
+        'id': target.pk,
+        'name': 'Target Series',
+        'year_began': 2000,
+    }
+    assert response.data['target_issue'] == {
+        'id': target_issue.pk,
+        'descriptor': target_issue.issue_descriptor,
+    }
+    assert response.data['bond_type'] == {
+        'id': bond_type.pk,
+        'name': 'continues',
+        'description': 'Continues at',
+    }
+    assert response.data['notes'] == (
+        'The numbering continues in the target Series.'
+    )
+    assert 'reserved' not in response.data
+
+
+def test_series_bond_list_applies_filter_query_params(
+    api_client,
+    series,
+    issue,
+):
+    """The list endpoint applies the complete relationship contract."""
+    bond, target, target_issue, bond_type = _create_bond(series, issue)
+
+    response = api_client.get(
+        reverse('series-bond-list'),
+        {
+            'origin': str(series.pk),
+            'origin_issue': str(issue.pk),
+            'target': str(target.pk),
+            'target_issue': str(target_issue.pk),
+            'bond_type': str(bond_type.pk),
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.data['count'] == 1
+    assert response.data['results'][0]['id'] == bond.pk
+
+
+def test_series_bond_list_returns_304_for_if_modified_since(
+    authenticated_client,
+    series,
+    issue,
+):
+    """List responses support Last-Modified cache validation."""
+    _create_bond(series, issue)
+
+    response = authenticated_client.get(reverse('series-bond-list'))
+
+    assert response.status_code == 200
+    assert 'Last-Modified' in response
+    assert 'ETag' in response
+
+    cached_response = authenticated_client.get(
+        reverse('series-bond-list'),
+        HTTP_IF_MODIFIED_SINCE=response['Last-Modified'],
+    )
+
+    assert cached_response.status_code == 304
+    assert cached_response.content == b''
+
+
+def test_series_bond_detail_returns_304_for_if_none_match(
+    authenticated_client,
+    series,
+    issue,
+):
+    """Detail responses support ETag cache validation."""
+    bond, _target, _target_issue, _bond_type = _create_bond(series, issue)
+
+    response = authenticated_client.get(
+        reverse('series-bond-detail', kwargs={'pk': bond.pk}),
+    )
+
+    assert response.status_code == 200
+    assert 'Last-Modified' in response
+    assert 'ETag' in response
+
+    cached_response = authenticated_client.get(
+        reverse('series-bond-detail', kwargs={'pk': bond.pk}),
+        HTTP_IF_NONE_MATCH=response['ETag'],
+    )
+
+    assert cached_response.status_code == 304
+    assert cached_response.content == b''
+
+
+def test_series_bond_reserved_state_is_never_exposed(
+    api_client,
+    series,
+    issue,
+):
+    """Internal reservation state remains absent from all API payloads."""
+    bond, _target, _target_issue, _bond_type = _create_bond(
+        series,
+        issue,
+        reserved=True,
+    )
+
+    list_response = api_client.get(reverse('series-bond-list'))
+    detail_response = api_client.get(
+        reverse('series-bond-detail', kwargs={'pk': bond.pk}),
+    )
+
+    assert list_response.status_code == 200
+    assert 'reserved' not in list_response.data['results'][0]
+    assert detail_response.status_code == 200
+    assert 'reserved' not in detail_response.data

--- a/apps/api_v2/urls_www.py
+++ b/apps/api_v2/urls_www.py
@@ -15,6 +15,7 @@ from apps.api_v2.routers import V2APIRouter
 from apps.api_v2.views.characters import CharacterViewSet
 from apps.api_v2.views.creators import CreatorViewSet
 from apps.api_v2.views.groups import GroupViewSet
+from apps.api_v2.views.indicia_printers import IndiciaPrinterViewSet
 from apps.api_v2.views.indicia_publishers import IndiciaPublisherViewSet
 from apps.api_v2.views.issues import IssueViewSet
 from apps.api_v2.views.publishers import PublisherViewSet
@@ -28,6 +29,11 @@ router = V2APIRouter()
 router.register('characters', CharacterViewSet, basename='character')
 router.register('creators', CreatorViewSet, basename='creator')
 router.register('groups', GroupViewSet, basename='group')
+router.register(
+    'indicia-printers',
+    IndiciaPrinterViewSet,
+    basename='indicia-printer',
+)
 router.register(
     'indicia-publishers',
     IndiciaPublisherViewSet,

--- a/apps/api_v2/urls_www.py
+++ b/apps/api_v2/urls_www.py
@@ -16,6 +16,7 @@ from apps.api_v2.views.brand_groups import BrandGroupViewSet
 from apps.api_v2.views.brands import BrandViewSet
 from apps.api_v2.views.characters import CharacterViewSet
 from apps.api_v2.views.creators import CreatorViewSet
+from apps.api_v2.views.features import FeatureViewSet
 from apps.api_v2.views.groups import GroupViewSet
 from apps.api_v2.views.indicia_printers import IndiciaPrinterViewSet
 from apps.api_v2.views.indicia_publishers import IndiciaPublisherViewSet
@@ -32,6 +33,7 @@ router.register('brand-groups', BrandGroupViewSet, basename='brand-group')
 router.register('brands', BrandViewSet, basename='brand')
 router.register('characters', CharacterViewSet, basename='character')
 router.register('creators', CreatorViewSet, basename='creator')
+router.register('features', FeatureViewSet, basename='feature')
 router.register('groups', GroupViewSet, basename='group')
 router.register(
     'indicia-printers',

--- a/apps/api_v2/urls_www.py
+++ b/apps/api_v2/urls_www.py
@@ -25,6 +25,7 @@ from apps.api_v2.views.issues import IssueViewSet
 from apps.api_v2.views.publishers import PublisherViewSet
 from apps.api_v2.views.reprints import ReprintViewSet
 from apps.api_v2.views.series import SeriesViewSet
+from apps.api_v2.views.series_bonds import SeriesBondViewSet
 from apps.api_v2.views.stories import StoryViewSet
 from apps.api_v2.views.story_arcs import StoryArcViewSet
 from apps.api_v2.views.universes import UniverseViewSet
@@ -51,6 +52,7 @@ router.register('issues', IssueViewSet, basename='issue')
 router.register('publishers', PublisherViewSet, basename='publisher')
 router.register('reprints', ReprintViewSet, basename='reprint')
 router.register('series', SeriesViewSet, basename='series')
+router.register('series-bonds', SeriesBondViewSet, basename='series-bond')
 router.register('story-arcs', StoryArcViewSet, basename='story-arc')
 router.register('stories', StoryViewSet, basename='story')
 router.register('universes', UniverseViewSet, basename='universe')

--- a/apps/api_v2/urls_www.py
+++ b/apps/api_v2/urls_www.py
@@ -13,6 +13,7 @@ from django.urls import include, path
 
 from apps.api_v2.routers import V2APIRouter
 from apps.api_v2.views.brand_groups import BrandGroupViewSet
+from apps.api_v2.views.brands import BrandViewSet
 from apps.api_v2.views.characters import CharacterViewSet
 from apps.api_v2.views.creators import CreatorViewSet
 from apps.api_v2.views.groups import GroupViewSet
@@ -28,6 +29,7 @@ from apps.api_v2.views.universes import UniverseViewSet
 
 router = V2APIRouter()
 router.register('brand-groups', BrandGroupViewSet, basename='brand-group')
+router.register('brands', BrandViewSet, basename='brand')
 router.register('characters', CharacterViewSet, basename='character')
 router.register('creators', CreatorViewSet, basename='creator')
 router.register('groups', GroupViewSet, basename='group')

--- a/apps/api_v2/urls_www.py
+++ b/apps/api_v2/urls_www.py
@@ -15,6 +15,7 @@ from apps.api_v2.routers import V2APIRouter
 from apps.api_v2.views.characters import CharacterViewSet
 from apps.api_v2.views.creators import CreatorViewSet
 from apps.api_v2.views.groups import GroupViewSet
+from apps.api_v2.views.indicia_publishers import IndiciaPublisherViewSet
 from apps.api_v2.views.issues import IssueViewSet
 from apps.api_v2.views.publishers import PublisherViewSet
 from apps.api_v2.views.reprints import ReprintViewSet
@@ -27,6 +28,11 @@ router = V2APIRouter()
 router.register('characters', CharacterViewSet, basename='character')
 router.register('creators', CreatorViewSet, basename='creator')
 router.register('groups', GroupViewSet, basename='group')
+router.register(
+    'indicia-publishers',
+    IndiciaPublisherViewSet,
+    basename='indicia-publisher',
+)
 router.register('issues', IssueViewSet, basename='issue')
 router.register('publishers', PublisherViewSet, basename='publisher')
 router.register('reprints', ReprintViewSet, basename='reprint')

--- a/apps/api_v2/urls_www.py
+++ b/apps/api_v2/urls_www.py
@@ -12,6 +12,7 @@ and the rest as they land in subsequent sprints. The dispatcher in
 from django.urls import include, path
 
 from apps.api_v2.routers import V2APIRouter
+from apps.api_v2.views.awards import AwardViewSet
 from apps.api_v2.views.brand_groups import BrandGroupViewSet
 from apps.api_v2.views.brands import BrandViewSet
 from apps.api_v2.views.characters import CharacterViewSet
@@ -29,6 +30,7 @@ from apps.api_v2.views.story_arcs import StoryArcViewSet
 from apps.api_v2.views.universes import UniverseViewSet
 
 router = V2APIRouter()
+router.register('awards', AwardViewSet, basename='award')
 router.register('brand-groups', BrandGroupViewSet, basename='brand-group')
 router.register('brands', BrandViewSet, basename='brand')
 router.register('characters', CharacterViewSet, basename='character')

--- a/apps/api_v2/urls_www.py
+++ b/apps/api_v2/urls_www.py
@@ -12,6 +12,7 @@ and the rest as they land in subsequent sprints. The dispatcher in
 from django.urls import include, path
 
 from apps.api_v2.routers import V2APIRouter
+from apps.api_v2.views.brand_groups import BrandGroupViewSet
 from apps.api_v2.views.characters import CharacterViewSet
 from apps.api_v2.views.creators import CreatorViewSet
 from apps.api_v2.views.groups import GroupViewSet
@@ -26,6 +27,7 @@ from apps.api_v2.views.story_arcs import StoryArcViewSet
 from apps.api_v2.views.universes import UniverseViewSet
 
 router = V2APIRouter()
+router.register('brand-groups', BrandGroupViewSet, basename='brand-group')
 router.register('characters', CharacterViewSet, basename='character')
 router.register('creators', CreatorViewSet, basename='creator')
 router.register('groups', GroupViewSet, basename='group')

--- a/apps/api_v2/views/awards.py
+++ b/apps/api_v2/views/awards.py
@@ -1,0 +1,250 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Viewsets for v2 Award endpoints."""
+
+import hashlib
+
+from django.contrib.contenttypes.prefetch import GenericPrefetch
+from django.db.models import Q, Subquery
+from django_filters.rest_framework import DjangoFilterBackend
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
+
+from apps.api_v2.filters.awards import (
+    AWARD_RECIPIENT_TYPES,
+    AwardFilterSet,
+    AwardRecipientFilterSet,
+)
+from apps.api_v2.serializers.awards import (
+    AwardListSerializer,
+    AwardRecipientSerializer,
+    AwardSerializer,
+)
+from apps.api_v2.utils.conditional import (
+    condition,
+    make_etag,
+    make_last_modified,
+)
+from apps.api_v2.views import GCDBaseViewSet
+from apps.gcd.models import (
+    Award,
+    Creator,
+    Issue,
+    ReceivedAward,
+    Series,
+    Story,
+)
+
+SUPPORTED_AWARD_RECIPIENT_TYPES = tuple(
+    value for value, _label in AWARD_RECIPIENT_TYPES
+)
+
+
+def _award_filter_queryset(request, *, pk=None, **kwargs):
+    """Return Awards scoped by request query parameters."""
+    del pk, kwargs
+    return AwardFilterSet(
+        request.GET,
+        queryset=Award.objects.all(),
+        request=request,
+    ).qs
+
+
+def _award_recipient_queryset(award_id):
+    """Return active supported recipient rows for one active Award."""
+    active_recipient = (
+        Q(
+            content_type__model='creator',
+            object_id__in=Creator.objects.filter(deleted=False).values('pk'),
+        )
+        | Q(
+            content_type__model='issue',
+            object_id__in=Issue.objects.filter(deleted=False).values('pk'),
+        )
+        | Q(
+            content_type__model='series',
+            object_id__in=Series.objects.filter(deleted=False).values('pk'),
+        )
+        | Q(
+            content_type__model='story',
+            object_id__in=Story.objects.filter(deleted=False).values('pk'),
+        )
+    )
+    return ReceivedAward.objects.filter(
+        active_recipient,
+        award_id=award_id,
+        award__deleted=False,
+        deleted=False,
+        content_type__app_label='gcd',
+    )
+
+
+def _award_recipient_filter_queryset(request, *, pk=None, **kwargs):
+    """Return recipient rows scoped by Award and request filters."""
+    del kwargs
+    if pk is None:
+        return ReceivedAward.objects.none()
+    return AwardRecipientFilterSet(
+        request.GET,
+        queryset=_award_recipient_queryset(pk),
+        request=request,
+    ).qs
+
+
+award_last_modified = make_last_modified(
+    Award,
+    queryset_getter=_award_filter_queryset,
+)
+award_etag = make_etag(
+    Award,
+    queryset_getter=_award_filter_queryset,
+)
+
+
+def _award_recipient_conditional_state(request, *, pk=None, **kwargs):
+    """Return cached parent existence and recipient modification state."""
+    del kwargs
+    if pk is None:
+        return None
+    cache = getattr(request, '_gcd_v2_award_recipient_condition', None)
+    cache_key = (request.get_full_path(), pk)
+    if cache is not None and cache_key in cache:
+        return cache[cache_key]
+
+    latest_recipient = (
+        _award_recipient_filter_queryset(request, pk=pk)
+        .order_by('-modified')
+        .values('modified')[:1]
+    )
+    state = (
+        Award.objects.filter(pk=pk, deleted=False)
+        .annotate(recipient_modified=Subquery(latest_recipient))
+        .values('recipient_modified')
+        .first()
+    )
+    if cache is None:
+        cache = {}
+        request._gcd_v2_award_recipient_condition = cache
+    cache[cache_key] = state
+    return state
+
+
+def award_recipient_last_modified(request, *, pk=None, **kwargs):
+    """Return the latest filtered recipient timestamp for an Award."""
+    state = _award_recipient_conditional_state(
+        request,
+        pk=pk,
+        **kwargs,
+    )
+    if state is None:
+        return None
+    return state['recipient_modified']
+
+
+def award_recipient_etag(request, *, pk=None, **kwargs):
+    """Return an ETag for one filtered Award recipient page."""
+    state = _award_recipient_conditional_state(
+        request,
+        pk=pk,
+        **kwargs,
+    )
+    if state is None:
+        return None
+    latest = state['recipient_modified']
+    latest_repr = 'empty' if latest is None else latest.isoformat()
+    payload = f'{request.get_full_path()}::{latest_repr}'
+    return hashlib.sha256(payload.encode('utf-8')).hexdigest()
+
+
+AWARD_RECIPIENT_PREFETCH = GenericPrefetch(
+    'recipient',
+    (
+        Creator.objects.filter(deleted=False),
+        Issue.objects.filter(deleted=False).select_related('series'),
+        Series.objects.filter(deleted=False),
+        Story.objects.filter(deleted=False).select_related(
+            'issue',
+            'issue__series',
+        ),
+    ),
+)
+
+AWARD_RECIPIENT_SCHEMA_PARAMETERS = [
+    OpenApiParameter(
+        name='recipient_type',
+        type=str,
+        location=OpenApiParameter.QUERY,
+        enum=SUPPORTED_AWARD_RECIPIENT_TYPES,
+        description='Filter by generic recipient type.',
+    ),
+    OpenApiParameter(
+        name='award_year',
+        type=int,
+        location=OpenApiParameter.QUERY,
+        description='Filter by exact Award year.',
+    ),
+]
+
+
+class AwardViewSet(GCDBaseViewSet):
+    """Read-only Award endpoints for the public v2 API."""
+
+    queryset = Award.objects.order_by('name', 'id')
+    filter_backends = (DjangoFilterBackend,)
+    filterset_class = AwardFilterSet
+
+    def get_serializer_class(self):
+        """Select the list, detail, or recipient serializer by action."""
+        if self.action == 'retrieve':
+            return AwardSerializer
+        if self.action == 'recipients':
+            return AwardRecipientSerializer
+        return AwardListSerializer
+
+    @condition(
+        etag_func=award_etag,
+        last_modified_func=award_last_modified,
+    )
+    def list(self, request, *args, **kwargs):
+        """Return a filtered, paginated Award collection."""
+        return super().list(request, *args, **kwargs)
+
+    @condition(
+        etag_func=award_etag,
+        last_modified_func=award_last_modified,
+    )
+    def retrieve(self, request, *args, **kwargs):
+        """Return a single Award detail record."""
+        return super().retrieve(request, *args, **kwargs)
+
+    @extend_schema(
+        parameters=AWARD_RECIPIENT_SCHEMA_PARAMETERS,
+        responses=AwardRecipientSerializer(many=True),
+    )
+    @action(detail=True, methods=('get',))
+    @condition(
+        etag_func=award_recipient_etag,
+        last_modified_func=award_recipient_last_modified,
+    )
+    def recipients(self, request, *args, **kwargs):
+        """Return a filtered, paginated page of typed Award recipients."""
+        award = self.get_object()
+        queryset = (
+            _award_recipient_queryset(award.pk)
+            .select_related('content_type')
+            .prefetch_related(AWARD_RECIPIENT_PREFETCH)
+            .order_by('award_year', 'award_name', 'id')
+        )
+        filterset = AwardRecipientFilterSet(
+            request.query_params,
+            queryset=queryset,
+            request=request,
+        )
+        if not filterset.is_valid():
+            raise ValidationError(filterset.errors)
+
+        page = self.paginate_queryset(filterset.qs)
+        serializer = AwardRecipientSerializer(page, many=True)
+        return self.get_paginated_response(serializer.data)

--- a/apps/api_v2/views/awards.py
+++ b/apps/api_v2/views/awards.py
@@ -246,5 +246,5 @@ class AwardViewSet(GCDBaseViewSet):
             raise ValidationError(filterset.errors)
 
         page = self.paginate_queryset(filterset.qs)
-        serializer = AwardRecipientSerializer(page, many=True)
+        serializer = self.get_serializer(page, many=True)
         return self.get_paginated_response(serializer.data)

--- a/apps/api_v2/views/brand_groups.py
+++ b/apps/api_v2/views/brand_groups.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Viewsets for v2 brand group endpoints."""
+
+from django.db.models import Prefetch
+from django_filters.rest_framework import DjangoFilterBackend
+
+from apps.api_v2.filters.brand_groups import BrandGroupFilterSet
+from apps.api_v2.serializers.brand_groups import (
+    BrandGroupListSerializer,
+    BrandGroupSerializer,
+)
+from apps.api_v2.utils.conditional import (
+    condition,
+    make_etag,
+    make_last_modified,
+)
+from apps.api_v2.views import GCDBaseViewSet
+from apps.gcd.models import Brand, BrandGroup
+
+
+def _brand_group_filter_queryset(request, *, pk=None, **kwargs):
+    """Return brand groups scoped by request query parameters."""
+    del pk, kwargs
+    return BrandGroupFilterSet(
+        request.GET,
+        queryset=BrandGroup.objects.all(),
+    ).qs
+
+
+brand_group_last_modified = make_last_modified(
+    BrandGroup,
+    queryset_getter=_brand_group_filter_queryset,
+)
+brand_group_etag = make_etag(
+    BrandGroup,
+    queryset_getter=_brand_group_filter_queryset,
+)
+
+ACTIVE_BRAND_GROUP_EMBLEM_PREFETCH = Prefetch(
+    'brand_set',
+    queryset=Brand.objects.filter(deleted=False).order_by('name', 'id'),
+    to_attr='active_brand_group_emblem_list',
+)
+
+
+class BrandGroupViewSet(GCDBaseViewSet):
+    """Read-only brand group endpoints for the public v2 API."""
+
+    queryset = BrandGroup.objects.select_related('parent').order_by(
+        'name',
+        'id',
+    )
+    filter_backends = (DjangoFilterBackend,)
+    filterset_class = BrandGroupFilterSet
+
+    def get_queryset(self):
+        """Prefetch descriptive detail relationships when required."""
+        queryset = super().get_queryset()
+        if self.action == 'retrieve':
+            queryset = queryset.prefetch_related(
+                'keywords',
+                ACTIVE_BRAND_GROUP_EMBLEM_PREFETCH,
+            )
+        return queryset
+
+    def get_serializer_class(self):
+        """Use the full serializer only for detail responses."""
+        if self.action == 'retrieve':
+            return BrandGroupSerializer
+        return BrandGroupListSerializer
+
+    @condition(
+        etag_func=brand_group_etag,
+        last_modified_func=brand_group_last_modified,
+    )
+    def list(self, request, *args, **kwargs):
+        """Return a filtered, paginated brand group collection."""
+        return super().list(request, *args, **kwargs)
+
+    @condition(
+        etag_func=brand_group_etag,
+        last_modified_func=brand_group_last_modified,
+    )
+    def retrieve(self, request, *args, **kwargs):
+        """Return a single brand group detail record."""
+        return super().retrieve(request, *args, **kwargs)

--- a/apps/api_v2/views/brands.py
+++ b/apps/api_v2/views/brands.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Viewsets for v2 Brand endpoints."""
+
+from django.db.models import Prefetch
+from django_filters.rest_framework import DjangoFilterBackend
+
+from apps.api_v2.filters.brands import BrandFilterSet
+from apps.api_v2.serializers.brands import (
+    BrandListSerializer,
+    BrandSerializer,
+)
+from apps.api_v2.utils.conditional import (
+    condition,
+    make_etag,
+    make_last_modified,
+)
+from apps.api_v2.views import GCDBaseViewSet
+from apps.gcd.models import Brand, BrandGroup, BrandUse
+
+
+def _brand_filter_queryset(request, *, pk=None, **kwargs):
+    """Return Brands scoped by request query parameters."""
+    del pk, kwargs
+    return BrandFilterSet(
+        request.GET,
+        queryset=Brand.objects.all(),
+    ).qs
+
+
+brand_last_modified = make_last_modified(
+    Brand,
+    queryset_getter=_brand_filter_queryset,
+)
+brand_etag = make_etag(
+    Brand,
+    queryset_getter=_brand_filter_queryset,
+)
+
+ACTIVE_BRAND_GROUP_PREFETCH = Prefetch(
+    'group',
+    queryset=(
+        BrandGroup.objects.filter(
+            deleted=False,
+            parent__deleted=False,
+        )
+        .select_related('parent')
+        .order_by('parent__name', 'name', 'id')
+    ),
+    to_attr='active_brand_group_list',
+)
+ACTIVE_BRAND_USE_PREFETCH = Prefetch(
+    'in_use',
+    queryset=(
+        BrandUse.objects.filter(publisher__deleted=False)
+        .select_related('publisher')
+        .order_by('publisher__name', 'year_began', 'id')
+    ),
+    to_attr='active_brand_use_list',
+)
+
+
+class BrandViewSet(GCDBaseViewSet):
+    """Read-only Brand endpoints for the public v2 API."""
+
+    queryset = Brand.objects.order_by('name', 'id')
+    filter_backends = (DjangoFilterBackend,)
+    filterset_class = BrandFilterSet
+
+    def get_queryset(self):
+        """Prefetch descriptive detail relationships when required."""
+        queryset = super().get_queryset()
+        if self.action == 'retrieve':
+            queryset = queryset.prefetch_related(
+                'keywords',
+                ACTIVE_BRAND_GROUP_PREFETCH,
+                ACTIVE_BRAND_USE_PREFETCH,
+            )
+        return queryset
+
+    def get_serializer_class(self):
+        """Use the full serializer only for detail responses."""
+        if self.action == 'retrieve':
+            return BrandSerializer
+        return BrandListSerializer
+
+    @condition(
+        etag_func=brand_etag,
+        last_modified_func=brand_last_modified,
+    )
+    def list(self, request, *args, **kwargs):
+        """Return a filtered, paginated Brand collection."""
+        return super().list(request, *args, **kwargs)
+
+    @condition(
+        etag_func=brand_etag,
+        last_modified_func=brand_last_modified,
+    )
+    def retrieve(self, request, *args, **kwargs):
+        """Return a single Brand detail record."""
+        return super().retrieve(request, *args, **kwargs)

--- a/apps/api_v2/views/features.py
+++ b/apps/api_v2/views/features.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Viewsets for v2 Feature endpoints."""
+
+from django.db.models import Prefetch
+from django_filters.rest_framework import DjangoFilterBackend
+
+from apps.api_v2.filters.features import FeatureFilterSet
+from apps.api_v2.serializers.features import (
+    FeatureListSerializer,
+    FeatureSerializer,
+)
+from apps.api_v2.utils.conditional import (
+    condition,
+    make_etag,
+    make_last_modified,
+)
+from apps.api_v2.views import GCDBaseViewSet
+from apps.gcd.models import Feature, FeatureLogo, FeatureRelation
+
+
+def _feature_filter_queryset(request, *, pk=None, **kwargs):
+    """Return Features scoped by request query parameters."""
+    del pk, kwargs
+    return FeatureFilterSet(
+        request.GET,
+        queryset=Feature.objects.all(),
+        request=request,
+    ).qs
+
+
+feature_last_modified = make_last_modified(
+    Feature,
+    queryset_getter=_feature_filter_queryset,
+)
+feature_etag = make_etag(
+    Feature,
+    queryset_getter=_feature_filter_queryset,
+)
+
+ACTIVE_FEATURE_LOGO_PREFETCH = Prefetch(
+    'featurelogo_set',
+    queryset=FeatureLogo.objects.filter(deleted=False).order_by(
+        'sort_name',
+        'id',
+    ),
+    to_attr='active_feature_logo_list',
+)
+OUTGOING_FEATURE_RELATION_PREFETCH = Prefetch(
+    'to_related_feature',
+    queryset=(
+        FeatureRelation.objects.filter(
+            from_feature__deleted=False,
+            to_feature__deleted=False,
+        )
+        .select_related('relation_type', 'to_feature__feature_type')
+        .order_by(
+            'relation_type__name',
+            'to_feature__sort_name',
+            'id',
+        )
+    ),
+    to_attr='outgoing_feature_relation_list',
+)
+INCOMING_FEATURE_RELATION_PREFETCH = Prefetch(
+    'from_related_feature',
+    queryset=(
+        FeatureRelation.objects.filter(
+            from_feature__deleted=False,
+            to_feature__deleted=False,
+        )
+        .select_related('relation_type', 'from_feature__feature_type')
+        .order_by(
+            'relation_type__name',
+            'from_feature__sort_name',
+            'id',
+        )
+    ),
+    to_attr='incoming_feature_relation_list',
+)
+
+
+class FeatureViewSet(GCDBaseViewSet):
+    """Read-only Feature endpoints for the public v2 API."""
+
+    queryset = Feature.objects.select_related(
+        'feature_type',
+        'language',
+    ).order_by(
+        'sort_name',
+        'disambiguation',
+        'language__code',
+        'id',
+    )
+    filter_backends = (DjangoFilterBackend,)
+    filterset_class = FeatureFilterSet
+
+    def get_queryset(self):
+        """Prefetch descriptive detail relationships when required."""
+        queryset = super().get_queryset()
+        if self.action == 'retrieve':
+            queryset = queryset.prefetch_related(
+                'keywords',
+                ACTIVE_FEATURE_LOGO_PREFETCH,
+                OUTGOING_FEATURE_RELATION_PREFETCH,
+                INCOMING_FEATURE_RELATION_PREFETCH,
+            )
+        return queryset
+
+    def get_serializer_class(self):
+        """Use the full serializer only for detail responses."""
+        if self.action == 'retrieve':
+            return FeatureSerializer
+        return FeatureListSerializer
+
+    @condition(
+        etag_func=feature_etag,
+        last_modified_func=feature_last_modified,
+    )
+    def list(self, request, *args, **kwargs):
+        """Return a filtered, paginated Feature collection."""
+        return super().list(request, *args, **kwargs)
+
+    @condition(
+        etag_func=feature_etag,
+        last_modified_func=feature_last_modified,
+    )
+    def retrieve(self, request, *args, **kwargs):
+        """Return a single Feature detail record."""
+        return super().retrieve(request, *args, **kwargs)

--- a/apps/api_v2/views/indicia_printers.py
+++ b/apps/api_v2/views/indicia_printers.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Viewsets for v2 indicia printer endpoints."""
+
+from django_filters.rest_framework import DjangoFilterBackend
+
+from apps.api_v2.filters.indicia_printers import IndiciaPrinterFilterSet
+from apps.api_v2.serializers.indicia_printers import (
+    IndiciaPrinterListSerializer,
+    IndiciaPrinterSerializer,
+)
+from apps.api_v2.utils.conditional import (
+    condition,
+    make_etag,
+    make_last_modified,
+)
+from apps.api_v2.views import GCDBaseViewSet
+from apps.gcd.models import IndiciaPrinter
+
+
+def _indicia_printer_filter_queryset(request, *, pk=None, **kwargs):
+    """Return indicia printers scoped by request query parameters."""
+    del pk, kwargs
+    return IndiciaPrinterFilterSet(
+        request.GET,
+        queryset=IndiciaPrinter.objects.all(),
+    ).qs
+
+
+indicia_printer_last_modified = make_last_modified(
+    IndiciaPrinter,
+    queryset_getter=_indicia_printer_filter_queryset,
+)
+indicia_printer_etag = make_etag(
+    IndiciaPrinter,
+    queryset_getter=_indicia_printer_filter_queryset,
+)
+
+
+class IndiciaPrinterViewSet(GCDBaseViewSet):
+    """Read-only indicia printer endpoints for the public v2 API."""
+
+    queryset = IndiciaPrinter.objects.select_related(
+        'parent',
+        'country',
+    ).order_by('name', 'id')
+    filter_backends = (DjangoFilterBackend,)
+    filterset_class = IndiciaPrinterFilterSet
+
+    def get_queryset(self):
+        """Prefetch descriptive detail relationships when required."""
+        queryset = super().get_queryset()
+        if self.action == 'retrieve':
+            queryset = queryset.prefetch_related('keywords')
+        return queryset
+
+    def get_serializer_class(self):
+        """Use the full serializer only for detail responses."""
+        if self.action == 'retrieve':
+            return IndiciaPrinterSerializer
+        return IndiciaPrinterListSerializer
+
+    @condition(
+        etag_func=indicia_printer_etag,
+        last_modified_func=indicia_printer_last_modified,
+    )
+    def list(self, request, *args, **kwargs):
+        """Return a filtered, paginated indicia printer collection."""
+        return super().list(request, *args, **kwargs)
+
+    @condition(
+        etag_func=indicia_printer_etag,
+        last_modified_func=indicia_printer_last_modified,
+    )
+    def retrieve(self, request, *args, **kwargs):
+        """Return a single indicia printer detail record."""
+        return super().retrieve(request, *args, **kwargs)

--- a/apps/api_v2/views/indicia_publishers.py
+++ b/apps/api_v2/views/indicia_publishers.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Viewsets for v2 indicia publisher endpoints."""
+
+from django_filters.rest_framework import DjangoFilterBackend
+
+from apps.api_v2.filters.indicia_publishers import (
+    IndiciaPublisherFilterSet,
+)
+from apps.api_v2.serializers.indicia_publishers import (
+    IndiciaPublisherListSerializer,
+    IndiciaPublisherSerializer,
+)
+from apps.api_v2.utils.conditional import (
+    condition,
+    make_etag,
+    make_last_modified,
+)
+from apps.api_v2.views import GCDBaseViewSet
+from apps.gcd.models import IndiciaPublisher
+
+
+def _indicia_publisher_filter_queryset(request, *, pk=None, **kwargs):
+    """Return indicia publishers scoped by request query parameters."""
+    del pk, kwargs
+    return IndiciaPublisherFilterSet(
+        request.GET,
+        queryset=IndiciaPublisher.objects.all(),
+    ).qs
+
+
+indicia_publisher_last_modified = make_last_modified(
+    IndiciaPublisher,
+    queryset_getter=_indicia_publisher_filter_queryset,
+)
+indicia_publisher_etag = make_etag(
+    IndiciaPublisher,
+    queryset_getter=_indicia_publisher_filter_queryset,
+)
+
+
+class IndiciaPublisherViewSet(GCDBaseViewSet):
+    """Read-only indicia publisher endpoints for the public v2 API."""
+
+    queryset = IndiciaPublisher.objects.select_related(
+        'parent',
+        'country',
+    ).order_by('name', 'id')
+    filter_backends = (DjangoFilterBackend,)
+    filterset_class = IndiciaPublisherFilterSet
+
+    def get_queryset(self):
+        """Prefetch descriptive detail relationships when required."""
+        queryset = super().get_queryset()
+        if self.action == 'retrieve':
+            queryset = queryset.prefetch_related('keywords')
+        return queryset
+
+    def get_serializer_class(self):
+        """Use the full serializer only for detail responses."""
+        if self.action == 'retrieve':
+            return IndiciaPublisherSerializer
+        return IndiciaPublisherListSerializer
+
+    @condition(
+        etag_func=indicia_publisher_etag,
+        last_modified_func=indicia_publisher_last_modified,
+    )
+    def list(self, request, *args, **kwargs):
+        """Return a filtered, paginated indicia publisher collection."""
+        return super().list(request, *args, **kwargs)
+
+    @condition(
+        etag_func=indicia_publisher_etag,
+        last_modified_func=indicia_publisher_last_modified,
+    )
+    def retrieve(self, request, *args, **kwargs):
+        """Return a single indicia publisher detail record."""
+        return super().retrieve(request, *args, **kwargs)

--- a/apps/api_v2/views/series_bonds.py
+++ b/apps/api_v2/views/series_bonds.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Grand Comics Database contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Viewsets for v2 Series Bond endpoints."""
+
+from django_filters.rest_framework import DjangoFilterBackend
+
+from apps.api_v2.filters.series_bonds import SeriesBondFilterSet
+from apps.api_v2.serializers.series_bonds import (
+    SeriesBondListSerializer,
+    SeriesBondSerializer,
+)
+from apps.api_v2.utils.conditional import (
+    condition,
+    make_etag,
+    make_last_modified,
+)
+from apps.api_v2.views import GCDBaseViewSet
+from apps.gcd.models import SeriesBond
+
+
+def _series_bond_filter_queryset(request, *, pk=None, **kwargs):
+    """Return Series Bonds scoped by request query parameters."""
+    del pk, kwargs
+    return SeriesBondFilterSet(
+        request.GET,
+        queryset=SeriesBond.objects.all(),
+    ).qs
+
+
+series_bond_last_modified = make_last_modified(
+    SeriesBond,
+    soft_delete=False,
+    queryset_getter=_series_bond_filter_queryset,
+)
+series_bond_etag = make_etag(
+    SeriesBond,
+    soft_delete=False,
+    queryset_getter=_series_bond_filter_queryset,
+)
+
+
+class SeriesBondViewSet(GCDBaseViewSet):
+    """Read-only Series Bond endpoints for the public v2 API."""
+
+    queryset = SeriesBond.objects.select_related(
+        'origin',
+        'origin_issue',
+        'target',
+        'target_issue',
+        'bond_type',
+    ).order_by('id')
+    filter_backends = (DjangoFilterBackend,)
+    filterset_class = SeriesBondFilterSet
+
+    def get_serializer_class(self):
+        """Use the full serializer only for detail responses."""
+        if self.action == 'retrieve':
+            return SeriesBondSerializer
+        return SeriesBondListSerializer
+
+    @condition(
+        etag_func=series_bond_etag,
+        last_modified_func=series_bond_last_modified,
+    )
+    def list(self, request, *args, **kwargs):
+        """Return a filtered, paginated Series Bond collection."""
+        return super().list(request, *args, **kwargs)
+
+    @condition(
+        etag_func=series_bond_etag,
+        last_modified_func=series_bond_last_modified,
+    )
+    def retrieve(self, request, *args, **kwargs):
+        """Return a single Series Bond detail record."""
+        return super().retrieve(request, *args, **kwargs)

--- a/apps/gcd/migrations/0074_series_bond_timestamps.py
+++ b/apps/gcd/migrations/0074_series_bond_timestamps.py
@@ -1,0 +1,71 @@
+from django.db import migrations, models
+from django.db.models import OuterRef, Subquery, Value
+from django.db.models.functions import Coalesce
+from django.utils import timezone
+
+
+APPROVED = 5
+
+
+def backfill_series_bond_timestamps(apps, schema_editor):
+    """Backfill known revision dates or a shared tracking baseline."""
+    series_bond = apps.get_model('gcd', 'SeriesBond')
+    series_bond_revision = apps.get_model('oi', 'SeriesBondRevision')
+    database = schema_editor.connection.alias
+    baseline = timezone.now()
+    approved_revisions = series_bond_revision.objects.using(database).filter(
+        series_bond_id=OuterRef('pk'),
+        changeset__state=APPROVED,
+    )
+    earliest_created = approved_revisions.order_by(
+        'created',
+        'id',
+    ).values('created')[:1]
+    latest_modified = approved_revisions.order_by(
+        '-created',
+        '-id',
+    ).values('modified')[:1]
+    baseline_value = Value(
+        baseline,
+        output_field=models.DateTimeField(),
+    )
+
+    series_bond.objects.using(database).update(
+        created=Coalesce(Subquery(earliest_created), baseline_value),
+        modified=Coalesce(Subquery(latest_modified), baseline_value),
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('gcd', '0073_merge_api_v2_beta'),
+        ('oi', '0062_add_character_order'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='seriesbond',
+            name='created',
+            field=models.DateTimeField(null=True),
+        ),
+        migrations.AddField(
+            model_name='seriesbond',
+            name='modified',
+            field=models.DateTimeField(db_index=True, null=True),
+        ),
+        migrations.RunPython(
+            backfill_series_bond_timestamps,
+            migrations.RunPython.noop,
+        ),
+        migrations.AlterField(
+            model_name='seriesbond',
+            name='created',
+            field=models.DateTimeField(auto_now_add=True),
+        ),
+        migrations.AlterField(
+            model_name='seriesbond',
+            name='modified',
+            field=models.DateTimeField(auto_now=True, db_index=True),
+        ),
+    ]

--- a/apps/gcd/models/seriesbond.py
+++ b/apps/gcd/models/seriesbond.py
@@ -2,6 +2,8 @@
 from django.db import models
 from functools import total_ordering
 
+from .gcddata import GcdLink
+
 BOND_TRACKING = {1, 2, 3, 4, 5, 6, 7}
 SUBNUMBER_TRACKING = 4
 MERGE_TRACKING = {5, 6}
@@ -22,7 +24,7 @@ class SeriesBondType(models.Model):
         return self.description
 
 
-class SeriesBond(models.Model):
+class SeriesBond(GcdLink):
     class Meta:
         app_label = 'gcd'
         db_table = 'gcd_series_bond'
@@ -43,10 +45,6 @@ class SeriesBond(models.Model):
 
     # Fields related to change management.
     reserved = models.BooleanField(default=False, db_index=True)
-
-    @property
-    def modified(self):
-        return self.revisions.filter(changeset__state=5).latest().modified
 
     # we check for deleted in the oi for models, so set to False
     deleted = False


### PR DESCRIPTION
## Summary

- add public API v2 list/detail endpoints for Indicia Publishers, Indicia
  Printers, Brand Groups, Brands, Features, Awards, and Series Bonds
- expose active publisher-family relationships, normalized directional Feature
  relations, and a paginated typed Award recipient action
- add persistent Series Bond timestamps with approved-revision backfill when
  available and a documented migration-time baseline otherwise
- keep every Phase 4 route on the public surface only, with no v1 or MyComics
  route changes

## API additions

- `/api/v2/indicia-publishers/`
- `/api/v2/indicia-printers/`
- `/api/v2/brand-groups/`
- `/api/v2/brands/`
- `/api/v2/features/`
- `/api/v2/awards/`
- `/api/v2/awards/{id}/recipients/`
- `/api/v2/series-bonds/`

Each root endpoint includes list/detail serializers, representative filters,
pagination, anonymous read access, conditional request support, OpenAPI schema
coverage, active-only behavior where the model supports soft deletion, and
fixed query-count regression tests.

## Data migration

`gcd.0074_series_bond_timestamps` adds persistent `created` and indexed
`modified` timestamps to Series Bonds. Existing rows use their earliest and
latest approved revision timestamps when those revisions exist. Rows without
approved history receive one shared migration-time value that marks the start
of reliable timestamp tracking.

The local production-copy database had no Series Bond revision rows, so all
6,556 legacy rows received the documented baseline
`2026-07-27T20:34:17.981447Z`. The migration completed with zero null values.

## Validation

- `ruff check apps/api_v2/`
- `ruff format --check apps/api_v2/`
- `python manage.py check`
- `python manage.py migrate --check`
- `python -m pytest apps/api_v2/tests/ -v --tb=short`
  (`314 passed`, 24 existing warnings)
- public/MyComics routing and OpenAPI schema regression coverage
- Series Bond migration history and no-history fallback regression coverage

## Production-copy manual baseline

- all 60 focused JSON requests returned `200`
- all 56 focused conditional replays returned `304`
- all 25 combined browsable/API-documentation requests returned `200`
- all 21 combined conditional replays returned `304`
- all seven active row counts and the high-cardinality relationship payloads
  matched direct production-copy database measurements
- focused maximum response times were about 17 ms for the publisher family,
  111 ms for Features, 24 ms for Awards, and 23 ms for Series Bonds

Final `EXPLAIN` review found the Brand relationship filters, Award recipient
queries, and Series Bond relationship filters using existing indexes. Feature
broad and `icontains` scans remained acceptable at the observed 47,648-row
scale, so no additional performance migration is included.
