### PR TITLE
disallow reprint links within an issue

### DIFF
--- a/apps/gcd/models/reprint.py
+++ b/apps/gcd/models/reprint.py
@@ -26,10 +26,22 @@ class Reprint(GcdLink):
 
     def is_internal(self):
         """Return whether both ends of the link are in the same issue."""
-        origin_issue = self.origin.issue if self.origin else self.origin_issue
-        target_issue = self.target.issue if self.target else self.target_issue
-        return (origin_issue is not None and target_issue is not None and
-                origin_issue == target_issue)
+        origin_issue_id = (self.origin.issue_id if self.origin
+                           else self.origin_issue_id)
+        target_issue_id = (self.target.issue_id if self.target
+                           else self.target_issue_id)
+
+        if origin_issue_id is None and target_issue_id is None:
+            origin_issue = (self.origin.issue if self.origin
+                            else self.origin_issue)
+            target_issue = (self.target.issue if self.target
+                            else self.target_issue)
+            return (origin_issue is not None and
+                    origin_issue == target_issue)
+
+        return (origin_issue_id is not None and
+                target_issue_id is not None and
+                origin_issue_id == target_issue_id)
 
     def save(self, update_fields=None, *args, **kwargs):
         """

--- a/apps/gcd/models/reprint.py
+++ b/apps/gcd/models/reprint.py
@@ -24,6 +24,13 @@ class Reprint(GcdLink):
 
     notes = models.TextField(max_length=255)
 
+    def is_internal(self):
+        """Return whether both ends of the link are in the same issue."""
+        origin_issue = self.origin.issue if self.origin else self.origin_issue
+        target_issue = self.target.issue if self.target else self.target_issue
+        return (origin_issue is not None and target_issue is not None and
+                origin_issue == target_issue)
+
     def save(self, update_fields=None, *args, **kwargs):
         """
         Ensure origin/target_issue are always in agreement with origin/target.
@@ -52,6 +59,10 @@ class Reprint(GcdLink):
             if (update_fields is not None and
                     'target_issue' not in update_fields):
                 update_fields.append('target_issue')
+
+        if self.is_internal():
+            raise ValueError(
+                'Reprint origin and target cannot be in the same issue.')
 
         if update_fields is not None:
             kwargs['update_fields'] = update_fields

--- a/apps/gcd/models/reprint.py
+++ b/apps/gcd/models/reprint.py
@@ -8,6 +8,16 @@ from .story import Story
 from .issue import Issue
 
 
+INTERNAL_REPRINT_ERROR = 'Reprint links must connect different issues.'
+
+
+def validate_reprint_issue_ids(origin_issue_id, target_issue_id):
+    """Reject a reprint link whose endpoints belong to the same issue."""
+    if (origin_issue_id is not None and
+            origin_issue_id == target_issue_id):
+        raise ValueError(INTERNAL_REPRINT_ERROR)
+
+
 class Reprint(GcdLink):
     class Meta:
         app_label = 'gcd'
@@ -23,25 +33,6 @@ class Reprint(GcdLink):
                                      on_delete=models.CASCADE)
 
     notes = models.TextField(max_length=255)
-
-    def is_internal(self):
-        """Return whether both ends of the link are in the same issue."""
-        origin_issue_id = (self.origin.issue_id if self.origin
-                           else self.origin_issue_id)
-        target_issue_id = (self.target.issue_id if self.target
-                           else self.target_issue_id)
-
-        if origin_issue_id is None and target_issue_id is None:
-            origin_issue = (self.origin.issue if self.origin
-                            else self.origin_issue)
-            target_issue = (self.target.issue if self.target
-                            else self.target_issue)
-            return (origin_issue is not None and
-                    origin_issue == target_issue)
-
-        return (origin_issue_id is not None and
-                target_issue_id is not None and
-                origin_issue_id == target_issue_id)
 
     def save(self, update_fields=None, *args, **kwargs):
         """
@@ -72,9 +63,8 @@ class Reprint(GcdLink):
                     'target_issue' not in update_fields):
                 update_fields.append('target_issue')
 
-        if self.is_internal():
-            raise ValueError(
-                'Reprint origin and target cannot be in the same issue.')
+        validate_reprint_issue_ids(self.origin_issue_id,
+                                   self.target_issue_id)
 
         if update_fields is not None:
             kwargs['update_fields'] = update_fields

--- a/apps/gcd/tests/test_reprint.py
+++ b/apps/gcd/tests/test_reprint.py
@@ -49,6 +49,15 @@ def test_save_rejects_internal_reprint(patched_for_save):
     assert not save_mock.called
 
 
+def test_is_internal_uses_issue_ids_without_loading_issues():
+    r = Reprint(origin=Story(issue_id=1),
+                target=Story(issue_id=1),
+                origin_issue_id=1,
+                target_issue_id=1)
+
+    assert r.is_internal()
+
+
 def test_save_fields_origin_with_story(patched_for_save):
     save_mock, origin, target = patched_for_save
     # Put in nonsense target_issue to show that save() properly ignores it

--- a/apps/gcd/tests/test_reprint.py
+++ b/apps/gcd/tests/test_reprint.py
@@ -38,6 +38,17 @@ def test_save_fields_none_both_issues(patched_for_save):
     assert r.target_issue == target.issue
 
 
+def test_save_rejects_internal_reprint(patched_for_save):
+    save_mock, origin, _ = patched_for_save
+    target = Story(title='target', issue=origin.issue)
+    r = Reprint(origin=origin, target=target)
+
+    with pytest.raises(ValueError, match='same issue'):
+        r.save()
+
+    assert not save_mock.called
+
+
 def test_save_fields_origin_with_story(patched_for_save):
     save_mock, origin, target = patched_for_save
     # Put in nonsense target_issue to show that save() properly ignores it

--- a/apps/gcd/tests/test_reprint.py
+++ b/apps/gcd/tests/test_reprint.py
@@ -40,22 +40,14 @@ def test_save_fields_none_both_issues(patched_for_save):
 
 def test_save_rejects_internal_reprint(patched_for_save):
     save_mock, origin, _ = patched_for_save
+    origin.issue.pk = 1
     target = Story(title='target', issue=origin.issue)
     r = Reprint(origin=origin, target=target)
 
-    with pytest.raises(ValueError, match='same issue'):
+    with pytest.raises(ValueError, match='connect different issues'):
         r.save()
 
     assert not save_mock.called
-
-
-def test_is_internal_uses_issue_ids_without_loading_issues():
-    r = Reprint(origin=Story(issue_id=1),
-                target=Story(issue_id=1),
-                origin_issue_id=1,
-                target_issue_id=1)
-
-    assert r.is_internal()
 
 
 def test_save_fields_origin_with_story(patched_for_save):

--- a/apps/oi/models.py
+++ b/apps/oi/models.py
@@ -8706,6 +8706,30 @@ class ReprintRevision(Revision):
             return 1
         return 0
 
+    def is_internal(self):
+        """Return whether both ends of the link are in the same issue."""
+        if self.origin_revision:
+            origin_issue = self.origin_revision.issue
+        elif self.origin:
+            origin_issue = self.origin.issue
+        else:
+            origin_issue = self.origin_issue
+
+        if self.target_revision:
+            target_issue = self.target_revision.issue
+        elif self.target:
+            target_issue = self.target.issue
+        else:
+            target_issue = self.target_issue
+
+        return (origin_issue is not None and target_issue is not None and
+                origin_issue == target_issue)
+
+    def _is_legacy_internal_clone(self):
+        """Return whether this is the initial clone of an internal source."""
+        return (self._state.adding and self.reprint_id is not None and
+                self.reprint.is_internal())
+
     def save(self, *args, **kwargs):
         # Ensure that we can't create a nonsense link.
         # Check first revisions since for sequence moves things get
@@ -8759,6 +8783,11 @@ class ReprintRevision(Revision):
                                                           self.target_issue))
             if not self.target_issue:
                 self.target_issue = self.target.issue
+
+        if (not self.deleted and self.is_internal() and
+                not self._is_legacy_internal_clone()):
+            raise ValueError(
+                'Reprint origin and target cannot be in the same issue.')
 
         super(ReprintRevision, self).save(*args, **kwargs)
 

--- a/apps/oi/models.py
+++ b/apps/oi/models.py
@@ -8709,21 +8709,40 @@ class ReprintRevision(Revision):
     def is_internal(self):
         """Return whether both ends of the link are in the same issue."""
         if self.origin_revision:
-            origin_issue = self.origin_revision.issue
+            origin_issue_id = self.origin_revision.issue_id
         elif self.origin:
-            origin_issue = self.origin.issue
+            origin_issue_id = self.origin.issue_id
         else:
-            origin_issue = self.origin_issue
+            origin_issue_id = self.origin_issue_id
 
         if self.target_revision:
-            target_issue = self.target_revision.issue
+            target_issue_id = self.target_revision.issue_id
         elif self.target:
-            target_issue = self.target.issue
+            target_issue_id = self.target.issue_id
         else:
-            target_issue = self.target_issue
+            target_issue_id = self.target_issue_id
 
-        return (origin_issue is not None and target_issue is not None and
-                origin_issue == target_issue)
+        if origin_issue_id is None and target_issue_id is None:
+            if self.origin_revision:
+                origin_issue = self.origin_revision.issue
+            elif self.origin:
+                origin_issue = self.origin.issue
+            else:
+                origin_issue = self.origin_issue
+
+            if self.target_revision:
+                target_issue = self.target_revision.issue
+            elif self.target:
+                target_issue = self.target.issue
+            else:
+                target_issue = self.target_issue
+
+            return (origin_issue is not None and
+                    origin_issue == target_issue)
+
+        return (origin_issue_id is not None and
+                target_issue_id is not None and
+                origin_issue_id == target_issue_id)
 
     def _is_legacy_internal_clone(self):
         """Return whether this is the initial clone of an internal source."""

--- a/apps/oi/models.py
+++ b/apps/oi/models.py
@@ -53,6 +53,7 @@ from apps.gcd.models import (
 from apps.gcd.models.gcddata import GcdData, GcdLink
 
 from apps.gcd.models.issue import issue_descriptor
+from apps.gcd.models.reprint import validate_reprint_issue_ids
 from apps.gcd.models.story import show_feature, show_feature_as_text, \
                                   show_characters, show_title, \
                                   _get_civilian_identity, \
@@ -8706,48 +8707,20 @@ class ReprintRevision(Revision):
             return 1
         return 0
 
-    def is_internal(self):
-        """Return whether both ends of the link are in the same issue."""
-        if self.origin_revision:
-            origin_issue_id = self.origin_revision.issue_id
-        elif self.origin:
-            origin_issue_id = self.origin.issue_id
-        else:
-            origin_issue_id = self.origin_issue_id
+    @staticmethod
+    def _endpoint_issue_id(story_revision, story, issue_id):
+        # Added stories only have revisions; existing stories use the display
+        # object, and issue-only links fall back to their explicit issue ID.
+        endpoint = story_revision or story
+        return endpoint.issue_id if endpoint else issue_id
 
-        if self.target_revision:
-            target_issue_id = self.target_revision.issue_id
-        elif self.target:
-            target_issue_id = self.target.issue_id
-        else:
-            target_issue_id = self.target_issue_id
-
-        if origin_issue_id is None and target_issue_id is None:
-            if self.origin_revision:
-                origin_issue = self.origin_revision.issue
-            elif self.origin:
-                origin_issue = self.origin.issue
-            else:
-                origin_issue = self.origin_issue
-
-            if self.target_revision:
-                target_issue = self.target_revision.issue
-            elif self.target:
-                target_issue = self.target.issue
-            else:
-                target_issue = self.target_issue
-
-            return (origin_issue is not None and
-                    origin_issue == target_issue)
-
-        return (origin_issue_id is not None and
-                target_issue_id is not None and
-                origin_issue_id == target_issue_id)
-
-    def _is_legacy_internal_clone(self):
-        """Return whether this is the initial clone of an internal source."""
-        return (self._state.adding and self.reprint_id is not None and
-                self.reprint.is_internal())
+    def validate_reprint_link(self):
+        """Validate the issues resolved from either kind of endpoint."""
+        origin_issue_id = self._endpoint_issue_id(
+          self.origin_revision, self.origin, self.origin_issue_id)
+        target_issue_id = self._endpoint_issue_id(
+          self.target_revision, self.target, self.target_issue_id)
+        validate_reprint_issue_ids(origin_issue_id, target_issue_id)
 
     def save(self, *args, **kwargs):
         # Ensure that we can't create a nonsense link.
@@ -8803,10 +8776,8 @@ class ReprintRevision(Revision):
             if not self.target_issue:
                 self.target_issue = self.target.issue
 
-        if (not self.deleted and self.is_internal() and
-                not self._is_legacy_internal_clone()):
-            raise ValueError(
-                'Reprint origin and target cannot be in the same issue.')
+        if not self.deleted:
+            self.validate_reprint_link()
 
         super(ReprintRevision, self).save(*args, **kwargs)
 

--- a/apps/oi/tests/test_reprint_revision.py
+++ b/apps/oi/tests/test_reprint_revision.py
@@ -3,7 +3,7 @@
 import mock
 import pytest
 
-from apps.gcd.models import Story, Issue, Series
+from apps.gcd.models import Reprint, Story, Issue, Series
 from apps.oi.models import StoryRevision, ReprintRevision, Changeset
 
 
@@ -77,6 +77,52 @@ def test_save_stories_and_issues_only(patched_for_save):
     assert r.target == target
     assert r.origin_issue == origin.issue
     assert r.target_issue == target.issue
+
+
+def test_save_rejects_internal_reprint(patched_for_save):
+    save_mock, origin, _ = patched_for_save
+    target = Story(title='target', issue=origin.issue)
+    origin_revision = StoryRevision(issue=origin.issue)
+    r = ReprintRevision(origin_revision=origin_revision, target=target)
+
+    with pytest.raises(ValueError, match='same issue'):
+        r.save()
+
+    assert not save_mock.called
+
+
+def test_save_allows_initial_clone_of_legacy_internal_reprint(
+        patched_for_save):
+    save_mock, origin, _ = patched_for_save
+    target = Story(title='target', issue=origin.issue)
+    source = Reprint(pk=1, origin=origin, target=target)
+    revision = ReprintRevision(reprint=source, origin=origin, target=target)
+
+    revision.save()
+
+    save_mock.assert_called_once_with()
+    revision._state.adding = False
+    save_mock.reset_mock()
+    with pytest.raises(ValueError, match='same issue'):
+        revision.save()
+    assert not save_mock.called
+
+    revision.deleted = True
+    revision.save()
+    save_mock.assert_called_once_with()
+
+
+def test_save_rejects_internal_change_to_valid_source(patched_for_save):
+    save_mock, origin, external_target = patched_for_save
+    internal_target = Story(title='target', issue=origin.issue)
+    source = Reprint(pk=1, origin=origin, target=external_target)
+    revision = ReprintRevision(reprint=source, origin=origin,
+                               target=internal_target)
+
+    with pytest.raises(ValueError, match='same issue'):
+        revision.save()
+
+    assert not save_mock.called
 
 
 def test_save_origin_mismatch(patched_for_save):

--- a/apps/oi/tests/test_reprint_revision.py
+++ b/apps/oi/tests/test_reprint_revision.py
@@ -91,6 +91,23 @@ def test_save_rejects_internal_reprint(patched_for_save):
     assert not save_mock.called
 
 
+def test_is_internal_uses_issue_ids_without_loading_issues():
+    revision = ReprintRevision(
+        origin_revision=StoryRevision(issue_id=1),
+        target_revision=StoryRevision(issue_id=1))
+
+    assert revision.is_internal()
+
+
+def test_is_internal_handles_shared_unsaved_issue():
+    issue = Issue()
+    revision = ReprintRevision(
+        origin_revision=StoryRevision(issue=issue),
+        target_revision=StoryRevision(issue=issue))
+
+    assert revision.is_internal()
+
+
 def test_save_allows_initial_clone_of_legacy_internal_reprint(
         patched_for_save):
     save_mock, origin, _ = patched_for_save

--- a/apps/oi/tests/test_reprint_revision.py
+++ b/apps/oi/tests/test_reprint_revision.py
@@ -85,48 +85,19 @@ def test_save_rejects_internal_reprint(patched_for_save):
     origin_revision = StoryRevision(issue=origin.issue)
     r = ReprintRevision(origin_revision=origin_revision, target=target)
 
-    with pytest.raises(ValueError, match='same issue'):
+    with pytest.raises(ValueError, match='connect different issues'):
         r.save()
 
     assert not save_mock.called
 
 
-def test_is_internal_uses_issue_ids_without_loading_issues():
+def test_validate_reprint_link_uses_issue_ids_without_loading_issues():
     revision = ReprintRevision(
         origin_revision=StoryRevision(issue_id=1),
         target_revision=StoryRevision(issue_id=1))
 
-    assert revision.is_internal()
-
-
-def test_is_internal_handles_shared_unsaved_issue():
-    issue = Issue()
-    revision = ReprintRevision(
-        origin_revision=StoryRevision(issue=issue),
-        target_revision=StoryRevision(issue=issue))
-
-    assert revision.is_internal()
-
-
-def test_save_allows_initial_clone_of_legacy_internal_reprint(
-        patched_for_save):
-    save_mock, origin, _ = patched_for_save
-    target = Story(title='target', issue=origin.issue)
-    source = Reprint(pk=1, origin=origin, target=target)
-    revision = ReprintRevision(reprint=source, origin=origin, target=target)
-
-    revision.save()
-
-    save_mock.assert_called_once_with()
-    revision._state.adding = False
-    save_mock.reset_mock()
-    with pytest.raises(ValueError, match='same issue'):
-        revision.save()
-    assert not save_mock.called
-
-    revision.deleted = True
-    revision.save()
-    save_mock.assert_called_once_with()
+    with pytest.raises(ValueError, match='connect different issues'):
+        revision.validate_reprint_link()
 
 
 def test_save_rejects_internal_change_to_valid_source(patched_for_save):
@@ -136,7 +107,7 @@ def test_save_rejects_internal_change_to_valid_source(patched_for_save):
     revision = ReprintRevision(reprint=source, origin=origin,
                                target=internal_target)
 
-    with pytest.raises(ValueError, match='same issue'):
+    with pytest.raises(ValueError, match='connect different issues'):
         revision.save()
 
     assert not save_mock.called

--- a/apps/oi/tests/test_reprint_views.py
+++ b/apps/oi/tests/test_reprint_views.py
@@ -5,11 +5,12 @@ import re
 import mock
 import pytest
 
+from django.db.models import Q
 from django.http import HttpResponse
 from django.template.loader import render_to_string
 from django.test import RequestFactory
 
-from apps.gcd.models import Issue, Story
+from apps.gcd.models import Issue, Reprint, Story
 from apps.oi import states
 from apps.oi.models import ReprintRevision, StoryRevision
 from apps.oi.views import add_reprint, confirm_reprint, \
@@ -308,12 +309,7 @@ def test_internal_reprint_disables_restore():
     ) == 1
 
 
-@pytest.mark.parametrize(
-    ('reprint_manager', 'other_issue_field'),
-    (('from_all_reprints', 'origin_issue_id'),
-     ('to_all_reprints', 'target_issue_id')))
-def test_move_story_rejects_internal_reprint_before_reserving(
-        reprint_manager, other_issue_field):
+def test_move_story_rejects_internal_reprint_before_reserving():
     request = RequestFactory().post('/')
     indexer = mock.Mock()
     request.user = indexer
@@ -323,16 +319,14 @@ def test_move_story_rejects_internal_reprint_before_reserving(
     changeset.issuerevisions.count.return_value = 2
     changeset.issuerevisions.exclude.return_value.get.return_value = new_issue
     story = mock.Mock(changeset=changeset, issue=old_issue, story_id=1)
-    story.story.from_all_reprints.filter.return_value.exists.return_value = \
-        reprint_manager == 'from_all_reprints'
-    story.story.to_all_reprints.filter.return_value.exists.return_value = \
-        reprint_manager == 'to_all_reprints'
     error_response = HttpResponse('internal reprint')
 
     with mock.patch('apps.oi.views.get_object_or_404', return_value=story), \
             mock.patch('apps.oi.views.render_error',
                        return_value=error_response) as render_error_mock, \
+            mock.patch.object(Reprint.objects, 'filter') as filter_mock, \
             mock.patch('apps.oi.views._do_reserve') as reserve_mock:
+        filter_mock.return_value.exists.return_value = True
         response = move_story_revision.__wrapped__(request, id=story.id)
 
     assert response is error_response
@@ -343,9 +337,11 @@ def test_move_story_rejects_internal_reprint_before_reserving(
     assert story.issue is old_issue
     reserve_mock.assert_not_called()
     changeset.reprintrevisions.filter.assert_not_called()
-    manager = getattr(story.story, reprint_manager)
-    manager.filter.assert_called_once_with(
-        **{other_issue_field: new_issue.issue_id})
+    filter_mock.assert_called_once_with(
+        Q(target_id=story.story_id,
+          origin_issue_id=new_issue.issue_id) |
+        Q(origin_id=story.story_id,
+          target_issue_id=new_issue.issue_id))
 
 
 @pytest.mark.django_db

--- a/apps/oi/tests/test_reprint_views.py
+++ b/apps/oi/tests/test_reprint_views.py
@@ -1,0 +1,403 @@
+# -*- coding: utf-8 -*-
+
+import re
+
+import mock
+import pytest
+
+from django.http import HttpResponse
+from django.template.loader import render_to_string
+from django.test import RequestFactory
+
+from apps.gcd.models import Issue, Story
+from apps.oi import states
+from apps.oi.models import ReprintRevision, StoryRevision
+from apps.oi.views import add_reprint, confirm_reprint, \
+                          create_matching_sequence, edit_reprint, \
+                          move_story_revision, save_reprint
+from apps.select.forms import get_select_cache_form
+from apps.select.views import select_object, store_select_data
+
+
+def _other_story_in_same_issue(story):
+    other_story = type(story).objects.get(pk=story.pk)
+    other_story.pk = None
+    other_story.sequence_number += 1
+    other_story.save()
+    assert other_story.issue == story.issue
+    return other_story
+
+
+@pytest.mark.django_db
+def test_save_reprint_rejects_link_within_same_issue(any_added_story,
+                                                     any_changeset):
+    other_story = _other_story_in_same_issue(any_added_story)
+
+    request = RequestFactory().post('/', {
+        'direction': 'from',
+        'reprint_link_notes': '',
+        'comments': '',
+    })
+    request.user = any_changeset.indexer
+    error_response = HttpResponse('internal reprint')
+
+    with mock.patch('apps.oi.views.render_error',
+                    return_value=error_response) as render_error_mock:
+        response = save_reprint.__wrapped__(
+            request,
+            reprint_revision_id='new',
+            changeset_id=str(any_changeset.id),
+            story_one_id=any_added_story.id,
+            story_two_id=other_story.id)
+
+    assert response is error_response
+    render_error_mock.assert_called_once_with(
+        request,
+        'Reprint links must connect different issues.',
+        redirect=False)
+    assert not ReprintRevision.objects.filter(
+        changeset=any_changeset).exists()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('object_type', ('issue', 'story'))
+def test_confirm_reprint_rejects_object_from_same_issue(any_added_story,
+                                                        any_changeset,
+                                                        object_type):
+    other_story = _other_story_in_same_issue(any_added_story)
+    selected_id = (any_added_story.issue_id if object_type == 'issue'
+                   else other_story.id)
+    request = RequestFactory().post('/')
+    request.session = {}
+    error_response = HttpResponse('internal reprint')
+    data = {
+        'story_id': any_added_story.id,
+        'changeset_id': any_changeset.id,
+    }
+
+    with mock.patch('apps.oi.views.render_error',
+                    return_value=error_response) as render_error_mock, \
+            mock.patch('apps.oi.views.oi_render') as oi_render_mock:
+        response = confirm_reprint.__wrapped__(request, data, object_type,
+                                               selected_id)
+
+    assert response is error_response
+    render_error_mock.assert_called_once_with(
+        request,
+        'Reprint links must connect different issues.',
+        redirect=False)
+    assert not oi_render_mock.called
+
+
+@pytest.mark.django_db
+def test_select_object_disables_cached_objects_from_current_issue(
+        any_added_story, any_indexer):
+    request = RequestFactory().get('/')
+    request.user = any_indexer
+    request.session = {
+        'cached_issues': [any_added_story.issue_id],
+        'cached_stories': [any_added_story.id],
+        'cached_covers': [any_added_story.id],
+    }
+    select_key = store_select_data(request, 'reprint-test', {
+        'heading': 'Select reprint target',
+        'target': 'a story or issue',
+        'story': True,
+        'issue': True,
+        'exclude_issue_id': any_added_story.issue_id,
+    })
+    response = HttpResponse('select object')
+
+    with mock.patch('apps.select.views.render',
+                    return_value=response) as render_mock:
+        actual = select_object.__wrapped__(request, select_key)
+
+    assert actual is response
+    context = render_mock.call_args.args[2]
+    assert set(context['disabled_choices']) == {
+        'issue_%d' % any_added_story.issue_id,
+        'story_%d' % any_added_story.id,
+        'cover_%d' % any_added_story.id,
+    }
+    assert isinstance(context['disabled_choices'], tuple)
+    html = render_to_string('select/select_object.html', context,
+                            request=request)
+    assert html.count('\n  disabled\n') == 3
+    assert 'aria-disabled' not in html
+    assert html.count('btn-blue-disabled') == 3
+    assert html.count(
+        'title="Cannot select because reprint links must connect different '
+        'issues."') == 3
+    assert html.count('aria-describedby="disabled-reprint-') == 3
+    assert html.count('<small id="disabled-reprint-') == 3
+    assert html.count('<em>(Current issue;') == 3
+
+
+def test_select_cache_form_keeps_other_issue_enabled():
+    current_issue = mock.Mock(id=1)
+    other_issue = mock.Mock(id=2)
+
+    form = get_select_cache_form(
+        cached_issues=[current_issue, other_issue],
+        exclude_issue_id=current_issue.id)()
+
+    assert form.disabled_choices == ('issue_1',)
+    assert [choice[0] for choice in
+            form.fields['object_choice'].choices] == ['issue_1', 'issue_2']
+
+
+@pytest.mark.parametrize(
+    'action', ('flip_direction', 'restore', 'matching_sequence'))
+def test_edit_reprint_rejects_invalid_action_on_internal_link(action):
+    request = RequestFactory().post('/', {action: '1'})
+    indexer = mock.Mock()
+    request.user = indexer
+    changeset = mock.Mock(indexer=indexer)
+    reprint_revision = mock.Mock(changeset=changeset)
+    reprint_revision.is_internal.return_value = True
+    reprint_revision.deleted = True
+    error_response = HttpResponse('internal reprint')
+
+    with mock.patch('apps.oi.views.get_object_or_404',
+                    return_value=reprint_revision), \
+            mock.patch('apps.oi.views.render_error',
+                       return_value=error_response) as render_error_mock:
+        response = edit_reprint.__wrapped__(request, id=1)
+
+    assert response is error_response
+    render_error_mock.assert_called_once_with(
+        request,
+        'Reprint links must connect different issues.',
+        redirect=False)
+    reprint_revision.save.assert_not_called()
+
+
+def test_create_matching_sequence_rejects_internal_link_before_copying():
+    request = RequestFactory().post('/')
+    indexer = mock.Mock()
+    request.user = indexer
+    issue = mock.Mock()
+    changeset = mock.Mock(indexer=indexer)
+    changeset.issuerevisions.get.return_value = mock.Mock(issue=issue)
+    reprint_revision = mock.Mock(changeset=changeset)
+    reprint_revision.is_internal.return_value = True
+    error_response = HttpResponse('internal reprint')
+
+    with mock.patch('apps.oi.views.get_object_or_404',
+                    side_effect=(mock.Mock(), issue, reprint_revision)), \
+            mock.patch('apps.oi.views.render_error',
+                       return_value=error_response) as render_error_mock, \
+            mock.patch.object(
+                StoryRevision, 'copied_revision') as copied_revision_mock:
+        response = create_matching_sequence.__wrapped__(
+            request, reprint_revision_id=1, story_id=2, issue_id=3)
+
+    assert response is error_response
+    render_error_mock.assert_called_once_with(
+        request,
+        'Reprint links must connect different issues.',
+        redirect=False)
+    copied_revision_mock.assert_not_called()
+
+
+def _button_tag(html, name):
+    match = re.search(r'<button[^>]*name="%s"[^>]*>' % name, html)
+    assert match
+    return match.group()
+
+
+@pytest.mark.parametrize(
+    ('is_source', 'origin_action', 'target_action', 'note_action'),
+    ((False, 'edit_origin', 'edit_target', 'edit_note_target'),
+     (True, 'edit_origin_internal', 'edit_target', 'edit_note_origin')))
+@pytest.mark.parametrize('render_branch', ('display', 'current', 'approved'))
+def test_internal_reprint_only_enables_corrective_actions(
+        is_source, origin_action, target_action, note_action, render_branch):
+    changeset = mock.Mock(id=2)
+    if render_branch == 'display':
+        reprint_changeset = None
+        reprint_changeset_id = None
+    elif render_branch == 'current':
+        reprint_changeset = changeset
+        reprint_changeset_id = changeset.id
+    else:
+        reprint_changeset = mock.Mock(id=3, state=states.APPROVED)
+        reprint_changeset_id = reprint_changeset.id
+    reprint = mock.Mock(
+        id=1,
+        changeset=reprint_changeset,
+        changeset_id=reprint_changeset_id,
+        deleted=False,
+        previous_revision=mock.Mock(),
+        source=None,
+        origin=None,
+        origin_issue=None,
+        target=None,
+        target_issue=None)
+    reprint.source = reprint
+    reprint.is_internal.return_value = True
+
+    with mock.patch(
+            'apps.oi.templatetags.editing.ContentType.objects.'
+            'get_for_model'), \
+            mock.patch(
+                'apps.oi.templatetags.editing.RevisionLock.objects.filter'
+            ) as lock_filter:
+        lock_filter.return_value.first.return_value = None
+        html = render_to_string(
+            'oi/bits/reprint_type_list.html',
+            {'reprint': reprint,
+             'changeset': changeset,
+             'is_source': is_source,
+             'create_sequence': True,
+             'states': states})
+
+    for action in (origin_action, note_action, 'flip_direction',
+                   'matching_sequence'):
+        button = _button_tag(html, action)
+        assert 'btn-blue-disabled' in button
+        assert re.search(r'\sdisabled(?:\s|>)', button)
+        assert 'aria-describedby=' in button
+
+    for action in (target_action, 'delete'):
+        button = _button_tag(html, action)
+        assert 'btn-blue-editing' in button
+        assert not re.search(r'\sdisabled(?:\s|>)', button)
+
+    assert 'name="edit_target_internal"' not in html
+
+    assert html.count(
+        'Legacy internal link; change its target or mark it to delete.'
+    ) == 1
+
+
+def test_internal_reprint_disables_restore():
+    changeset = mock.Mock(id=2)
+    reprint = mock.Mock(
+        id=1,
+        changeset=changeset,
+        changeset_id=changeset.id,
+        deleted=True,
+        previous_revision=mock.Mock(),
+        source=mock.Mock(),
+        origin=None,
+        origin_issue=None,
+        target=None,
+        target_issue=None)
+    reprint.is_internal.return_value = True
+
+    with mock.patch(
+            'apps.oi.templatetags.editing.ContentType.objects.'
+            'get_for_model'), \
+            mock.patch(
+                'apps.oi.templatetags.editing.RevisionLock.objects.filter'
+            ) as lock_filter:
+        lock_filter.return_value.first.return_value = None
+        html = render_to_string(
+            'oi/bits/reprint_type_list.html',
+            {'reprint': reprint,
+             'changeset': changeset,
+             'is_source': True})
+
+    button = _button_tag(html, 'restore')
+    assert 'btn-blue-disabled' in button
+    assert re.search(r'\sdisabled(?:\s|>)', button)
+    assert 'aria-describedby=' in button
+    assert html.count(
+        'Legacy internal link; restoring it is unavailable.'
+    ) == 1
+
+
+@pytest.mark.parametrize(
+    ('reprint_manager', 'other_issue_field'),
+    (('from_all_reprints', 'origin_issue_id'),
+     ('to_all_reprints', 'target_issue_id')))
+def test_move_story_rejects_internal_reprint_before_reserving(
+        reprint_manager, other_issue_field):
+    request = RequestFactory().post('/')
+    indexer = mock.Mock()
+    request.user = indexer
+    old_issue = mock.Mock()
+    new_issue = mock.Mock(issue=mock.Mock(), issue_id=2)
+    changeset = mock.Mock(indexer=indexer)
+    changeset.issuerevisions.count.return_value = 2
+    changeset.issuerevisions.exclude.return_value.get.return_value = new_issue
+    story = mock.Mock(changeset=changeset, issue=old_issue, story_id=1)
+    story.story.from_all_reprints.filter.return_value.exists.return_value = \
+        reprint_manager == 'from_all_reprints'
+    story.story.to_all_reprints.filter.return_value.exists.return_value = \
+        reprint_manager == 'to_all_reprints'
+    error_response = HttpResponse('internal reprint')
+
+    with mock.patch('apps.oi.views.get_object_or_404', return_value=story), \
+            mock.patch('apps.oi.views.render_error',
+                       return_value=error_response) as render_error_mock, \
+            mock.patch('apps.oi.views._do_reserve') as reserve_mock:
+        response = move_story_revision.__wrapped__(request, id=story.id)
+
+    assert response is error_response
+    render_error_mock.assert_called_once_with(
+        request,
+        'Reprint links must connect different issues.',
+        redirect=False)
+    assert story.issue is old_issue
+    reserve_mock.assert_not_called()
+    changeset.reprintrevisions.filter.assert_not_called()
+    manager = getattr(story.story, reprint_manager)
+    manager.filter.assert_called_once_with(
+        **{other_issue_field: new_issue.issue_id})
+
+
+@pytest.mark.django_db
+def test_add_reprint_excludes_current_issue_from_selector(
+        any_added_story_rev):
+    request = RequestFactory().get('/')
+    request.session = {}
+
+    with mock.patch('apps.oi.views.store_select_data',
+                    return_value='reprint-test') as store_select_data_mock:
+        add_reprint.__wrapped__(
+            request,
+            changeset_id=any_added_story_rev.changeset_id,
+            story_id=any_added_story_rev.id)
+
+    data = store_select_data_mock.call_args.args[2]
+    assert data['exclude_issue_id'] == any_added_story_rev.issue_id
+
+
+def test_save_reprint_rejects_before_saving_story_revision():
+    request = RequestFactory().post('/', {
+        'direction': 'from',
+        'reprint_link_notes': '',
+        'reprint_notes': 'must not be saved',
+        'comments': '',
+    })
+    issue = Issue(id=1)
+    story = Story(id=2, issue=issue)
+    story_revision = mock.Mock(id=3, story=story, issue=issue)
+    changeset = mock.Mock(id=4)
+    error_response = HttpResponse('internal reprint')
+
+    with mock.patch('apps.oi.views.get_object_or_404',
+                    return_value=changeset), \
+            mock.patch('apps.oi.views.StoryRevision.objects.get',
+                       return_value=story_revision), \
+            mock.patch('apps.oi.views.Story.objects.get',
+                       return_value=story), \
+            mock.patch('apps.oi.views.Issue.objects.get',
+                       return_value=issue), \
+            mock.patch('apps.oi.views.render_error',
+                       return_value=error_response) as render_error_mock:
+        response = save_reprint.__wrapped__(
+            request,
+            reprint_revision_id='new',
+            changeset_id=str(changeset.id),
+            story_revision_id=story_revision.id,
+            issue_two_id=issue.id)
+
+    assert response is error_response
+    render_error_mock.assert_called_once_with(
+        request,
+        'Reprint links must connect different issues.',
+        redirect=False)
+    story_revision.save.assert_not_called()

--- a/apps/oi/tests/test_reprint_views.py
+++ b/apps/oi/tests/test_reprint_views.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import re
+from html.parser import HTMLParser
 
 import mock
 import pytest
@@ -11,13 +11,47 @@ from django.template.loader import render_to_string
 from django.test import RequestFactory
 
 from apps.gcd.models import Issue, Reprint, Story
-from apps.oi import states
-from apps.oi.models import ReprintRevision, StoryRevision
-from apps.oi.views import add_reprint, confirm_reprint, \
-                          create_matching_sequence, edit_reprint, \
-                          move_story_revision, save_reprint
+from apps.oi.models import ReprintRevision
+from apps.oi.views import add_reprint, confirm_reprint, move_story_revision, \
+                          save_reprint
 from apps.select.forms import get_select_cache_form
 from apps.select.views import select_object, store_select_data
+
+
+class _DisabledChoiceParser(HTMLParser):
+    """Collect disabled-choice markup without parsing unrelated page HTML."""
+
+    def __init__(self):
+        super().__init__()
+        self.buttons = []
+        self.help = {}
+        self._help_id = None
+        self._help_text = []
+        self._help_emphasized = False
+
+    def handle_starttag(self, tag, attrs):
+        attrs = dict(attrs)
+        if tag == 'button' and attrs.get('name') == 'select_object':
+            self.buttons.append(attrs)
+        elif tag == 'small' and attrs.get('id', '').startswith(
+                'disabled-choice-'):
+            self._help_id = attrs['id']
+            self._help_text = []
+            self._help_emphasized = False
+        elif tag == 'em' and self._help_id:
+            self._help_emphasized = True
+
+    def handle_data(self, data):
+        if self._help_id:
+            self._help_text.append(data)
+
+    def handle_endtag(self, tag):
+        if tag == 'small' and self._help_id:
+            self.help[self._help_id] = {
+                'text': ' '.join(''.join(self._help_text).split()),
+                'emphasized': self._help_emphasized,
+            }
+            self._help_id = None
 
 
 def _other_story_in_same_issue(story):
@@ -74,6 +108,7 @@ def test_confirm_reprint_rejects_object_from_same_issue(any_added_story,
     data = {
         'story_id': any_added_story.id,
         'changeset_id': any_changeset.id,
+        'exclude_issue_id': any_added_story.issue_id,
     }
 
     with mock.patch('apps.oi.views.render_error',
@@ -87,7 +122,40 @@ def test_confirm_reprint_rejects_object_from_same_issue(any_added_story,
         request,
         'Reprint links must connect different issues.',
         redirect=False)
-    assert not oi_render_mock.called
+    oi_render_mock.assert_not_called()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('object_type', ('issue', 'story'))
+def test_confirm_reprint_accepts_object_from_different_issue(
+        any_added_story, any_added_variant, any_changeset, object_type):
+    if object_type == 'story':
+        selected_story = type(any_added_story).objects.get(
+            pk=any_added_story.pk)
+        selected_story.pk = None
+        selected_story.issue = any_added_variant
+        selected_story.save()
+        selected_id = selected_story.id
+    else:
+        selected_id = any_added_variant.id
+    request = RequestFactory().post('/')
+    request.session = {}
+    confirm_response = HttpResponse('confirm reprint')
+    data = {
+        'story_id': any_added_story.id,
+        'changeset_id': any_changeset.id,
+        'exclude_issue_id': any_added_story.issue_id,
+    }
+
+    with mock.patch('apps.oi.views.oi_render',
+                    return_value=confirm_response) as oi_render_mock, \
+            mock.patch('apps.oi.views.render_error') as render_error_mock:
+        response = confirm_reprint.__wrapped__(request, data, object_type,
+                                               selected_id)
+
+    assert response is confirm_response
+    oi_render_mock.assert_called_once()
+    render_error_mock.assert_not_called()
 
 
 @pytest.mark.django_db
@@ -106,6 +174,11 @@ def test_select_object_disables_cached_objects_from_current_issue(
         'story': True,
         'issue': True,
         'exclude_issue_id': any_added_story.issue_id,
+        'disabled_choice_title': (
+            'Cannot select because reprint links must connect different '
+            'issues.'),
+        'disabled_choice_help': (
+            'Current issue; cannot select for a reprint link.'),
     })
     response = HttpResponse('select object')
 
@@ -115,23 +188,32 @@ def test_select_object_disables_cached_objects_from_current_issue(
 
     assert actual is response
     context = render_mock.call_args.args[2]
-    assert set(context['disabled_choices']) == {
+    assert set(context['cache_form'].disabled_choices) == {
         'issue_%d' % any_added_story.issue_id,
         'story_%d' % any_added_story.id,
         'cover_%d' % any_added_story.id,
     }
-    assert isinstance(context['disabled_choices'], tuple)
+    assert isinstance(context['cache_form'].disabled_choices, tuple)
     html = render_to_string('select/select_object.html', context,
                             request=request)
-    assert html.count('\n  disabled\n') == 3
     assert 'aria-disabled' not in html
-    assert html.count('btn-blue-disabled') == 3
-    assert html.count(
-        'title="Cannot select because reprint links must connect different '
-        'issues."') == 3
-    assert html.count('aria-describedby="disabled-reprint-') == 3
-    assert html.count('<small id="disabled-reprint-') == 3
-    assert html.count('<em>(Current issue;') == 3
+    parser = _DisabledChoiceParser()
+    parser.feed(html)
+    assert len(parser.buttons) == 3
+    for counter, button in enumerate(parser.buttons, start=1):
+        help_id = 'disabled-choice-%d' % counter
+        assert set(button['class'].split()) == {
+            'btn-blue-disabled', 'inline', 'py-1', 'px-2'}
+        assert button['type'] == 'submit'
+        assert 'disabled' in button
+        assert button['aria-describedby'] == help_id
+        assert button['title'] == (
+            'Cannot select because reprint links must connect different '
+            'issues.')
+        assert parser.help[help_id] == {
+            'text': '(Current issue; cannot select for a reprint link.)',
+            'emphasized': True,
+        }
 
 
 def test_select_cache_form_keeps_other_issue_enabled():
@@ -145,168 +227,6 @@ def test_select_cache_form_keeps_other_issue_enabled():
     assert form.disabled_choices == ('issue_1',)
     assert [choice[0] for choice in
             form.fields['object_choice'].choices] == ['issue_1', 'issue_2']
-
-
-@pytest.mark.parametrize(
-    'action', ('flip_direction', 'restore', 'matching_sequence'))
-def test_edit_reprint_rejects_invalid_action_on_internal_link(action):
-    request = RequestFactory().post('/', {action: '1'})
-    indexer = mock.Mock()
-    request.user = indexer
-    changeset = mock.Mock(indexer=indexer)
-    reprint_revision = mock.Mock(changeset=changeset)
-    reprint_revision.is_internal.return_value = True
-    reprint_revision.deleted = True
-    error_response = HttpResponse('internal reprint')
-
-    with mock.patch('apps.oi.views.get_object_or_404',
-                    return_value=reprint_revision), \
-            mock.patch('apps.oi.views.render_error',
-                       return_value=error_response) as render_error_mock:
-        response = edit_reprint.__wrapped__(request, id=1)
-
-    assert response is error_response
-    render_error_mock.assert_called_once_with(
-        request,
-        'Reprint links must connect different issues.',
-        redirect=False)
-    reprint_revision.save.assert_not_called()
-
-
-def test_create_matching_sequence_rejects_internal_link_before_copying():
-    request = RequestFactory().post('/')
-    indexer = mock.Mock()
-    request.user = indexer
-    issue = mock.Mock()
-    changeset = mock.Mock(indexer=indexer)
-    changeset.issuerevisions.get.return_value = mock.Mock(issue=issue)
-    reprint_revision = mock.Mock(changeset=changeset)
-    reprint_revision.is_internal.return_value = True
-    error_response = HttpResponse('internal reprint')
-
-    with mock.patch('apps.oi.views.get_object_or_404',
-                    side_effect=(mock.Mock(), issue, reprint_revision)), \
-            mock.patch('apps.oi.views.render_error',
-                       return_value=error_response) as render_error_mock, \
-            mock.patch.object(
-                StoryRevision, 'copied_revision') as copied_revision_mock:
-        response = create_matching_sequence.__wrapped__(
-            request, reprint_revision_id=1, story_id=2, issue_id=3)
-
-    assert response is error_response
-    render_error_mock.assert_called_once_with(
-        request,
-        'Reprint links must connect different issues.',
-        redirect=False)
-    copied_revision_mock.assert_not_called()
-
-
-def _button_tag(html, name):
-    match = re.search(r'<button[^>]*name="%s"[^>]*>' % name, html)
-    assert match
-    return match.group()
-
-
-@pytest.mark.parametrize(
-    ('is_source', 'origin_action', 'target_action', 'note_action'),
-    ((False, 'edit_origin', 'edit_target', 'edit_note_target'),
-     (True, 'edit_origin_internal', 'edit_target', 'edit_note_origin')))
-@pytest.mark.parametrize('render_branch', ('display', 'current', 'approved'))
-def test_internal_reprint_only_enables_corrective_actions(
-        is_source, origin_action, target_action, note_action, render_branch):
-    changeset = mock.Mock(id=2)
-    if render_branch == 'display':
-        reprint_changeset = None
-        reprint_changeset_id = None
-    elif render_branch == 'current':
-        reprint_changeset = changeset
-        reprint_changeset_id = changeset.id
-    else:
-        reprint_changeset = mock.Mock(id=3, state=states.APPROVED)
-        reprint_changeset_id = reprint_changeset.id
-    reprint = mock.Mock(
-        id=1,
-        changeset=reprint_changeset,
-        changeset_id=reprint_changeset_id,
-        deleted=False,
-        previous_revision=mock.Mock(),
-        source=None,
-        origin=None,
-        origin_issue=None,
-        target=None,
-        target_issue=None)
-    reprint.source = reprint
-    reprint.is_internal.return_value = True
-
-    with mock.patch(
-            'apps.oi.templatetags.editing.ContentType.objects.'
-            'get_for_model'), \
-            mock.patch(
-                'apps.oi.templatetags.editing.RevisionLock.objects.filter'
-            ) as lock_filter:
-        lock_filter.return_value.first.return_value = None
-        html = render_to_string(
-            'oi/bits/reprint_type_list.html',
-            {'reprint': reprint,
-             'changeset': changeset,
-             'is_source': is_source,
-             'create_sequence': True,
-             'states': states})
-
-    for action in (origin_action, note_action, 'flip_direction',
-                   'matching_sequence'):
-        button = _button_tag(html, action)
-        assert 'btn-blue-disabled' in button
-        assert re.search(r'\sdisabled(?:\s|>)', button)
-        assert 'aria-describedby=' in button
-
-    for action in (target_action, 'delete'):
-        button = _button_tag(html, action)
-        assert 'btn-blue-editing' in button
-        assert not re.search(r'\sdisabled(?:\s|>)', button)
-
-    assert 'name="edit_target_internal"' not in html
-
-    assert html.count(
-        'Legacy internal link; change its target or mark it to delete.'
-    ) == 1
-
-
-def test_internal_reprint_disables_restore():
-    changeset = mock.Mock(id=2)
-    reprint = mock.Mock(
-        id=1,
-        changeset=changeset,
-        changeset_id=changeset.id,
-        deleted=True,
-        previous_revision=mock.Mock(),
-        source=mock.Mock(),
-        origin=None,
-        origin_issue=None,
-        target=None,
-        target_issue=None)
-    reprint.is_internal.return_value = True
-
-    with mock.patch(
-            'apps.oi.templatetags.editing.ContentType.objects.'
-            'get_for_model'), \
-            mock.patch(
-                'apps.oi.templatetags.editing.RevisionLock.objects.filter'
-            ) as lock_filter:
-        lock_filter.return_value.first.return_value = None
-        html = render_to_string(
-            'oi/bits/reprint_type_list.html',
-            {'reprint': reprint,
-             'changeset': changeset,
-             'is_source': True})
-
-    button = _button_tag(html, 'restore')
-    assert 'btn-blue-disabled' in button
-    assert re.search(r'\sdisabled(?:\s|>)', button)
-    assert 'aria-describedby=' in button
-    assert html.count(
-        'Legacy internal link; restoring it is unavailable.'
-    ) == 1
 
 
 def test_move_story_rejects_internal_reprint_before_reserving():

--- a/apps/oi/views.py
+++ b/apps/oi/views.py
@@ -216,6 +216,8 @@ REACHED_CHANGE_LIMIT = 'You have reached your limit of open changes.  You ' \
   'If you are an experienced indexer and frequently hit ' \
   'your reservation limit please contact us.'
 
+INTERNAL_REPRINT_ERROR = 'Reprint links must connect different issues.'
+
 ##############################################################################
 # Helper functions
 ##############################################################################
@@ -4301,6 +4303,16 @@ def reserve_reprint(request, changeset_id, reprint_id):
       'edit_reprint', kwargs={'id': revision.id, 'which_side': which_side}))
 
 
+def _reprint_issue_id(story=None, story_revision=None, issue=None):
+    if story_revision:
+        return story_revision.issue_id
+    if story:
+        return story.issue_id
+    if issue:
+        return issue.id
+    return None
+
+
 @permission_required('indexer.can_reserve')
 def edit_reprint(request, id, which_side=None):
     reprint_revision = get_object_or_404(ReprintRevision, id=id)
@@ -4373,6 +4385,9 @@ def edit_reprint(request, id, which_side=None):
         else:
             story_revision = reprint_revision.origin_revision
     elif which_side == 'flip_direction':
+        if reprint_revision.is_internal():
+            return render_error(
+                request, INTERNAL_REPRINT_ERROR, redirect=False)
         origin = reprint_revision.target
         origin_revision = reprint_revision.target_revision
         origin_issue = reprint_revision.target_issue
@@ -4392,6 +4407,9 @@ def edit_reprint(request, id, which_side=None):
           'list_issue_reprints', kwargs={'id': changeset_issue.id}))
     elif which_side == 'restore':
         if reprint_revision.deleted:
+            if reprint_revision.is_internal():
+                return render_error(
+                    request, INTERNAL_REPRINT_ERROR, redirect=False)
             reprint_revision.deleted = False
             reprint_revision.save()
             return HttpResponseRedirect(
@@ -4403,6 +4421,9 @@ def edit_reprint(request, id, which_side=None):
         return HttpResponseRedirect(
           urlresolvers.reverse('remove_reprint_revision', kwargs={'id': id}))
     elif which_side == 'matching_sequence':
+        if reprint_revision.is_internal():
+            return render_error(
+                request, INTERNAL_REPRINT_ERROR, redirect=False)
         if reprint_revision.origin:
             story = reprint_revision.origin
             issue = reprint_revision.target_issue
@@ -4511,6 +4532,8 @@ def edit_reprint(request, id, which_side=None):
         story_revision_id = None
         heading = 'Select story/issue for the reprint link with %s' \
                   % (esc(issue))
+    exclude_issue_id = _reprint_issue_id(
+      story=story, story_revision=story_revision, issue=issue)
     data = {'story_id': story_id,
             'story_revision_id': story_revision_id,
             'issue_id': issue_id,
@@ -4518,6 +4541,7 @@ def edit_reprint(request, id, which_side=None):
             'changeset_id': changeset.id,
             'story': True,
             'issue': True,
+            'exclude_issue_id': exclude_issue_id,
             'initial': initial,
             'heading': mark_safe('<h2>%s</h2>' % heading),
             'target': 'a story or issue',
@@ -4536,9 +4560,11 @@ def add_reprint(request, changeset_id,
     if story_id:
         story = get_object_or_404(StoryRevision, id=story_id,
                                   changeset__id=changeset_id)
+        exclude_issue_id = story.issue_id
     else:
         issue = get_object_or_404(IssueRevision, id=issue_id,
                                   changeset__id=changeset_id)
+        exclude_issue_id = issue.issue_id
     if reprint_note:
         publisher, series, year, number, volume = \
             parse_reprint(unquote(reprint_note).split(';')[0])
@@ -4557,6 +4583,7 @@ def add_reprint(request, changeset_id,
             'changeset_id': changeset_id,
             'story': True,
             'issue': True,
+            'exclude_issue_id': exclude_issue_id,
             'initial': initial,
             'heading': mark_safe('<h2>%s</h2>' % heading),
             'target': 'a story or issue',
@@ -4710,6 +4737,9 @@ def create_matching_sequence(request, reprint_revision_id, story_id, issue_id,
           'Only the reservation holder may access this page.')
     if issue != changeset_issue.issue:
         return _cant_get(request)
+    if reprint_revision.is_internal():
+        return render_error(
+            request, INTERNAL_REPRINT_ERROR, redirect=False)
     if request.method != 'POST' and not edit:
         if story == reprint_revision.origin:
             direction = 'from'
@@ -4759,6 +4789,7 @@ def confirm_reprint(request, data, object_type, selected_id):
 
     if 'story_id' in data and data['story_id']:
         story = get_object_or_404(Story, id=data['story_id'])
+        current_issue_id = story.issue_id
         story_revision = False
         story_story = True
         current_issue = None
@@ -4768,6 +4799,7 @@ def confirm_reprint(request, data, object_type, selected_id):
         story_revision = get_object_or_404(StoryRevision,
                                            id=data['story_revision_id'],
                                            changeset__id=data['changeset_id'])
+        current_issue_id = story_revision.issue_id
         story = PreviewStory.init(story_revision)
         current_issue = None
     elif 'issue_id' in data and data['issue_id']:
@@ -4775,13 +4807,15 @@ def confirm_reprint(request, data, object_type, selected_id):
         story_revision = False
         story = None
         current_issue = get_object_or_404(Issue, id=data['issue_id'])
+        current_issue_id = current_issue.id
     elif 'issue_revision_id' in data and data['issue_revision_id']:
         story_story = False
         story_revision = False
         story = None
-        current_issue = get_object_or_404(IssueRevision,
-                                          id=data['issue_revision_id'])
-        current_issue = current_issue.issue
+        current_issue_revision = get_object_or_404(
+          IssueRevision, id=data['issue_revision_id'])
+        current_issue = current_issue_revision.issue
+        current_issue_id = current_issue_revision.issue_id
     else:
         raise NotImplementedError
 
@@ -4790,9 +4824,15 @@ def confirm_reprint(request, data, object_type, selected_id):
     if object_type == 'story':
         selected_story = get_object_or_404(Story, id=selected_id)
         selected_issue = None
+        selected_issue_id = selected_story.issue_id
     else:
         selected_story = None
         selected_issue = get_object_or_404(Issue, id=selected_id)
+        selected_issue_id = selected_issue.id
+
+    if current_issue_id and current_issue_id == selected_issue_id:
+        return render_error(
+            request, INTERNAL_REPRINT_ERROR, redirect=False)
 
     if 'reprint_revision_id' in data:
         reprint_revision = get_object_or_404(ReprintRevision,
@@ -4852,12 +4892,12 @@ def save_reprint(request, reprint_revision_id, changeset_id,
     target = None
     target_revision = None
     target_issue = None
+    story_revision = None
 
     if story_revision_id:
         story_revision = StoryRevision.objects.get(id=story_revision_id)
         if 'reprint_notes' in request.POST:
             story_revision.reprint_notes = request.POST['reprint_notes']
-        story_revision.save()
         if story_revision.story:
             story_one_id = story_revision.story.id
             story_revision_id = None
@@ -4890,7 +4930,8 @@ def save_reprint(request, reprint_revision_id, changeset_id,
             target_issue = Issue.objects.get(id=issue_two_id)
 
     notes = request.POST['reprint_link_notes']
-    if revision:
+    is_new_revision = revision is None
+    if not is_new_revision:
         revision.origin = origin
         revision.origin_revision = origin_revision
         revision.origin_issue = origin_issue
@@ -4898,7 +4939,6 @@ def save_reprint(request, reprint_revision_id, changeset_id,
         revision.target_revision = target_revision
         revision.target_issue = target_issue
         revision.notes = notes
-        revision.save()
     else:
         revision = ReprintRevision(origin=origin,
                                    origin_revision=origin_revision,
@@ -4907,11 +4947,22 @@ def save_reprint(request, reprint_revision_id, changeset_id,
                                    target_revision=target_revision,
                                    target_issue=target_issue,
                                    notes=notes)
+
+    if revision.is_internal():
+        return render_error(
+            request, INTERNAL_REPRINT_ERROR, redirect=False)
+
+    if story_revision:
+        story_revision.save()
+
+    if is_new_revision:
         revision.save_added_revision(changeset=changeset)
         if request.POST['direction'] == 'from':
             request.session['which_side'] = 'origin'
         else:
             request.session['which_side'] = 'target'
+    else:
+        revision.save()
 
     if request.POST['comments'].strip():
         revision.comments.create(commenter=request.user,
@@ -5166,6 +5217,16 @@ def move_issue(request, issue_revision_id, series_id):
           'edit', kwargs={'id': issue_revision.changeset.id}))
 
 
+def _story_move_creates_internal_reprint(story, new_issue):
+    if not story.story_id or not new_issue.issue_id:
+        return False
+    return (
+      story.story.from_all_reprints.filter(
+        origin_issue_id=new_issue.issue_id).exists() or
+      story.story.to_all_reprints.filter(
+        target_issue_id=new_issue.issue_id).exists())
+
+
 @permission_required('indexer.can_reserve')
 def move_story_revision(request, id):
     """ move story revision between two issue revisions """
@@ -5182,6 +5243,9 @@ def move_story_revision(request, id):
         return _cant_get(request)
 
     new_issue = story.changeset.issuerevisions.exclude(issue=story.issue).get()
+    if _story_move_creates_internal_reprint(story, new_issue):
+        return render_error(
+            request, INTERNAL_REPRINT_ERROR, redirect=False)
     story.issue = new_issue.issue
 
     # In a two issue changeset (so far) one cannot add/edit reprints, but

--- a/apps/oi/views.py
+++ b/apps/oi/views.py
@@ -5220,11 +5220,11 @@ def move_issue(request, issue_revision_id, series_id):
 def _story_move_creates_internal_reprint(story, new_issue):
     if not story.story_id or not new_issue.issue_id:
         return False
-    return (
-      story.story.from_all_reprints.filter(
-        origin_issue_id=new_issue.issue_id).exists() or
-      story.story.to_all_reprints.filter(
-        target_issue_id=new_issue.issue_id).exists())
+    return Reprint.objects.filter(
+        Q(target_id=story.story_id,
+          origin_issue_id=new_issue.issue_id) |
+        Q(origin_id=story.story_id,
+          target_issue_id=new_issue.issue_id)).exists()
 
 
 @permission_required('indexer.can_reserve')

--- a/apps/oi/views.py
+++ b/apps/oi/views.py
@@ -53,6 +53,8 @@ from apps.gcd.views.details import (  # noqa: F401
 from apps.gcd.views.covers import get_image_tag, get_image_tags_per_issue
 from apps.gcd.views.search import do_advanced_search, used_search
 from apps.gcd.models.cover import ZOOM_LARGE, ZOOM_MEDIUM
+from apps.gcd.models.reprint import INTERNAL_REPRINT_ERROR, \
+                                    validate_reprint_issue_ids
 from apps.oi.templatetags.editing import show_revision_short
 from apps.select.views import store_select_data, get_cached_stories, \
                               get_cached_covers
@@ -217,7 +219,10 @@ REACHED_CHANGE_LIMIT = 'You have reached your limit of open changes.  You ' \
   'If you are an experienced indexer and frequently hit ' \
   'your reservation limit please contact us.'
 
-INTERNAL_REPRINT_ERROR = 'Reprint links must connect different issues.'
+INTERNAL_REPRINT_SELECT_TITLE = \
+  'Cannot select because reprint links must connect different issues.'
+INTERNAL_REPRINT_SELECT_HELP = \
+  'Current issue; cannot select for a reprint link.'
 
 ##############################################################################
 # Helper functions
@@ -4338,14 +4343,13 @@ def reserve_reprint(request, changeset_id, reprint_id):
       'edit_reprint', kwargs={'id': revision.id, 'which_side': which_side}))
 
 
-def _reprint_issue_id(story=None, story_revision=None, issue=None):
-    if story_revision:
-        return story_revision.issue_id
-    if story:
-        return story.issue_id
-    if issue:
-        return issue.id
-    return None
+def _reprint_select_exclusion(issue_id):
+    """Return reprint-specific metadata for the generic object selector."""
+    return {
+        'exclude_issue_id': issue_id,
+        'disabled_choice_title': INTERNAL_REPRINT_SELECT_TITLE,
+        'disabled_choice_help': INTERNAL_REPRINT_SELECT_HELP,
+    }
 
 
 @permission_required('indexer.can_reserve')
@@ -4420,9 +4424,6 @@ def edit_reprint(request, id, which_side=None):
         else:
             story_revision = reprint_revision.origin_revision
     elif which_side == 'flip_direction':
-        if reprint_revision.is_internal():
-            return render_error(
-                request, INTERNAL_REPRINT_ERROR, redirect=False)
         origin = reprint_revision.target
         origin_revision = reprint_revision.target_revision
         origin_issue = reprint_revision.target_issue
@@ -4442,9 +4443,6 @@ def edit_reprint(request, id, which_side=None):
           'list_issue_reprints', kwargs={'id': changeset_issue.id}))
     elif which_side == 'restore':
         if reprint_revision.deleted:
-            if reprint_revision.is_internal():
-                return render_error(
-                    request, INTERNAL_REPRINT_ERROR, redirect=False)
             reprint_revision.deleted = False
             reprint_revision.save()
             return HttpResponseRedirect(
@@ -4456,9 +4454,6 @@ def edit_reprint(request, id, which_side=None):
         return HttpResponseRedirect(
           urlresolvers.reverse('remove_reprint_revision', kwargs={'id': id}))
     elif which_side == 'matching_sequence':
-        if reprint_revision.is_internal():
-            return render_error(
-                request, INTERNAL_REPRINT_ERROR, redirect=False)
         if reprint_revision.origin:
             story = reprint_revision.origin
             issue = reprint_revision.target_issue
@@ -4567,8 +4562,12 @@ def edit_reprint(request, id, which_side=None):
         story_revision_id = None
         heading = 'Select story/issue for the reprint link with %s' \
                   % (esc(issue))
-    exclude_issue_id = _reprint_issue_id(
-      story=story, story_revision=story_revision, issue=issue)
+    if story_revision:
+        exclude_issue_id = story_revision.issue_id
+    elif story:
+        exclude_issue_id = story.issue_id
+    else:
+        exclude_issue_id = issue.id
     data = {'story_id': story_id,
             'story_revision_id': story_revision_id,
             'issue_id': issue_id,
@@ -4576,7 +4575,6 @@ def edit_reprint(request, id, which_side=None):
             'changeset_id': changeset.id,
             'story': True,
             'issue': True,
-            'exclude_issue_id': exclude_issue_id,
             'initial': initial,
             'heading': mark_safe('<h2>%s</h2>' % heading),
             'target': 'a story or issue',
@@ -4584,6 +4582,7 @@ def edit_reprint(request, id, which_side=None):
             'which_side': which_side,
             'cancel': urlresolvers.reverse('edit',
                                            kwargs={'id': changeset.id})}
+    data.update(_reprint_select_exclusion(exclude_issue_id))
     select_key = store_select_data(request, None, data)
     return HttpResponseRedirect(urlresolvers.reverse(
       'select_object', kwargs={'select_key': select_key}))
@@ -4618,13 +4617,13 @@ def add_reprint(request, changeset_id,
             'changeset_id': changeset_id,
             'story': True,
             'issue': True,
-            'exclude_issue_id': exclude_issue_id,
             'initial': initial,
             'heading': mark_safe('<h2>%s</h2>' % heading),
             'target': 'a story or issue',
             'return': 'confirm_reprint',
             'cancel': urlresolvers.reverse('edit',
                                            kwargs={'id': changeset_id})}
+    data.update(_reprint_select_exclusion(exclude_issue_id))
     select_key = store_select_data(request, None, data)
     return HttpResponseRedirect(urlresolvers.reverse(
       'select_object', kwargs={'select_key': select_key}))
@@ -4772,9 +4771,6 @@ def create_matching_sequence(request, reprint_revision_id, story_id, issue_id,
           'Only the reservation holder may access this page.')
     if issue != changeset_issue.issue:
         return _cant_get(request)
-    if reprint_revision.is_internal():
-        return render_error(
-            request, INTERNAL_REPRINT_ERROR, redirect=False)
     if request.method != 'POST' and not edit:
         if story == reprint_revision.origin:
             direction = 'from'
@@ -4824,7 +4820,6 @@ def confirm_reprint(request, data, object_type, selected_id):
 
     if 'story_id' in data and data['story_id']:
         story = get_object_or_404(Story, id=data['story_id'])
-        current_issue_id = story.issue_id
         story_revision = False
         story_story = True
         current_issue = None
@@ -4834,7 +4829,6 @@ def confirm_reprint(request, data, object_type, selected_id):
         story_revision = get_object_or_404(StoryRevision,
                                            id=data['story_revision_id'],
                                            changeset__id=data['changeset_id'])
-        current_issue_id = story_revision.issue_id
         story = PreviewStory.init(story_revision)
         current_issue = None
     elif 'issue_id' in data and data['issue_id']:
@@ -4842,15 +4836,13 @@ def confirm_reprint(request, data, object_type, selected_id):
         story_revision = False
         story = None
         current_issue = get_object_or_404(Issue, id=data['issue_id'])
-        current_issue_id = current_issue.id
     elif 'issue_revision_id' in data and data['issue_revision_id']:
         story_story = False
         story_revision = False
         story = None
-        current_issue_revision = get_object_or_404(
-          IssueRevision, id=data['issue_revision_id'])
-        current_issue = current_issue_revision.issue
-        current_issue_id = current_issue_revision.issue_id
+        current_issue = get_object_or_404(IssueRevision,
+                                          id=data['issue_revision_id'])
+        current_issue = current_issue.issue
     else:
         raise NotImplementedError
 
@@ -4859,15 +4851,19 @@ def confirm_reprint(request, data, object_type, selected_id):
     if object_type == 'story':
         selected_story = get_object_or_404(Story, id=selected_id)
         selected_issue = None
-        selected_issue_id = selected_story.issue_id
     else:
         selected_story = None
         selected_issue = get_object_or_404(Issue, id=selected_id)
-        selected_issue_id = selected_issue.id
 
-    if current_issue_id and current_issue_id == selected_issue_id:
-        return render_error(
-            request, INTERNAL_REPRINT_ERROR, redirect=False)
+    # A selector opened before deployment may lack this optional UX metadata;
+    # save-time model validation remains the authoritative fallback.
+    current_issue_id = data.get('exclude_issue_id')
+    selected_issue_id = (selected_story.issue_id if selected_story
+                         else selected_issue.id)
+    try:
+        validate_reprint_issue_ids(current_issue_id, selected_issue_id)
+    except ValueError as error:
+        return render_error(request, str(error), redirect=False)
 
     if 'reprint_revision_id' in data:
         reprint_revision = get_object_or_404(ReprintRevision,
@@ -4983,9 +4979,10 @@ def save_reprint(request, reprint_revision_id, changeset_id,
                                    target_issue=target_issue,
                                    notes=notes)
 
-    if revision.is_internal():
-        return render_error(
-            request, INTERNAL_REPRINT_ERROR, redirect=False)
+    try:
+        revision.validate_reprint_link()
+    except ValueError as error:
+        return render_error(request, str(error), redirect=False)
 
     if story_revision:
         story_revision.save()

--- a/apps/oi/views.py
+++ b/apps/oi/views.py
@@ -217,6 +217,8 @@ REACHED_CHANGE_LIMIT = 'You have reached your limit of open changes.  You ' \
   'If you are an experienced indexer and frequently hit ' \
   'your reservation limit please contact us.'
 
+INTERNAL_REPRINT_ERROR = 'Reprint links must connect different issues.'
+
 ##############################################################################
 # Helper functions
 ##############################################################################
@@ -4336,6 +4338,16 @@ def reserve_reprint(request, changeset_id, reprint_id):
       'edit_reprint', kwargs={'id': revision.id, 'which_side': which_side}))
 
 
+def _reprint_issue_id(story=None, story_revision=None, issue=None):
+    if story_revision:
+        return story_revision.issue_id
+    if story:
+        return story.issue_id
+    if issue:
+        return issue.id
+    return None
+
+
 @permission_required('indexer.can_reserve')
 def edit_reprint(request, id, which_side=None):
     reprint_revision = get_object_or_404(ReprintRevision, id=id)
@@ -4408,6 +4420,9 @@ def edit_reprint(request, id, which_side=None):
         else:
             story_revision = reprint_revision.origin_revision
     elif which_side == 'flip_direction':
+        if reprint_revision.is_internal():
+            return render_error(
+                request, INTERNAL_REPRINT_ERROR, redirect=False)
         origin = reprint_revision.target
         origin_revision = reprint_revision.target_revision
         origin_issue = reprint_revision.target_issue
@@ -4427,6 +4442,9 @@ def edit_reprint(request, id, which_side=None):
           'list_issue_reprints', kwargs={'id': changeset_issue.id}))
     elif which_side == 'restore':
         if reprint_revision.deleted:
+            if reprint_revision.is_internal():
+                return render_error(
+                    request, INTERNAL_REPRINT_ERROR, redirect=False)
             reprint_revision.deleted = False
             reprint_revision.save()
             return HttpResponseRedirect(
@@ -4438,6 +4456,9 @@ def edit_reprint(request, id, which_side=None):
         return HttpResponseRedirect(
           urlresolvers.reverse('remove_reprint_revision', kwargs={'id': id}))
     elif which_side == 'matching_sequence':
+        if reprint_revision.is_internal():
+            return render_error(
+                request, INTERNAL_REPRINT_ERROR, redirect=False)
         if reprint_revision.origin:
             story = reprint_revision.origin
             issue = reprint_revision.target_issue
@@ -4546,6 +4567,8 @@ def edit_reprint(request, id, which_side=None):
         story_revision_id = None
         heading = 'Select story/issue for the reprint link with %s' \
                   % (esc(issue))
+    exclude_issue_id = _reprint_issue_id(
+      story=story, story_revision=story_revision, issue=issue)
     data = {'story_id': story_id,
             'story_revision_id': story_revision_id,
             'issue_id': issue_id,
@@ -4553,6 +4576,7 @@ def edit_reprint(request, id, which_side=None):
             'changeset_id': changeset.id,
             'story': True,
             'issue': True,
+            'exclude_issue_id': exclude_issue_id,
             'initial': initial,
             'heading': mark_safe('<h2>%s</h2>' % heading),
             'target': 'a story or issue',
@@ -4571,9 +4595,11 @@ def add_reprint(request, changeset_id,
     if story_id:
         story = get_object_or_404(StoryRevision, id=story_id,
                                   changeset__id=changeset_id)
+        exclude_issue_id = story.issue_id
     else:
         issue = get_object_or_404(IssueRevision, id=issue_id,
                                   changeset__id=changeset_id)
+        exclude_issue_id = issue.issue_id
     if reprint_note:
         publisher, series, year, number, volume = \
             parse_reprint(unquote(reprint_note).split(';')[0])
@@ -4592,6 +4618,7 @@ def add_reprint(request, changeset_id,
             'changeset_id': changeset_id,
             'story': True,
             'issue': True,
+            'exclude_issue_id': exclude_issue_id,
             'initial': initial,
             'heading': mark_safe('<h2>%s</h2>' % heading),
             'target': 'a story or issue',
@@ -4745,6 +4772,9 @@ def create_matching_sequence(request, reprint_revision_id, story_id, issue_id,
           'Only the reservation holder may access this page.')
     if issue != changeset_issue.issue:
         return _cant_get(request)
+    if reprint_revision.is_internal():
+        return render_error(
+            request, INTERNAL_REPRINT_ERROR, redirect=False)
     if request.method != 'POST' and not edit:
         if story == reprint_revision.origin:
             direction = 'from'
@@ -4794,6 +4824,7 @@ def confirm_reprint(request, data, object_type, selected_id):
 
     if 'story_id' in data and data['story_id']:
         story = get_object_or_404(Story, id=data['story_id'])
+        current_issue_id = story.issue_id
         story_revision = False
         story_story = True
         current_issue = None
@@ -4803,6 +4834,7 @@ def confirm_reprint(request, data, object_type, selected_id):
         story_revision = get_object_or_404(StoryRevision,
                                            id=data['story_revision_id'],
                                            changeset__id=data['changeset_id'])
+        current_issue_id = story_revision.issue_id
         story = PreviewStory.init(story_revision)
         current_issue = None
     elif 'issue_id' in data and data['issue_id']:
@@ -4810,13 +4842,15 @@ def confirm_reprint(request, data, object_type, selected_id):
         story_revision = False
         story = None
         current_issue = get_object_or_404(Issue, id=data['issue_id'])
+        current_issue_id = current_issue.id
     elif 'issue_revision_id' in data and data['issue_revision_id']:
         story_story = False
         story_revision = False
         story = None
-        current_issue = get_object_or_404(IssueRevision,
-                                          id=data['issue_revision_id'])
-        current_issue = current_issue.issue
+        current_issue_revision = get_object_or_404(
+          IssueRevision, id=data['issue_revision_id'])
+        current_issue = current_issue_revision.issue
+        current_issue_id = current_issue_revision.issue_id
     else:
         raise NotImplementedError
 
@@ -4825,9 +4859,15 @@ def confirm_reprint(request, data, object_type, selected_id):
     if object_type == 'story':
         selected_story = get_object_or_404(Story, id=selected_id)
         selected_issue = None
+        selected_issue_id = selected_story.issue_id
     else:
         selected_story = None
         selected_issue = get_object_or_404(Issue, id=selected_id)
+        selected_issue_id = selected_issue.id
+
+    if current_issue_id and current_issue_id == selected_issue_id:
+        return render_error(
+            request, INTERNAL_REPRINT_ERROR, redirect=False)
 
     if 'reprint_revision_id' in data:
         reprint_revision = get_object_or_404(ReprintRevision,
@@ -4887,12 +4927,12 @@ def save_reprint(request, reprint_revision_id, changeset_id,
     target = None
     target_revision = None
     target_issue = None
+    story_revision = None
 
     if story_revision_id:
         story_revision = StoryRevision.objects.get(id=story_revision_id)
         if 'reprint_notes' in request.POST:
             story_revision.reprint_notes = request.POST['reprint_notes']
-        story_revision.save()
         if story_revision.story:
             story_one_id = story_revision.story.id
             story_revision_id = None
@@ -4925,7 +4965,8 @@ def save_reprint(request, reprint_revision_id, changeset_id,
             target_issue = Issue.objects.get(id=issue_two_id)
 
     notes = request.POST['reprint_link_notes']
-    if revision:
+    is_new_revision = revision is None
+    if not is_new_revision:
         revision.origin = origin
         revision.origin_revision = origin_revision
         revision.origin_issue = origin_issue
@@ -4933,7 +4974,6 @@ def save_reprint(request, reprint_revision_id, changeset_id,
         revision.target_revision = target_revision
         revision.target_issue = target_issue
         revision.notes = notes
-        revision.save()
     else:
         revision = ReprintRevision(origin=origin,
                                    origin_revision=origin_revision,
@@ -4942,11 +4982,22 @@ def save_reprint(request, reprint_revision_id, changeset_id,
                                    target_revision=target_revision,
                                    target_issue=target_issue,
                                    notes=notes)
+
+    if revision.is_internal():
+        return render_error(
+            request, INTERNAL_REPRINT_ERROR, redirect=False)
+
+    if story_revision:
+        story_revision.save()
+
+    if is_new_revision:
         revision.save_added_revision(changeset=changeset)
         if request.POST['direction'] == 'from':
             request.session['which_side'] = 'origin'
         else:
             request.session['which_side'] = 'target'
+    else:
+        revision.save()
 
     if request.POST['comments'].strip():
         revision.comments.create(commenter=request.user,
@@ -5201,6 +5252,16 @@ def move_issue(request, issue_revision_id, series_id):
           'edit', kwargs={'id': issue_revision.changeset.id}))
 
 
+def _story_move_creates_internal_reprint(story, new_issue):
+    if not story.story_id or not new_issue.issue_id:
+        return False
+    return (
+      story.story.from_all_reprints.filter(
+        origin_issue_id=new_issue.issue_id).exists() or
+      story.story.to_all_reprints.filter(
+        target_issue_id=new_issue.issue_id).exists())
+
+
 @permission_required('indexer.can_reserve')
 def move_story_revision(request, id):
     """ move story revision between two issue revisions """
@@ -5217,6 +5278,9 @@ def move_story_revision(request, id):
         return _cant_get(request)
 
     new_issue = story.changeset.issuerevisions.exclude(issue=story.issue).get()
+    if _story_move_creates_internal_reprint(story, new_issue):
+        return render_error(
+            request, INTERNAL_REPRINT_ERROR, redirect=False)
     story.issue = new_issue.issue
 
     # In a two issue changeset (so far) one cannot add/edit reprints, but

--- a/apps/oi/views.py
+++ b/apps/oi/views.py
@@ -5255,11 +5255,11 @@ def move_issue(request, issue_revision_id, series_id):
 def _story_move_creates_internal_reprint(story, new_issue):
     if not story.story_id or not new_issue.issue_id:
         return False
-    return (
-      story.story.from_all_reprints.filter(
-        origin_issue_id=new_issue.issue_id).exists() or
-      story.story.to_all_reprints.filter(
-        target_issue_id=new_issue.issue_id).exists())
+    return Reprint.objects.filter(
+        Q(target_id=story.story_id,
+          origin_issue_id=new_issue.issue_id) |
+        Q(origin_id=story.story_id,
+          target_issue_id=new_issue.issue_id)).exists()
 
 
 @permission_required('indexer.can_reserve')

--- a/apps/select/forms.py
+++ b/apps/select/forms.py
@@ -7,24 +7,35 @@ from apps.gcd.templatetags.display import show_story_short
 
 
 def get_select_cache_form(cached_issues=None, cached_stories=None,
-                          cached_covers=None):
+                          cached_covers=None, exclude_issue_id=None):
 
     class SelectCacheForm(forms.Form):
         fields = []
+        disabled_choices = []
         if cached_issues:
             for cached_issue in cached_issues:
-                fields.append(('issue_%d' % cached_issue.id,
+                choice = 'issue_%d' % cached_issue.id
+                fields.append((choice,
                               'issue: %s' % cached_issue))
+                if cached_issue.id == exclude_issue_id:
+                    disabled_choices.append(choice)
         if cached_stories:
             for cached_story in cached_stories:
-                fields.append(('story_%d' % cached_story.id,
+                choice = 'story_%d' % cached_story.id
+                fields.append((choice,
                               mark_safe('story: %s in %s' %
                                         (show_story_short(cached_story),
                                          esc(cached_story.issue)))))
+                if cached_story.issue_id == exclude_issue_id:
+                    disabled_choices.append(choice)
         if cached_covers:
             for cached_cover in cached_covers:
-                fields.append(('cover_%d' % cached_cover.id,
+                choice = 'cover_%d' % cached_cover.id
+                fields.append((choice,
                               'cover of issue: %s' % cached_cover.issue))
+                if cached_cover.issue_id == exclude_issue_id:
+                    disabled_choices.append(choice)
+        disabled_choices = tuple(disabled_choices)
         if fields:
             object_choice = forms.ChoiceField(widget=RadioSelect,
                                               choices=fields, label='')

--- a/apps/select/templates/select/select_object.html
+++ b/apps/select/templates/select/select_object.html
@@ -72,9 +72,20 @@ or select from the data cache:
     {% for radio in cache_form.object_choice %}
 <form action="{% url 'select_object' select_key=select_key %}" method="POST">
       {% csrf_token %}
-<button class="btn-blue-editing inline" type="submit" name="select_object">Select</button>
+<button
+  class="{% if radio.data.value in disabled_choices %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline py-1 px-2"
+  type="submit" name="select_object"
+  {% if radio.data.value in disabled_choices %}
+  disabled
+  aria-describedby="disabled-reprint-{{ forloop.counter }}"
+  title="Cannot select because reprint links must connect different issues."
+  {% endif %}>Select</button>
  <input type="hidden" name="object_choice" value="{{ radio.data.value }}">
       {{ radio.choice_label }}
+      {% if radio.data.value in disabled_choices %}
+        <small id="disabled-reprint-{{ forloop.counter }}"><em>(Current issue;
+        cannot select for a reprint link.)</em></small>
+      {% endif %}
 </form>
     {% endfor %}
   {% endif %}

--- a/apps/select/templates/select/select_object.html
+++ b/apps/select/templates/select/select_object.html
@@ -73,18 +73,18 @@ or select from the data cache:
 <form action="{% url 'select_object' select_key=select_key %}" method="POST">
       {% csrf_token %}
 <button
-  class="{% if radio.data.value in disabled_choices %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline py-1 px-2"
+  class="{% if radio.data.value in cache_form.disabled_choices %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline py-1 px-2"
   type="submit" name="select_object"
-  {% if radio.data.value in disabled_choices %}
+  {% if radio.data.value in cache_form.disabled_choices %}
   disabled
-  aria-describedby="disabled-reprint-{{ forloop.counter }}"
-  title="Cannot select because reprint links must connect different issues."
+  aria-describedby="disabled-choice-{{ forloop.counter }}"
+  title="{{ disabled_choice_title }}"
   {% endif %}>Select</button>
  <input type="hidden" name="object_choice" value="{{ radio.data.value }}">
       {{ radio.choice_label }}
-      {% if radio.data.value in disabled_choices %}
-        <small id="disabled-reprint-{{ forloop.counter }}"><em>(Current issue;
-        cannot select for a reprint link.)</em></small>
+      {% if radio.data.value in cache_form.disabled_choices %}
+        <small id="disabled-choice-{{ forloop.counter }}"><em>
+        ({{ disabled_choice_help }})</em></small>
       {% endif %}
 </form>
     {% endfor %}

--- a/apps/select/views.py
+++ b/apps/select/views.py
@@ -73,7 +73,8 @@ def get_select_data(request, select_key):
 
 
 def get_select_forms(request, initial, data, publisher=False,
-                     series=False, issue=False, story=False, cover=False):
+                     series=False, issue=False, story=False, cover=False,
+                     exclude_issue_id=None):
     if issue:
         cached_issues = get_cached_issues(request)
     else:
@@ -99,7 +100,8 @@ def get_select_forms(request, initial, data, publisher=False,
 
     cache_form = get_select_cache_form(cached_issues=cached_issues,
                                        cached_stories=cached_stories,
-                                       cached_covers=cached_covers)()
+                                       cached_covers=cached_covers,
+                                       exclude_issue_id=exclude_issue_id)()
 
     return search_form, cache_form
 
@@ -298,6 +300,7 @@ def select_object(request, select_key):
         issue = data.get('issue', False)
         story = data.get('story', False)
         cover = data.get('cover', False)
+        exclude_issue_id = data.get('exclude_issue_id')
         search_form, cache_form = get_select_forms(request,
                                                    initial,
                                                    request_data,
@@ -305,12 +308,15 @@ def select_object(request, select_key):
                                                    series=series,
                                                    issue=issue,
                                                    story=story,
-                                                   cover=cover)
+                                                   cover=cover,
+                                                   exclude_issue_id=(
+                                                     exclude_issue_id))
         haystack_form = FacetedSearchForm()
         return render(request, 'select/select_object.html',
                       {'heading': data['heading'],
                        'select_key': select_key,
                        'cache_form': cache_form,
+                       'disabled_choices': cache_form.disabled_choices,
                        'search_form': search_form,
                        'haystack_form': haystack_form,
                        'publisher': publisher,

--- a/apps/select/views.py
+++ b/apps/select/views.py
@@ -327,6 +327,8 @@ def select_object(request, select_key):
         story = data.get('story', False)
         cover = data.get('cover', False)
         exclude_issue_id = data.get('exclude_issue_id')
+        disabled_choice_title = data.get('disabled_choice_title', '')
+        disabled_choice_help = data.get('disabled_choice_help', '')
         search_form, cache_form = get_select_forms(request,
                                                    initial,
                                                    request_data,
@@ -342,7 +344,8 @@ def select_object(request, select_key):
                       {'heading': data['heading'],
                        'select_key': select_key,
                        'cache_form': cache_form,
-                       'disabled_choices': cache_form.disabled_choices,
+                       'disabled_choice_title': disabled_choice_title,
+                       'disabled_choice_help': disabled_choice_help,
                        'search_form': search_form,
                        'haystack_form': haystack_form,
                        'publisher': publisher,

--- a/apps/select/views.py
+++ b/apps/select/views.py
@@ -77,7 +77,8 @@ def get_select_data(request, select_key):
 
 
 def get_select_forms(request, initial, data, publisher=False,
-                     series=False, issue=False, story=False, cover=False):
+                     series=False, issue=False, story=False, cover=False,
+                     exclude_issue_id=None):
     if issue:
         cached_issues = get_cached_issues(request)
     else:
@@ -103,7 +104,8 @@ def get_select_forms(request, initial, data, publisher=False,
 
     cache_form = get_select_cache_form(cached_issues=cached_issues,
                                        cached_stories=cached_stories,
-                                       cached_covers=cached_covers)()
+                                       cached_covers=cached_covers,
+                                       exclude_issue_id=exclude_issue_id)()
 
     return search_form, cache_form
 
@@ -324,6 +326,7 @@ def select_object(request, select_key):
         issue = data.get('issue', False)
         story = data.get('story', False)
         cover = data.get('cover', False)
+        exclude_issue_id = data.get('exclude_issue_id')
         search_form, cache_form = get_select_forms(request,
                                                    initial,
                                                    request_data,
@@ -331,12 +334,15 @@ def select_object(request, select_key):
                                                    series=series,
                                                    issue=issue,
                                                    story=story,
-                                                   cover=cover)
+                                                   cover=cover,
+                                                   exclude_issue_id=(
+                                                     exclude_issue_id))
         haystack_form = FacetedSearchForm()
         return render(request, 'select/select_object.html',
                       {'heading': data['heading'],
                        'select_key': select_key,
                        'cache_form': cache_form,
+                       'disabled_choices': cache_form.disabled_choices,
                        'search_form': search_form,
                        'haystack_form': haystack_form,
                        'publisher': publisher,

--- a/templates/oi/bits/reprint_type_list.html
+++ b/templates/oi/bits/reprint_type_list.html
@@ -6,22 +6,26 @@
   <td class="ps-1"> {{ reprint|link_other_reprint:is_source }}</td>
 {% endif %}
   <td>
+{% with reprint.is_internal as internal_reprint %}
 {% if not reprint|is_locked and not reprint.changeset %}
     <form action="{% url 'reserve_reprint' reprint_id=reprint.id changeset_id=changeset.id %}" method="POST">
   {% csrf_token %}
   {% if not is_source %}
-      <button class="btn-blue-editing inline" type="submit" name="edit_target_internal">Change Target</button>
-      <button class="btn-blue-editing inline" type="submit" name="edit_origin">Change Origin</button>
-      <button class="btn-blue-editing inline" type="submit" name="edit_note_target">Edit Note</button>
+      <button class="btn-blue-editing inline" type="submit" name="{% if internal_reprint %}edit_target{% else %}edit_target_internal{% endif %}">Change Target</button>
+      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-target-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="edit_origin">Change Origin</button>
+      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-target-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="edit_note_target">Edit Note</button>
   {% else %}
-      <button class="btn-blue-editing inline" type="submit" name="edit_origin_internal">Change Origin</button>
+      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-source-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="edit_origin_internal">Change Origin</button>
       <button class="btn-blue-editing inline" type="submit" name="edit_target">Change Target</button>
-      <button class="btn-blue-editing inline" type="submit" name="edit_note_origin">Edit Note</button>
+      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-source-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="edit_note_origin">Edit Note</button>
   {% endif %}
-      <button class="btn-blue-editing inline" type="submit" name="flip_direction">Flip Reprint Direction</button>
+      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-{% if is_source %}source{% else %}target{% endif %}-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="flip_direction">Flip Reprint Direction</button>
       <button class="btn-blue-editing inline" type="submit" name="delete">Mark To Delete</button>
   {% if create_sequence %}
-      <button class="btn-blue-editing inline" type="submit" name="matching_sequence">Create Corresponding Sequence</button>
+      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-{% if is_source %}source{% else %}target{% endif %}-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="matching_sequence">Create Corresponding Sequence</button>
+  {% endif %}
+  {% if internal_reprint %}
+      <small id="internal-reprint-{{ reprint.id }}-{% if is_source %}source{% else %}target{% endif %}-reason"><em>(Legacy internal link; change its target or mark it to delete.)</em></small>
   {% endif %}
     </form>
 {% else %}
@@ -29,25 +33,31 @@
     <form action="{% url 'edit_reprint' id=reprint.id %}" method="POST">
     {% csrf_token %}
     {% if reprint.deleted %}
-      <button class="btn-blue-editing inline" type="submit" name="restore">Restore</button>
+      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-{% if is_source %}source{% else %}target{% endif %}-reason" title="Cannot restore because reprint links must connect different issues."{% endif %} name="restore">Restore</button>
+      {% if internal_reprint %}
+      <small id="internal-reprint-{{ reprint.id }}-{% if is_source %}source{% else %}target{% endif %}-reason"><em>(Legacy internal link; restoring it is unavailable.)</em></small>
+      {% endif %}
     {% else %}
       {% if not is_source %}
-      <button class="btn-blue-editing inline {% if not reprint.source %}bg-stone-100 hover:bg-stone-100 {% endif %}" type="submit" {% if not reprint.source %} disabled {% endif %} name="edit_target_internal">Change Target</button>
-      <button class="btn-blue-editing inline" type="submit" name="edit_origin">Change Origin</button>
-      <button class="btn-blue-editing inline" type="submit" name="edit_note_target">Edit Note</button>
+      <button class="btn-blue-editing inline {% if not reprint.source %}bg-stone-100 hover:bg-stone-100 {% endif %}" type="submit" {% if not reprint.source %} disabled {% endif %} name="{% if internal_reprint %}edit_target{% else %}edit_target_internal{% endif %}">Change Target</button>
+      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-target-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="edit_origin">Change Origin</button>
+      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-target-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="edit_note_target">Edit Note</button>
       {% else %}
-      <button class="btn-blue-editing inline {% if not reprint.source %}bg-stone-100 hover:bg-stone-100 {% endif %}" type="submit" {% if not reprint.source %} disabled {% endif %} name="edit_origin_internal">Change Origin</button>
+      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing {% if not reprint.source %}bg-stone-100 hover:bg-stone-100 {% endif %}{% endif %} inline" type="submit" {% if internal_reprint or not reprint.source %}disabled{% endif %} {% if internal_reprint %}aria-describedby="internal-reprint-{{ reprint.id }}-source-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="edit_origin_internal">Change Origin</button>
       <button class="btn-blue-editing inline" type="submit" name="edit_target">Change Target</button>
-      <button class="btn-blue-editing inline" type="submit" name="edit_note_origin">Edit Note</button>
+      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-source-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="edit_note_origin">Edit Note</button>
       {% endif %}
-      <button class="btn-blue-editing inline" type="submit" name="flip_direction">Flip Reprint Direction</button>
+      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-{% if is_source %}source{% else %}target{% endif %}-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="flip_direction">Flip Reprint Direction</button>
       {% if reprint.source %}
       <button class="btn-blue-editing inline" type="submit" name="delete">Mark To Delete</button>
       {% else %}
       <button class="btn-blue-editing inline" type="submit" name="remove">Remove</button>
       {% endif %}
       {% if create_sequence %}
-      <button class="btn-blue-editing inline" type="submit" name="matching_sequence">Create Corresponding Sequence</button>
+      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-{% if is_source %}source{% else %}target{% endif %}-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="matching_sequence">Create Corresponding Sequence</button>
+      {% endif %}
+      {% if internal_reprint %}
+      <small id="internal-reprint-{{ reprint.id }}-{% if is_source %}source{% else %}target{% endif %}-reason"><em>(Legacy internal link; change its target or mark it to delete.)</em></small>
       {% endif %}
     {% endif %}
     </form>
@@ -56,18 +66,21 @@
     <form action="{% url 'reserve_reprint' reprint_id=reprint.source.id changeset_id=changeset.id %}" method="POST">
       {% csrf_token %}
       {% if not is_source %}
-      <button class="btn-blue-editing inline" type="submit" name="edit_target_internal">Change Target</button>
-      <button class="btn-blue-editing inline" type="submit" name="edit_origin">Change Origin</button>
-      <button class="btn-blue-editing inline" type="submit" name="edit_note_target">Edit Note</button>
+      <button class="btn-blue-editing inline" type="submit" name="{% if internal_reprint %}edit_target{% else %}edit_target_internal{% endif %}">Change Target</button>
+      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-target-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="edit_origin">Change Origin</button>
+      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-target-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="edit_note_target">Edit Note</button>
       {% else %}
-      <button class="btn-blue-editing inline" type="submit" name="edit_origin_internal">Change Origin</button>
+      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-source-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="edit_origin_internal">Change Origin</button>
       <button class="btn-blue-editing inline" type="submit" name="edit_target">Change Target</button>
-      <button class="btn-blue-editing inline" type="submit" name="edit_note_origin">Edit Note</button>
+      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-source-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="edit_note_origin">Edit Note</button>
       {% endif %}
-      <button class="btn-blue-editing inline" type="submit" name="flip_direction">Flip Reprint Direction</button>
+      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-{% if is_source %}source{% else %}target{% endif %}-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="flip_direction">Flip Reprint Direction</button>
       <button class="btn-blue-editing inline" type="submit" name="delete">Mark To Delete</button>
       {% if create_sequence %}
-      <button class="btn-blue-editing inline" type="submit" name="matching_sequence">Create Corresponding Sequence</button>
+      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-{% if is_source %}source{% else %}target{% endif %}-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="matching_sequence">Create Corresponding Sequence</button>
+      {% endif %}
+      {% if internal_reprint %}
+      <small id="internal-reprint-{{ reprint.id }}-{% if is_source %}source{% else %}target{% endif %}-reason"><em>(Legacy internal link; change its target or mark it to delete.)</em></small>
       {% endif %}
     </form>
     {% else %}
@@ -81,5 +94,6 @@
     </span>
   {% endif %}
 {% endif %}
+{% endwith %}
   </td>
 </tr>

--- a/templates/oi/bits/reprint_type_list.html
+++ b/templates/oi/bits/reprint_type_list.html
@@ -6,26 +6,22 @@
   <td class="ps-1"> {{ reprint|link_other_reprint:is_source }}</td>
 {% endif %}
   <td>
-{% with reprint.is_internal as internal_reprint %}
 {% if not reprint|is_locked and not reprint.changeset %}
     <form action="{% url 'reserve_reprint' reprint_id=reprint.id changeset_id=changeset.id %}" method="POST">
   {% csrf_token %}
   {% if not is_source %}
-      <button class="btn-blue-editing inline" type="submit" name="{% if internal_reprint %}edit_target{% else %}edit_target_internal{% endif %}">Change Target</button>
-      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-target-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="edit_origin">Change Origin</button>
-      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-target-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="edit_note_target">Edit Note</button>
+      <button class="btn-blue-editing inline" type="submit" name="edit_target_internal">Change Target</button>
+      <button class="btn-blue-editing inline" type="submit" name="edit_origin">Change Origin</button>
+      <button class="btn-blue-editing inline" type="submit" name="edit_note_target">Edit Note</button>
   {% else %}
-      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-source-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="edit_origin_internal">Change Origin</button>
+      <button class="btn-blue-editing inline" type="submit" name="edit_origin_internal">Change Origin</button>
       <button class="btn-blue-editing inline" type="submit" name="edit_target">Change Target</button>
-      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-source-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="edit_note_origin">Edit Note</button>
+      <button class="btn-blue-editing inline" type="submit" name="edit_note_origin">Edit Note</button>
   {% endif %}
-      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-{% if is_source %}source{% else %}target{% endif %}-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="flip_direction">Flip Reprint Direction</button>
+      <button class="btn-blue-editing inline" type="submit" name="flip_direction">Flip Reprint Direction</button>
       <button class="btn-blue-editing inline" type="submit" name="delete">Mark To Delete</button>
   {% if create_sequence %}
-      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-{% if is_source %}source{% else %}target{% endif %}-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="matching_sequence">Create Corresponding Sequence</button>
-  {% endif %}
-  {% if internal_reprint %}
-      <small id="internal-reprint-{{ reprint.id }}-{% if is_source %}source{% else %}target{% endif %}-reason"><em>(Legacy internal link; change its target or mark it to delete.)</em></small>
+      <button class="btn-blue-editing inline" type="submit" name="matching_sequence">Create Corresponding Sequence</button>
   {% endif %}
     </form>
 {% else %}
@@ -33,31 +29,25 @@
     <form action="{% url 'edit_reprint' id=reprint.id %}" method="POST">
     {% csrf_token %}
     {% if reprint.deleted %}
-      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-{% if is_source %}source{% else %}target{% endif %}-reason" title="Cannot restore because reprint links must connect different issues."{% endif %} name="restore">Restore</button>
-      {% if internal_reprint %}
-      <small id="internal-reprint-{{ reprint.id }}-{% if is_source %}source{% else %}target{% endif %}-reason"><em>(Legacy internal link; restoring it is unavailable.)</em></small>
-      {% endif %}
+      <button class="btn-blue-editing inline" type="submit" name="restore">Restore</button>
     {% else %}
       {% if not is_source %}
-      <button class="btn-blue-editing inline {% if not reprint.source %}bg-stone-100 hover:bg-stone-100 {% endif %}" type="submit" {% if not reprint.source %} disabled {% endif %} name="{% if internal_reprint %}edit_target{% else %}edit_target_internal{% endif %}">Change Target</button>
-      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-target-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="edit_origin">Change Origin</button>
-      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-target-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="edit_note_target">Edit Note</button>
+      <button class="btn-blue-editing inline {% if not reprint.source %}bg-stone-100 hover:bg-stone-100 {% endif %}" type="submit" {% if not reprint.source %} disabled {% endif %} name="edit_target_internal">Change Target</button>
+      <button class="btn-blue-editing inline" type="submit" name="edit_origin">Change Origin</button>
+      <button class="btn-blue-editing inline" type="submit" name="edit_note_target">Edit Note</button>
       {% else %}
-      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing {% if not reprint.source %}bg-stone-100 hover:bg-stone-100 {% endif %}{% endif %} inline" type="submit" {% if internal_reprint or not reprint.source %}disabled{% endif %} {% if internal_reprint %}aria-describedby="internal-reprint-{{ reprint.id }}-source-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="edit_origin_internal">Change Origin</button>
+      <button class="btn-blue-editing inline {% if not reprint.source %}bg-stone-100 hover:bg-stone-100 {% endif %}" type="submit" {% if not reprint.source %} disabled {% endif %} name="edit_origin_internal">Change Origin</button>
       <button class="btn-blue-editing inline" type="submit" name="edit_target">Change Target</button>
-      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-source-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="edit_note_origin">Edit Note</button>
+      <button class="btn-blue-editing inline" type="submit" name="edit_note_origin">Edit Note</button>
       {% endif %}
-      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-{% if is_source %}source{% else %}target{% endif %}-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="flip_direction">Flip Reprint Direction</button>
+      <button class="btn-blue-editing inline" type="submit" name="flip_direction">Flip Reprint Direction</button>
       {% if reprint.source %}
       <button class="btn-blue-editing inline" type="submit" name="delete">Mark To Delete</button>
       {% else %}
       <button class="btn-blue-editing inline" type="submit" name="remove">Remove</button>
       {% endif %}
       {% if create_sequence %}
-      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-{% if is_source %}source{% else %}target{% endif %}-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="matching_sequence">Create Corresponding Sequence</button>
-      {% endif %}
-      {% if internal_reprint %}
-      <small id="internal-reprint-{{ reprint.id }}-{% if is_source %}source{% else %}target{% endif %}-reason"><em>(Legacy internal link; change its target or mark it to delete.)</em></small>
+      <button class="btn-blue-editing inline" type="submit" name="matching_sequence">Create Corresponding Sequence</button>
       {% endif %}
     {% endif %}
     </form>
@@ -66,21 +56,18 @@
     <form action="{% url 'reserve_reprint' reprint_id=reprint.source.id changeset_id=changeset.id %}" method="POST">
       {% csrf_token %}
       {% if not is_source %}
-      <button class="btn-blue-editing inline" type="submit" name="{% if internal_reprint %}edit_target{% else %}edit_target_internal{% endif %}">Change Target</button>
-      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-target-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="edit_origin">Change Origin</button>
-      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-target-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="edit_note_target">Edit Note</button>
+      <button class="btn-blue-editing inline" type="submit" name="edit_target_internal">Change Target</button>
+      <button class="btn-blue-editing inline" type="submit" name="edit_origin">Change Origin</button>
+      <button class="btn-blue-editing inline" type="submit" name="edit_note_target">Edit Note</button>
       {% else %}
-      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-source-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="edit_origin_internal">Change Origin</button>
+      <button class="btn-blue-editing inline" type="submit" name="edit_origin_internal">Change Origin</button>
       <button class="btn-blue-editing inline" type="submit" name="edit_target">Change Target</button>
-      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-source-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="edit_note_origin">Edit Note</button>
+      <button class="btn-blue-editing inline" type="submit" name="edit_note_origin">Edit Note</button>
       {% endif %}
-      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-{% if is_source %}source{% else %}target{% endif %}-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="flip_direction">Flip Reprint Direction</button>
+      <button class="btn-blue-editing inline" type="submit" name="flip_direction">Flip Reprint Direction</button>
       <button class="btn-blue-editing inline" type="submit" name="delete">Mark To Delete</button>
       {% if create_sequence %}
-      <button class="{% if internal_reprint %}btn-blue-disabled{% else %}btn-blue-editing{% endif %} inline" type="submit" {% if internal_reprint %}disabled aria-describedby="internal-reprint-{{ reprint.id }}-{% if is_source %}source{% else %}target{% endif %}-reason" title="Unavailable for an internal reprint link. Change the target or mark it to delete."{% endif %} name="matching_sequence">Create Corresponding Sequence</button>
-      {% endif %}
-      {% if internal_reprint %}
-      <small id="internal-reprint-{{ reprint.id }}-{% if is_source %}source{% else %}target{% endif %}-reason"><em>(Legacy internal link; change its target or mark it to delete.)</em></small>
+      <button class="btn-blue-editing inline" type="submit" name="matching_sequence">Create Corresponding Sequence</button>
       {% endif %}
     </form>
     {% else %}
@@ -94,6 +81,5 @@
     </span>
   {% endif %}
 {% endif %}
-{% endwith %}
   </td>
 </tr>


### PR DESCRIPTION
## Summary

Fixes #708.

Reprint links whose origin and target belong to the same issue are not meaningful reprints. The site previously allowed users to create these internal links, after which several reprint-editing operations could fail with unhandled exceptions.

This change establishes the invariant that a reprint’s origin and target cannot belong to the same issue. It enforces that invariant at the model boundary and throughout the OI workflows that can create or indirectly produce a reprint link.

The change also preserves a limited cleanup path for legacy internal links already present in imported data:

- **Change Target** remains available so the target can be moved to another issue.
- **Mark To Delete** remains available.
- **Change Origin**, **Edit Note**, **Flip Reprint Direction**, and **Create Corresponding Sequence** are disabled.
- Once a legacy internal link is marked for deletion, **Restore** is disabled.

No existing reprint records are automatically deleted or modified by this PR.

## Problem and root cause

As described in #708, the application could accept reprint links between two sequences in the same issue even though those relationships are not reprints.

There was no single invariant preventing this at either of the main persistence boundaries:

- `Reprint`, for records in the display database.
- `ReprintRevision`, for changes being processed through OI.

This meant an internal link could arise through several paths:

- Selecting the current issue, one of its sequences, or one of its covers while adding or editing a reprint.
- Entering the current issue ID or one of its story IDs manually.
- Flipping or restoring a legacy internal link.
- Creating a corresponding sequence from an internal link.
- Moving a story or sequence between issues when an existing external reprint would become internal after the move.
- Calling model or view code directly without passing through the selector UI.

Some of these paths reached the persistence layer and raised an unhandled `ValueError`; others could partially save related revisions before the invalid relationship was discovered.

## Resulting behavior

| Operation | Result |
|---|---|
| Add a reprint to the current issue | Rejected |
| Add a reprint to a sequence in the current issue | Rejected |
| Add a reprint to a cover in the current issue | Rejected |
| Manually enter the current issue or story ID | Rejected before the reprint edit/save workflow proceeds |
| Save an internal `Reprint` directly | Rejected by the model |
| Save a new or modified internal `ReprintRevision` | Rejected by the model |
| Change the target of a legacy internal link | Allowed, so the link can be repaired |
| Change the origin of a legacy internal link | Disabled |
| Edit the note on a legacy internal link | Disabled |
| Flip a legacy internal link | Disabled and rejected server-side |
| Create a corresponding sequence from an internal link | Disabled and rejected server-side |
| Mark a legacy internal link for deletion | Allowed |
| Restore a deleted internal link | Disabled and rejected server-side |
| Move a story or sequence when the move would make a reprint internal | Rejected before reservation or mutation |
| Create or edit a normal cross-issue reprint | Unchanged |

The common user-facing validation message is:

> Reprint origin and target cannot be in the same issue.

## Implementation details

### Model-level invariant

`Reprint` and `ReprintRevision` expose an `is_internal()` helper and validate the issue boundary during `save()`.

The display model rejects any persisted reprint whose resolved origin and target issue IDs are equal.

The revision model rejects new or modified non-deleted internal revisions. It has one deliberately narrow exception: OI may create the initial revision history for an already-existing legacy internal `Reprint`.

That exception:

- Requires an existing display-database reprint.
- Only applies while creating its first cloned revision.
- Does not permit creation of a new internal reprint.
- Does not permit subsequent edits that leave the revision internal.
- Allows imported legacy data to be reserved and then repaired or deleted through OI.

### OI workflow validation

The affected reprint views check the invariant before performing related writes. This includes:

- Reprint selection and confirmation.
- Saving reprint changes.
- Flipping the relationship.
- Restoring a deleted relationship.
- Creating a corresponding sequence.
- Moving a story or sequence between issues.

The save flow validates the assembled reprint revision before saving an associated `StoryRevision`. An invalid request therefore does not leave behind an unrelated story revision.

Story and sequence moves are checked before objects are reserved or mutated, preventing an existing cross-issue link from silently becoming internal as a side effect of a move.

Server-side checks remain in place even when the corresponding control is disabled in the template. Stale pages, direct POST requests, and hand-entered IDs therefore return a normal validation response rather than a server error.

### Object selector

The object selector accepts the current issue as an exclusion and disables choices representing:

- The current issue.
- Stories or sequences belonging to the current issue.
- Covers belonging to the current issue.

The disabled choices are maintained as an immutable tuple on the form instance.

Users can still enter IDs manually, so the selector behavior is backed by server-side validation during selection confirmation and save.

### Legacy-link controls

For an existing internal reprint link:

- **Change Target** uses the normal global object selector and remains enabled.
- **Mark To Delete** remains enabled.
- **Change Origin**, **Edit Note**, **Flip Reprint Direction**, and **Create Corresponding Sequence** are disabled.
- **Restore** is disabled after the link has been marked for deletion.

This behavior is applied consistently to:

- Display-database reprints.
- Revisions in the current changeset.
- Approved revision-history rows.
- Both origin-side and target-side renderings.

### Accessibility and disabled-state UX

Disabled controls use the native `disabled` attribute and a visibly inactive button style. They do not retain the active blue color or active hover treatment.

Each disabled control includes:

- Hover text explaining why it is unavailable.
- `aria-describedby` pointing to the visible explanation.
- A smaller, italicized explanation alongside the relevant controls.

Redundant `aria-disabled="true"` attributes were removed where the native `disabled` attribute already supplies the disabled state.

## Tests

Coverage was added for:

- The display-model invariant.
- The revision-model invariant.
- Initial revision cloning for legacy internal links.
- Rejection when a previously valid source is changed into an internal link.
- Rejection of manually entered current-issue and current-story IDs.
- Disabled issue, story, and cover choices in cached selectors.
- The immutable disabled-choice collection.
- Selector exclusions when adding a reprint.
- Graceful rejection of flip, restore, and matching-sequence requests.
- Guarding both matching-sequence endpoints.
- Validation before saving a related `StoryRevision`.
- Story and sequence moves that would create an internal link.
- The complete legacy-link button matrix.
- Display, current-changeset, and approved-revision template branches.
- Origin-side and target-side rendering.
- Disabling **Restore** after marking an internal link for deletion.

## Validation performed

- Focused pytest selection: **52 passed, 5 deselected**
- `python manage.py check --settings=settings_dev`: **no issues** 12 pre-existing silenced messages comprise one development reCAPTCHA test-key check and eleven intentional OI 
preview-proxy accessor clashes.
- Flake8 on the new and changed Python code: clean
- `git diff --check`: clean
- Docker runtime smoke check: HTTP 200
- Live UAT confirmed:
  - Current-issue selector choices are disabled.
  - **Change Target** opens the global selector.
  - The remaining unsafe internal-link actions are disabled.
  - Matching-sequence requests are rejected gracefully.
  - Rejected saves do not save a `StoryRevision`.
  - Accessibility description IDs are unique.

A full-file Flake8 run on `apps/oi/models.py` reports two pre-existing, unrelated violations:

- `apps/oi/models.py:6031:27 E122`
- `apps/oi/models.py:7685:80 E501`

The lines added by this PR are clean.

## Reviewer UAT setup

The development database dump contains useful legacy internal-reprint fixtures, but those objects do not necessarily have the OI revision history required to reserve and edit them.

The separately attached `seed_issue_708_history.py` helper creates the missing development-only history for issue `26941` and the reprints touching it. It is intentionally not included in the branch.

[seed_issue_708_history.py](https://github.com/user-attachments/files/31278157/seed_issue_708_history.py)

Run the helper against a fresh development import before reserving issue `26941`.

### Prerequisites

Follow the Docker repository’s normal database-import procedure, then apply the existing migrations and load the development users:

```bash
docker compose up -d --build web
docker compose run --rm web python gcd-django/manage.py migrate
docker compose run --rm web python gcd-django/manage.py loaddata gcd-django/apps/indexer/fixtures/users.yaml
```

This PR contains no schema changes or new migrations.

### Run the attached helper

From PowerShell:

```powershell
Get-Content -Raw .\seed_issue_708_history.py |
  docker compose exec -T `
    -e DJANGO_SETTINGS_MODULE=settings `
    -e PYTHONPATH=/code/gcd-django `
    web python -
```

From a POSIX shell:

```bash
docker compose exec -T \
  -e DJANGO_SETTINGS_MODULE=settings \
  -e PYTHONPATH=/code/gcd-django \
  web python - < seed_issue_708_history.py
```

On the current UAT data, the two internal fixture IDs are:

- `1487375`
- `1487376`

The helper is transactional and idempotent. Running it again after a successful setup should report that no additional histories were created. It also refuses to seed missing history when one of the affected objects is already locked.

## Manual UAT

1. Start with a fresh imported development database.
2. Apply the existing migrations and load the development users.
3. Run the attached history setup helper before reserving issue `26941`.
4. Sign in as `dexter_1234` with the standard development password.
5. Reserve and edit issue `26941`.
6. Open its reprint-link editing page.
7. Start adding or changing a reprint and inspect the cached-object selector:
   - The current issue’s **Select** button should be disabled.
   - Its sequences and covers should also have disabled **Select** buttons.
   - Disabled buttons should have an inactive color and no active hover treatment.
   - Hover text and the smaller italicized explanation should identify why the choice is unavailable.
8. Enter issue ID `26941`, or a story ID belonging to it, manually:
   - The request should be rejected before an internal reprint can reach the edit/save workflow.
   - The response should not be a server error.
9. Inspect legacy internal links `1487375` and `1487376`:
   - **Change Target** should remain enabled and open the global selector.
   - **Change Origin** should be disabled.
   - **Edit Note** should be disabled.
   - **Flip Reprint Direction** should be disabled.
   - **Create Corresponding Sequence** should be disabled where applicable.
   - **Mark To Delete** should remain enabled.
10. Mark one of the legacy internal links for deletion:
    - The operation should succeed.
    - **Restore** should then be disabled.
11. Verify that a normal reprint between different issues can still be added and edited.
12. Optionally submit stale or direct requests for flip, restore, or matching-sequence actions:
    - They should return the validation message instead of an unhandled exception.
13. Optionally attempt a story or sequence move that would make an existing reprint internal:
    - The move should be rejected before the object is reserved or changed.

## Scope and follow-up

This PR does not:

- Automatically delete or migrate existing internal reprint links.
- Change the existing behavior that may remove internal links when an issue is edited.

The implementation is limited to preventing new internal reprint links, preventing unsafe modifications of legacy ones, and preserving explicit repair and deletion paths.