### PR TITLE
Show reviewing changeset states on mobile devices

### DIFF
--- a/apps/oi/tests/test_standard_queues_template.py
+++ b/apps/oi/tests/test_standard_queues_template.py
@@ -1,0 +1,69 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+from django.template.loader import render_to_string
+
+from apps.oi import states
+
+
+class ChangesetList(list):
+    def count(self):
+        return len(self)
+
+
+def render_queue(changeset_state, queue_name='reviews'):
+    changeset = SimpleNamespace(
+        id=123,
+        state=changeset_state,
+        display_state=states.DISPLAY_NAME[changeset_state],
+        country=None,
+        queue_name='Northstar Comics #12',
+        changeset_action='',
+        queue_descriptor='',
+        indexer=SimpleNamespace(indexer=None),
+        approver=SimpleNamespace(indexer=None),
+        modified=datetime(2026, 8, 12, tzinfo=timezone.utc),
+    )
+    context = {
+        'actions': 'oi/bits/approval_actions.html',
+        'countries': {},
+        'country_names': {},
+        'data': [{
+            'object_name': 'Issues',
+            'changesets': ChangesetList([changeset]),
+        }],
+        'link_target': 'preview',
+        'perms': SimpleNamespace(
+            indexer=SimpleNamespace(can_approve=False)),
+        'queue_name': queue_name,
+        'states': states,
+        'user': SimpleNamespace(
+            indexer=SimpleNamespace(collapse_compare_view=False)),
+    }
+    return render_to_string('oi/bits/standard_queues.html', context)
+
+
+@pytest.mark.parametrize(
+    ('changeset_state', 'label', 'classes'),
+    (
+        (states.OPEN, 'EDITING', 'bg-index-status-edit'),
+        (states.DISCUSSED, 'IN DISCUSSION',
+         'bg-index-status-in-queue border border-gray-400'),
+        (states.REVIEWING, 'UNDER REVIEW', 'bg-index-status-in-queue'),
+    ),
+)
+def test_reviewing_queue_shows_mobile_state_badge(
+        changeset_state, label, classes):
+    rendered = render_queue(changeset_state)
+
+    assert label in rendered
+    assert 'sm:hidden block w-fit' in rendered
+    assert classes in rendered
+
+
+def test_mobile_state_badge_is_limited_to_reviewing_queue():
+    rendered = render_queue(states.REVIEWING, queue_name='pending')
+
+    assert 'UNDER REVIEW' not in rendered
+    assert 'sm:hidden block w-fit' not in rendered

--- a/templates/oi/bits/standard_queues.html
+++ b/templates/oi/bits/standard_queues.html
@@ -47,6 +47,11 @@
     </td>
         {% endif %}
     <td>
+        {% if queue_name == 'reviews' %}
+      <span class="sm:hidden block w-fit mb-0.5 rounded px-1 py-0.5 text-sm font-bold text-black {% if changeset.state == states.OPEN %}bg-index-status-edit{% elif changeset.state == states.DISCUSSED %}bg-index-status-in-queue border border-gray-400{% else %}bg-index-status-in-queue{% endif %}">
+        {{ changeset.display_state|upper }}
+      </span>
+        {% endif %}
         {% if link_target == 'preview' or changeset.state == states.PENDING or changeset.state == states.REVIEWING or changeset.state == states.DISCUSSED %}
       <a href="{% url 'compare' id=changeset.id %}{% if user.indexer.collapse_compare_view %}?collapse=1{% endif %}">
         {% else %}

--- a/templates/oi/bits/standard_queues.html
+++ b/templates/oi/bits/standard_queues.html
@@ -48,7 +48,16 @@
         {% endif %}
     <td>
         {% if queue_name == 'reviews' %}
-      <span class="sm:hidden block w-fit mb-0.5 rounded px-1 py-0.5 text-sm font-bold text-black {% if changeset.state == states.OPEN %}bg-index-status-edit{% elif changeset.state == states.DISCUSSED %}bg-index-status-in-queue border border-gray-400{% else %}bg-index-status-in-queue{% endif %}">
+      <span
+        class="sm:hidden block w-fit mb-0.5 rounded px-1 py-0.5
+               text-sm font-bold text-black
+               {% if changeset.state == states.OPEN %}
+                 bg-index-status-edit
+               {% elif changeset.state == states.DISCUSSED %}
+                 bg-index-status-in-queue border border-gray-400
+               {% else %}
+                 bg-index-status-in-queue
+               {% endif %}">
         {{ changeset.display_state|upper }}
       </span>
         {% endif %}


### PR DESCRIPTION
## Summary

Add compact, mobile-only state badges to the Changes Under Review queue.

The badges make it possible to distinguish changesets that are:

- Under Review
- Editing
- In Discussion

## Motivation

On portrait-oriented mobile screens, the State column is hidden to keep the reviewing queue usable within the available width. This also removes information reviewers need when deciding which changeset to open. At least, I feel like I need it.

Displaying the state inside the Change cell keeps that information visible without adding another mobile table column or causing horizontal scrolling.

## Changes

- Display an uppercase state badge above each changeset name on the Reviewing queue at widths below 640px.
- Use the existing project status palette:
  - Pink for Editing
  - Orange for Under Review
  - Orange with an outline for In Discussion
- Keep the existing desktop State column and desktop layout unchanged.
- Limit the new badges to the Reviewing queue.
- Add template regression tests covering all three states and queue scoping.

## User impact

Reviewers using a phone in portrait orientation can identify a changeset’s state before opening it. The desktop experience and other queues are unaffected.

## Validation

- Focused template tests: 4 passed
- Flake8 passed
- Django system check passed
- `git diff --check` passed
- Local web health check returned HTTP 200
- Local database health check passed
- Manual UAT passed using a desktop browser’s portrait-mobile emulation, including:
  - Under Review
  - In Discussion
  - Editing
  - The responsive transition between 639px and 640px