### PR TITLE
Fix character-order revision commit handling

### DIFF
--- a/apps/oi/models.py
+++ b/apps/oi/models.py
@@ -5560,7 +5560,7 @@ class CharacterOrderRevision(Revision):
         current_orders = {
             current_order.story_character_id: current_order
             for current_order in CharacterThroughOrder.objects.filter(
-                order=self.character_order)
+                order_id=self.character_order_id)
         }
         revision_orders = CharacterThroughOrderRevision.objects.filter(
             order=self).select_related('story_character')
@@ -5577,7 +5577,7 @@ class CharacterOrderRevision(Revision):
         removed_ids = current_orders.keys() - desired_orders.keys()
         if removed_ids:
             CharacterThroughOrder.objects.filter(
-                order=self.character_order,
+                order_id=self.character_order_id,
                 story_character_id__in=removed_ids).delete()
 
         changed_orders = []
@@ -5590,7 +5590,7 @@ class CharacterOrderRevision(Revision):
                     changed_orders.append(current_order)
             else:
                 new_orders.append(CharacterThroughOrder(
-                    order=self.character_order,
+                    order_id=self.character_order_id,
                     story_character_id=story_character_id,
                     order_code=order_code))
 

--- a/apps/oi/models.py
+++ b/apps/oi/models.py
@@ -54,7 +54,8 @@ from apps.gcd.models.gcddata import GcdData, GcdLink
 from apps.gcd.models.issue import issue_descriptor
 from apps.gcd.models.story import show_feature, show_feature_as_text, \
                                   show_characters, show_title, \
-                                  _get_civilian_identity
+                                  _get_civilian_identity, \
+                                  CharacterThroughOrder
 from apps.gcd.models.image import CropToFace
 from apps.indexer.views import ErrorWithMessage
 
@@ -5556,27 +5557,48 @@ class CharacterOrderRevision(Revision):
         self.story_revision = kwargs['story_revision']
 
     def _post_save_object(self, changes):
-        characters = self.character_order.characters.all()
-        character_revisions = self.character_revisions.all()
-        for character in characters:
-            if not character_revisions.filter(
-              character__id=character.id,
-              universe=character.universe).count():
-                self.character_order.characters.remove(character)
+        current_orders = {
+            current_order.story_character_id: current_order
+            for current_order in CharacterThroughOrder.objects.filter(
+                order=self.character_order)
+        }
+        revision_orders = CharacterThroughOrderRevision.objects.filter(
+            order=self).select_related('story_character')
+        desired_orders = {}
+        for revision_order in revision_orders:
+            story_character_id = \
+                revision_order.story_character.story_character_id
+            if story_character_id is None:
+                raise IntegrityError(
+                    'Character order revision contains an uncommitted '
+                    'story character revision.')
+            desired_orders[story_character_id] = revision_order.order_code
+
+        removed_ids = current_orders.keys() - desired_orders.keys()
+        if removed_ids:
+            CharacterThroughOrder.objects.filter(
+                order=self.character_order,
+                story_character_id__in=removed_ids).delete()
+
+        changed_orders = []
+        new_orders = []
+        for story_character_id, order_code in desired_orders.items():
+            if story_character_id in current_orders:
+                current_order = current_orders[story_character_id]
+                if current_order.order_code != order_code:
+                    current_order.order_code = order_code
+                    changed_orders.append(current_order)
             else:
-                character.order_code = character_revisions.get(
-                  character__id=character.id,
-                  universe=character.universe).order_code
-                character.save()
-        for character_revision in character_revisions:
-            if not characters.filter(
-              id=character_revision.character.id,
-              universe=character_revision.universe).exists():
-                order_code = character_revision\
-                  .characterthroughorderrevision_set.get(order=self).order_code
-                self.character_order.characters.add(
-                  character_revision.story_character,
-                  through_defaults={'order_code': order_code})
+                new_orders.append(CharacterThroughOrder(
+                    order=self.character_order,
+                    story_character_id=story_character_id,
+                    order_code=order_code))
+
+        if changed_orders:
+            CharacterThroughOrder.objects.bulk_update(
+                changed_orders, ['order_code'])
+        if new_orders:
+            CharacterThroughOrder.objects.bulk_create(new_orders)
 
     @property
     def ordered_characters(self):

--- a/apps/oi/tests/db/test_character_order_revision.py
+++ b/apps/oi/tests/db/test_character_order_revision.py
@@ -167,6 +167,8 @@ def test_reconciliation_uses_bounded_queries(large_character_order_world):
         for number in range(10)
     ]
     revision = revision_with_order(*desired_order)
+    # Exercise reconciliation without a cached CharacterOrder relation.
+    revision = CharacterOrderRevision.objects.get(pk=revision.pk)
 
     with CaptureQueriesContext(connection) as queries:
         revision._post_save_object({})

--- a/apps/oi/tests/db/test_character_order_revision.py
+++ b/apps/oi/tests/db/test_character_order_revision.py
@@ -1,0 +1,175 @@
+# -*- coding: utf-8 -*-
+
+
+import pytest
+
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
+from apps.gcd.models import (
+    Character, CharacterNameDetail, CharacterOrder, CharacterOrderType,
+    StoryCharacter)
+from apps.gcd.models.story import CharacterThroughOrder
+from apps.oi.models import (
+    CharacterOrderRevision, CharacterThroughOrderRevision, Changeset,
+    StoryCharacterRevision, StoryRevision, CTYPES)
+from apps.oi import states
+
+
+def make_character_order_world(any_added_story_rev, any_added_story,
+                               any_language, any_indexer, extra_count=0):
+    order_type = CharacterOrderType.objects.create(name='Test order')
+    character_order = CharacterOrder.objects.create(
+        story=any_added_story, type=order_type)
+
+    appearances = {}
+    approved_character_revisions = {}
+    character_names = ('Alpha', 'Beta', 'Gamma') + tuple(
+        'Extra %s' % number for number in range(extra_count))
+    for name in character_names:
+        character = Character.objects.create(
+            name=name,
+            sort_name=name,
+            disambiguation='',
+            language=any_language,
+            description='',
+            notes='')
+        name_detail = CharacterNameDetail.objects.create(
+            name=name,
+            sort_name=name,
+            character=character,
+            is_official_name=True)
+        appearance = StoryCharacter.objects.create(
+            character=name_detail,
+            story=any_added_story,
+            notes='')
+        appearances[name] = appearance
+        approved_character_revisions[name] = \
+            StoryCharacterRevision.objects.create(
+                changeset=any_added_story_rev.changeset,
+                committed=True,
+                story_character=appearance,
+                character=name_detail,
+                story_revision=any_added_story_rev,
+                notes='')
+
+    current_order = [('Alpha', 10), ('Beta', 20)] + [
+        ('Extra %s' % number, 30 + number * 10)
+        for number in range(extra_count)
+    ]
+    for name, order_code in current_order:
+        CharacterThroughOrder.objects.create(
+            order=character_order,
+            story_character=appearances[name],
+            order_code=order_code)
+
+    approved_order_revision = CharacterOrderRevision.objects.create(
+        changeset=any_added_story_rev.changeset,
+        committed=True,
+        character_order=character_order,
+        story_revision=any_added_story_rev,
+        type=order_type)
+    for name, order_code in current_order:
+        CharacterThroughOrderRevision.objects.create(
+            order=approved_order_revision,
+            story_character=approved_character_revisions[name],
+            order_code=order_code)
+
+    def revision_with_order(*ordered_names):
+        changeset = Changeset.objects.create(
+            state=states.OPEN,
+            indexer=any_indexer,
+            change_type=CTYPES['issue'])
+        story_revision = StoryRevision.clone(
+            any_added_story, changeset=changeset)
+        character_revisions = {
+            name: StoryCharacterRevision.clone(
+                appearance,
+                changeset=changeset,
+                story_revision=story_revision)
+            for name, appearance in appearances.items()
+        }
+        order_revision = CharacterOrderRevision.clone(
+            character_order,
+            changeset=changeset,
+            story_revision=story_revision)
+        for name, order_code in ordered_names:
+            CharacterThroughOrderRevision.objects.create(
+                order=order_revision,
+                story_character=character_revisions[name],
+                order_code=order_code)
+        return order_revision
+
+    return character_order, appearances, revision_with_order
+
+
+@pytest.fixture
+def character_order_world(any_added_story_rev, any_added_story, any_language,
+                          any_indexer):
+    return make_character_order_world(
+        any_added_story_rev, any_added_story, any_language, any_indexer)
+
+
+@pytest.fixture
+def large_character_order_world(any_added_story_rev, any_added_story,
+                                any_language, any_indexer):
+    return make_character_order_world(
+        any_added_story_rev, any_added_story, any_language, any_indexer,
+        extra_count=10)
+
+
+def order_codes(character_order):
+    return dict(CharacterThroughOrder.objects.filter(
+        order=character_order).values_list(
+            'story_character__character__name', 'order_code'))
+
+
+@pytest.mark.django_db
+def test_commit_adds_character_to_order(character_order_world):
+    character_order, _, revision_with_order = character_order_world
+    revision = revision_with_order(
+        ('Alpha', 10), ('Beta', 20), ('Gamma', 30))
+
+    revision.commit_to_display()
+
+    assert order_codes(character_order) == {
+        'Alpha': 10,
+        'Beta': 20,
+        'Gamma': 30,
+    }
+
+
+@pytest.mark.django_db
+def test_commit_removes_character_from_order(character_order_world):
+    character_order, _, revision_with_order = character_order_world
+    revision = revision_with_order(('Beta', 20),)
+
+    revision.commit_to_display()
+
+    assert order_codes(character_order) == {'Beta': 20}
+
+
+@pytest.mark.django_db
+def test_commit_updates_character_order_codes(character_order_world):
+    character_order, _, revision_with_order = character_order_world
+    revision = revision_with_order(('Beta', 10), ('Alpha', 20))
+
+    revision.commit_to_display()
+
+    assert order_codes(character_order) == {'Alpha': 20, 'Beta': 10}
+
+
+@pytest.mark.django_db
+def test_reconciliation_uses_bounded_queries(large_character_order_world):
+    _, _, revision_with_order = large_character_order_world
+    desired_order = [('Beta', 5), ('Gamma', 10)] + [
+        ('Extra %s' % number, 15 + number * 5)
+        for number in range(10)
+    ]
+    revision = revision_with_order(*desired_order)
+
+    with CaptureQueriesContext(connection) as queries:
+        revision._post_save_object({})
+
+    # Two reads plus at most one batched delete, update, and insert.
+    assert len(queries) <= 5


### PR DESCRIPTION
## Summary

- reconcile character-order revisions through `CharacterThroughOrder` and `CharacterThroughOrderRevision`
- batch character removals, order-code updates, and additions instead of querying once per character
- add regression coverage for additions, removals, reordered codes, and bounded query count

## Root cause

The commit path treated `StoryCharacter` and `StoryCharacterRevision` as if they contained `order_code`. That value belongs to the explicit through rows, so existing code could raise `AttributeError`, save the wrong model, and fail to persist order changes.

## Impact

Committing a character-order revision now applies the revision through rows to the display through rows, keyed by the persistent story-character appearance. The reconciliation uses two reads and at most one batched delete, update, and insert.

## Validation

- `pytest -q apps/oi/tests/db/test_character_order_revision.py --reuse-db` — 4 passed
- `pytest -q apps/oi/tests --reuse-db` — 257 passed, 9 existing warnings
- `pytest -q --reuse-db` — 452 passed, 9 existing warnings
- scoped `flake8`, Python compilation, and `git diff --check`

## Scope

The unsaved-form-instance concern from the original issue is not changed, following Jochen's clarification that there are no unsaved instances on this path. This PR contains no schema or migration changes.

Closes #730
