### PR TITLE
Avoid duplicate active-name query in creator name handling

### DIFF
--- a/apps/gcd/models/creator.py
+++ b/apps/gcd/models/creator.py
@@ -172,10 +172,12 @@ class CreatorNameDetail(GcdData):
                     as_name = self.creator_relation.get().to_creator\
                                   .active_names().get(is_official_name=True)
                     if as_name != self.name:
-                        if as_name.creator.active_names().filter(
-                          name=self.name):
-                            as_name = as_name.creator.active_names().filter(
-                              name=self.name)[0]
+                        matching_name = (
+                            as_name.creator.active_names()
+                            .filter(name=self.name)
+                            .first())
+                        if matching_name:
+                            as_name = matching_name
                 else:
                     # handles case of house name with different spellings,
                     # show only the name as entered, not also official name

--- a/apps/gcd/tests/test_creator.py
+++ b/apps/gcd/tests/test_creator.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+
+from types import SimpleNamespace
+
+import mock
+
+from apps.gcd.models.creator import (
+    Creator, CreatorNameDetail, NAME_TYPES, NameType)
+
+
+def _house_name_credit(matching_name):
+    creator = Creator(gcd_official_name='Credited Creator',
+                      disambiguation='')
+    house_name = CreatorNameDetail(
+        name='House Alias',
+        creator=creator,
+        type=NameType(id=NAME_TYPES['house']),
+        is_official_name=False)
+    credit = SimpleNamespace(
+        is_credited=True,
+        credited_as='',
+        uncertain=False,
+        creator=house_name,
+        is_sourced=False,
+        credit_name='')
+
+    active_names = mock.MagicMock()
+    target_creator = mock.MagicMock()
+    official_name = SimpleNamespace(
+        name='Official House Name', creator=target_creator)
+    active_names.get.return_value = official_name
+    active_names.filter.return_value.first.return_value = matching_name
+    active_names.filter.return_value.__bool__.return_value = \
+        matching_name is not None
+    target_creator.active_names.return_value = active_names
+
+    relation_manager = mock.MagicMock()
+    relation_manager.filter.return_value.exists.return_value = True
+    relation_manager.get.return_value.to_creator = target_creator
+
+    return house_name, credit, relation_manager, active_names
+
+
+def test_display_credit_queries_matching_house_name_once():
+    matching_name = SimpleNamespace(name='House Alias')
+    house_name, credit, relation_manager, active_names = \
+        _house_name_credit(matching_name)
+
+    with mock.patch.object(
+      CreatorNameDetail, 'creator_relation',
+      new_callable=mock.PropertyMock, return_value=relation_manager):
+        credit_text = house_name.display_credit(credit, url=False)
+
+    assert credit_text == \
+        'Credited Creator (under house name House Alias)'
+    active_names.filter.assert_called_once_with(name='House Alias')
+
+
+def test_display_credit_keeps_official_house_name_without_match():
+    house_name, credit, relation_manager, active_names = \
+        _house_name_credit(None)
+
+    with mock.patch.object(
+      CreatorNameDetail, 'creator_relation',
+      new_callable=mock.PropertyMock, return_value=relation_manager):
+        credit_text = house_name.display_credit(credit, url=False)
+
+    assert credit_text == \
+        'Credited Creator (under house name Official House Name)'
+    active_names.filter.assert_called_once_with(name='House Alias')

--- a/apps/gcd/tests/test_creator.py
+++ b/apps/gcd/tests/test_creator.py
@@ -30,8 +30,6 @@ def _house_name_credit(matching_name):
         name='Official House Name', creator=target_creator)
     active_names.get.return_value = official_name
     active_names.filter.return_value.first.return_value = matching_name
-    active_names.filter.return_value.__bool__.return_value = \
-        matching_name is not None
     target_creator.active_names.return_value = active_names
 
     relation_manager = mock.MagicMock()


### PR DESCRIPTION
## Summary

- evaluate the matching active-name queryset once with `.first()`
- reuse the matching creator name when present
- preserve the official house-name fallback when no match exists
- add focused coverage for both branches

## Root cause

`CreatorNameDetail.display_credit()` evaluated the same filtered active-name queryset once for truthiness and again to retrieve its first result. That issued two equivalent database queries on the matching house-name path.

## Impact

House-name credit rendering now performs one matching-name lookup without changing the rendered result or fallback behavior. This PR has no schema or migration changes.

## Validation

- `pytest -q apps/gcd/tests/test_creator.py` — 2 passed
- `pytest -q apps/gcd/tests` — 183 passed, 9 existing warnings
- `pytest -q` — 450 passed, 18 existing warnings
- Django system check, Python compilation, focused flake8, and `git diff --check` passed

Closes #732
