### PR TITLE
Add core development environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+.env
+.venv
+__pycache__
+*.py[cod]
+.DS_Store
+media
+static_root

--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,7 @@ MYSQL_DATABASE=gcd_dev
 MYSQL_USER=gcd_dev
 MYSQL_PASSWORD=gcd_dev_password
 MYSQL_ROOT_PASSWORD=gcd_dev_root
+
+# Native-only database overrides. Docker services always use db:3306.
+MYSQL_HOST=127.0.0.1
+MYSQL_PORT=3308

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Optional local overrides for the development launcher.
+#
+# Copy this file to .env if you need non-default ports or database credentials.
+# Values are read as literal KEY=VALUE pairs; do not add shell expressions.
+
+COMPOSE_PROJECT_NAME=gcd-django-dev
+GCD_WEB_PORT=8000
+GCD_MYSQL_PORT=3308
+
+MYSQL_DATABASE=gcd_dev
+MYSQL_USER=gcd_dev
+MYSQL_PASSWORD=gcd_dev_password
+MYSQL_ROOT_PASSWORD=gcd_dev_root

--- a/.github/workflows/dev-environment-ci.yml
+++ b/.github/workflows/dev-environment-ci.yml
@@ -59,6 +59,7 @@ jobs:
           sudo apt-get install -y \
             build-essential \
             default-libmysqlclient-dev \
+            git \
             libicu-dev \
             pkg-config
 
@@ -76,6 +77,7 @@ jobs:
       - name: Run application smoke tests
         run: |
           python -m pytest -q \
+            apps/gcd/tests/test_dev_environment_core.py \
             apps/gcd/tests/test_publisher.py \
             apps/gcd/tests/test_series.py \
             apps/gcd/tests/test_issue.py \
@@ -88,3 +90,24 @@ jobs:
           if [ -d apps/api_v2/tests ]; then
             python -m pytest apps/api_v2/tests/ -q
           fi
+
+  compose-smoke:
+    name: Docker Compose core setup
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Start the core stack
+        run: docker compose up --build --wait
+
+      - name: Verify the running environment
+        run: |
+          ./bin/dev doctor
+          curl --fail --silent --show-error http://127.0.0.1:8000/ -o /dev/null
+
+      - name: Stop the core stack
+        if: always()
+        run: docker compose down --volumes

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ settings_local.py
 *.nja
 .idea
 *.iml
+# Local development environment
+.env
+.venv/

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,22 @@
+FROM python:3.13-slim-bookworm
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        default-libmysqlclient-dev \
+        default-mysql-client \
+        git \
+        libicu-dev \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+COPY requirements.txt ./
+RUN python -m pip install --upgrade pip "setuptools<81" \
+    && python -m pip install --no-cache-dir -r requirements.txt
+
+COPY . ./

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ http://groups.google.com/group/gcd-tech/
 
 ## Setting up a Development Environment
 
-We recommend that you use [our Docker-based development environment](https://github.com/GrandComicsDatabase/gcd-django-docker).
+See [the core development environment guide](docs/development/CORE_SETUP.md)
+for the supported Docker and Docker-free local setup.
 
 You can find manual instructions for various platforms using virtual environments for python in the docs directory
 [GCD Docs](https://github.com/GrandComicsDatabase/gcd-django/tree/beta/docs) but they aren't

--- a/apps/gcd/tests/test_dev_environment_core.py
+++ b/apps/gcd/tests/test_dev_environment_core.py
@@ -1,0 +1,91 @@
+"""Contract tests for the one-clone core development environment."""
+
+import subprocess
+from pathlib import Path
+
+import yaml
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _read_project_file(relative_path):
+    """Read a repository file as UTF-8 text."""
+    return (PROJECT_ROOT / relative_path).read_text(encoding='utf-8')
+
+
+def _load_compose_file():
+    """Load the Compose definition under test."""
+    return yaml.safe_load(_read_project_file('compose.yaml'))
+
+
+def _run_dev(*arguments):
+    """Run the development launcher without invoking a shell."""
+    return subprocess.run(
+        [str(PROJECT_ROOT / 'bin' / 'dev'), *arguments],
+        check=False,
+        capture_output=True,
+        cwd=PROJECT_ROOT,
+        text=True,
+    )
+
+
+def test_compose_defines_the_core_services_and_local_only_ports():
+    """The core stack has database, migration, and web services."""
+    compose = _load_compose_file()
+
+    assert compose['name'] == 'gcd-django-dev'
+    assert set(compose['services']) == {'db', 'migrate', 'web'}
+    assert compose['services']['db']['image'] == 'mysql:8.0'
+    assert compose['services']['db']['ports'] == [
+        '127.0.0.1:${GCD_MYSQL_PORT:-3308}:3306'
+    ]
+    assert compose['services']['web']['ports'] == [
+        '127.0.0.1:${GCD_WEB_PORT:-8000}:8000'
+    ]
+    assert compose['services']['db'].get('container_name') is None
+    assert compose['volumes'] == {'mysql_data': None}
+
+
+def test_compose_waits_for_database_and_migrations_before_web_starts():
+    """Startup is health-gated rather than relying on a polling script."""
+    services = _load_compose_file()['services']
+
+    assert services['db']['healthcheck']['test'][0] == 'CMD-SHELL'
+    assert services['migrate']['depends_on']['db'] == {
+        'condition': 'service_healthy'
+    }
+    assert 'migrate --noinput' in services['migrate']['command']
+    assert services['web']['depends_on']['migrate'] == {
+        'condition': 'service_completed_successfully'
+    }
+    assert 'runserver 0.0.0.0:8000' in services['web']['command']
+
+
+def test_development_image_uses_the_supported_python_line():
+    """The Docker image is built from the supported Python release line."""
+    dockerfile = _read_project_file('Dockerfile.dev')
+
+    assert dockerfile.startswith('FROM python:3.13-slim-bookworm')
+    assert 'setuptools<81' in dockerfile
+    assert 'default-libmysqlclient-dev' in dockerfile
+    assert 'git' in dockerfile
+    assert 'libicu-dev' in dockerfile
+
+
+def test_dev_launcher_documents_supported_commands():
+    """The launcher gives contributors a usable command reference."""
+    result = _run_dev('help')
+
+    assert result.returncode == 0
+    assert './bin/dev up' in result.stdout
+    assert '--runtime native' in result.stdout
+    assert 'reset --yes' in result.stdout
+
+
+def test_dev_launcher_refuses_reset_without_explicit_confirmation():
+    """The destructive reset command cannot run accidentally."""
+    result = _run_dev('reset')
+
+    assert result.returncode != 0
+    assert '--yes' in result.stderr

--- a/apps/gcd/tests/test_dev_environment_core.py
+++ b/apps/gcd/tests/test_dev_environment_core.py
@@ -62,6 +62,21 @@ def test_compose_waits_for_database_and_migrations_before_web_starts():
     assert 'runserver 0.0.0.0:8000' in services['web']['command']
 
 
+def test_compose_healthchecks_quote_credentials_and_remain_readable():
+    """Healthchecks safely handle credentials and retain a clear web command."""
+    services = _load_compose_file()['services']
+
+    assert services['db']['healthcheck']['test'] == [
+        'CMD-SHELL',
+        "mysqladmin ping -h localhost -u'$$MYSQL_USER' -p'$$MYSQL_PASSWORD'",
+    ]
+    assert services['web']['healthcheck']['test'] == [
+        'CMD-SHELL',
+        "python -c \"from urllib.request import urlopen; "
+        "urlopen('http://127.0.0.1:8000/', timeout=3)\"",
+    ]
+
+
 def test_development_image_uses_the_supported_python_line():
     """The Docker image is built from the supported Python release line."""
     dockerfile = _read_project_file('Dockerfile.dev')
@@ -89,3 +104,14 @@ def test_dev_launcher_refuses_reset_without_explicit_confirmation():
 
     assert result.returncode != 0
     assert '--yes' in result.stderr
+
+
+def test_dev_launcher_handles_crlf_dotenv_and_native_database_overrides():
+    """The .env parser supports Windows endings and native DB configuration."""
+    launcher = _read_project_file('bin/dev')
+    example_environment = _read_project_file('.env.example')
+
+    assert 'MYSQL_HOST MYSQL_PORT' in launcher
+    assert 'line="${line%$\'\\r\'}"' in launcher
+    assert 'MYSQL_HOST=127.0.0.1' in example_environment
+    assert 'MYSQL_PORT=3308' in example_environment

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# One entry point for the supported local development workflows.
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PYTHON_BIN="${PYTHON:-python}"
+ALLOWED_ENVIRONMENT_VARIABLES=(
+  COMPOSE_PROJECT_NAME GCD_WEB_PORT GCD_MYSQL_PORT MYSQL_DATABASE MYSQL_USER
+  MYSQL_PASSWORD MYSQL_ROOT_PASSWORD
+)
+
+usage() {
+  cat <<'EOF'
+Usage: ./bin/dev [--runtime docker|native] <command> [arguments]
+
+Runtime defaults to docker. Docker is the supported default; native is an
+intentional Docker-free path for a locally installed Python 3.13 and MySQL 8.
+
+Commands:
+  up                  Start the application at http://127.0.0.1:8000
+  down                Stop the Docker stack (native has nothing to stop)
+  test [pytest args]  Run the test suite
+  shell               Open a Django development shell
+  manage <args>       Run a Django management command
+  doctor              Check the selected development environment
+  logs [service]      Follow Docker logs (db, migrate, or web)
+  reset --yes         Destroy Docker data, or flush the native development DB
+  help                Show this command reference
+
+Examples:
+  ./bin/dev up
+  ./bin/dev test apps/gcd/tests
+  ./bin/dev manage createsuperuser
+  ./bin/dev --runtime native up
+EOF
+}
+
+is_allowed_environment_variable() {
+  local key="$1" allowed
+  for allowed in "${ALLOWED_ENVIRONMENT_VARIABLES[@]}"; do
+    [[ "$key" == "$allowed" ]] && return 0
+  done
+  return 1
+}
+
+load_optional_environment() {
+  local environment_file="$PROJECT_ROOT/.env" line key value
+  [[ -f "$environment_file" ]] || return 0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ -z "$line" || "$line" == \#* ]] && continue
+    if [[ ! "$line" =~ ^([A-Z][A-Z0-9_]*)=(.*)$ ]]; then
+      echo "Invalid .env entry (expected KEY=VALUE): $line" >&2
+      exit 2
+    fi
+    key="${BASH_REMATCH[1]}"
+    value="${BASH_REMATCH[2]}"
+    if ! is_allowed_environment_variable "$key"; then
+      echo "Unsupported .env variable: $key" >&2
+      exit 2
+    fi
+    if [[ -z "${!key+x}" ]]; then
+      export "$key=$value"
+    fi
+  done < "$environment_file"
+}
+
+set_defaults() {
+  export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-gcd-django-dev}"
+  export GCD_WEB_PORT="${GCD_WEB_PORT:-8000}"
+  export GCD_MYSQL_PORT="${GCD_MYSQL_PORT:-3308}"
+  export MYSQL_DATABASE="${MYSQL_DATABASE:-gcd_dev}"
+  export MYSQL_USER="${MYSQL_USER:-gcd_dev}"
+  export MYSQL_PASSWORD="${MYSQL_PASSWORD:-gcd_dev_password}"
+  export MYSQL_ROOT_PASSWORD="${MYSQL_ROOT_PASSWORD:-gcd_dev_root}"
+  export DEV_UID="${DEV_UID:-$(id -u)}"
+  export DEV_GID="${DEV_GID:-$(id -g)}"
+}
+
+compose() {
+  docker compose --project-directory "$PROJECT_ROOT" -f "$PROJECT_ROOT/compose.yaml" "$@"
+}
+
+require_docker() {
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "Docker is required for the default runtime. Use --runtime native for Docker-free development." >&2
+    exit 1
+  fi
+  if ! docker info >/dev/null 2>&1; then
+    echo "Docker is installed but its daemon is unavailable. Start Docker Desktop and try again." >&2
+    exit 1
+  fi
+}
+
+require_native_python() {
+  if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+    echo "Python executable not found: $PYTHON_BIN" >&2
+    exit 1
+  fi
+  if ! "$PYTHON_BIN" -c 'import sys; raise SystemExit(sys.version_info[:2] != (3, 13))'; then
+    echo "Native development requires Python 3.13; use PYTHON=/path/to/python3.13." >&2
+    exit 1
+  fi
+}
+
+prepare_docker_application() {
+  compose build web
+  compose up -d --wait db
+}
+
+native_environment() {
+  export DJANGO_SETTINGS_MODULE=settings_dev
+  export MYSQL_HOST="${MYSQL_HOST:-127.0.0.1}"
+  export MYSQL_PORT="${MYSQL_PORT:-$GCD_MYSQL_PORT}"
+}
+
+native_database_name() {
+  "$PYTHON_BIN" -c 'import django; django.setup(); from django.conf import settings; print(settings.DATABASES["default"]["NAME"])'
+}
+
+runtime="docker"
+if [[ "${1:-}" == "--runtime" ]]; then
+  runtime="${2:-}"
+  shift 2
+fi
+if [[ "$runtime" != "docker" && "$runtime" != "native" ]]; then
+  echo "Unknown runtime: $runtime (expected docker or native)" >&2
+  exit 2
+fi
+command="${1:-help}"
+if [[ $# -gt 0 ]]; then shift; fi
+
+load_optional_environment
+set_defaults
+
+case "$command" in
+  help|-h|--help) usage ;;
+  up)
+    if [[ "$runtime" == "docker" ]]; then
+      require_docker
+      compose up --build --wait
+      echo "GCD is available at http://127.0.0.1:${GCD_WEB_PORT}"
+    else
+      require_native_python; native_environment
+      "$PYTHON_BIN" manage.py migrate --noinput
+      exec "$PYTHON_BIN" manage.py runserver "127.0.0.1:${GCD_WEB_PORT}"
+    fi ;;
+  down)
+    if [[ "$runtime" == "docker" ]]; then
+      require_docker; compose down
+    else
+      echo "The native runtime does not manage a background stack."
+    fi ;;
+  test)
+    if [[ "$runtime" == "docker" ]]; then
+      require_docker; prepare_docker_application
+      compose run --rm --no-deps -e MYSQL_USER=root -e MYSQL_PASSWORD="$MYSQL_ROOT_PASSWORD" web python -m pytest "$@"
+    else
+      require_native_python; native_environment; "$PYTHON_BIN" -m pytest "$@"
+    fi ;;
+  shell)
+    if [[ "$runtime" == "docker" ]]; then
+      require_docker; prepare_docker_application
+      compose run --rm --no-deps web python manage.py shell
+    else
+      require_native_python; native_environment; exec "$PYTHON_BIN" manage.py shell
+    fi ;;
+  manage)
+    if [[ $# -eq 0 ]]; then
+      echo "Usage: ./bin/dev manage <Django management command>" >&2; exit 2
+    fi
+    if [[ "$runtime" == "docker" ]]; then
+      require_docker; prepare_docker_application
+      compose run --rm --no-deps web python manage.py "$@"
+    else
+      require_native_python; native_environment; exec "$PYTHON_BIN" manage.py "$@"
+    fi ;;
+  doctor)
+    if [[ "$runtime" == "docker" ]]; then
+      require_docker; compose config --quiet
+      if compose ps --status running --services | grep -qx web; then
+        compose exec -T web python scripts/check_dev_environment.py
+      else
+        echo "Docker configuration is valid. The web service is not running; run ./bin/dev up."
+      fi
+    else
+      require_native_python; native_environment; "$PYTHON_BIN" scripts/check_dev_environment.py
+    fi ;;
+  logs)
+    if [[ "$runtime" != "docker" ]]; then
+      echo "Logs are managed by your native process supervisor or terminal." >&2; exit 2
+    fi
+    require_docker
+    service="${1:-web}"
+    if [[ "$service" != "db" && "$service" != "migrate" && "$service" != "web" ]]; then
+      echo "Unknown service: $service (expected db, migrate, or web)" >&2; exit 2
+    fi
+    compose logs --follow "$service" ;;
+  reset)
+    if [[ "${1:-}" != "--yes" ]]; then
+      echo "reset is destructive; rerun with: ./bin/dev reset --yes" >&2; exit 2
+    fi
+    if [[ "$runtime" == "docker" ]]; then
+      require_docker; compose down --volumes; compose up --build --wait
+    else
+      require_native_python; native_environment
+      database_name="$(native_database_name)"
+      if [[ "$database_name" != "gcd_dev" && "$database_name" != "gcd_django_dev" ]]; then
+        echo "Native reset only permits gcd_dev or gcd_django_dev (got $database_name)." >&2; exit 2
+      fi
+      "$PYTHON_BIN" manage.py flush --noinput
+      "$PYTHON_BIN" manage.py migrate --noinput
+    fi ;;
+  *) echo "Unknown command: $command" >&2; usage >&2; exit 2 ;;
+esac

--- a/bin/dev
+++ b/bin/dev
@@ -7,7 +7,7 @@ PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PYTHON_BIN="${PYTHON:-python}"
 ALLOWED_ENVIRONMENT_VARIABLES=(
   COMPOSE_PROJECT_NAME GCD_WEB_PORT GCD_MYSQL_PORT MYSQL_DATABASE MYSQL_USER
-  MYSQL_PASSWORD MYSQL_ROOT_PASSWORD
+  MYSQL_PASSWORD MYSQL_ROOT_PASSWORD MYSQL_HOST MYSQL_PORT
 )
 
 usage() {
@@ -48,6 +48,7 @@ load_optional_environment() {
   local environment_file="$PROJECT_ROOT/.env" line key value
   [[ -f "$environment_file" ]] || return 0
   while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line%$'\r'}"
     [[ -z "$line" || "$line" == \#* ]] && continue
     if [[ ! "$line" =~ ^([A-Z][A-Z0-9_]*)=(.*)$ ]]; then
       echo "Invalid .env entry (expected KEY=VALUE): $line" >&2

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,65 @@
+name: gcd-django-dev
+
+services:
+  db:
+    image: mysql:8.0
+    environment:
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-gcd_dev}
+      MYSQL_USER: ${MYSQL_USER:-gcd_dev}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-gcd_dev_password}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-gcd_dev_root}
+    ports:
+      - "127.0.0.1:${GCD_MYSQL_PORT:-3308}:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u$$MYSQL_USER -p$$MYSQL_PASSWORD"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+
+  migrate:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    user: "${DEV_UID:-1000}:${DEV_GID:-1000}"
+    working_dir: /workspace
+    volumes:
+      - ./:/workspace
+    environment: &django_environment
+      DJANGO_SETTINGS_MODULE: settings_dev
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-gcd_dev}
+      MYSQL_USER: ${MYSQL_USER:-gcd_dev}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-gcd_dev_password}
+      MYSQL_HOST: db
+      MYSQL_PORT: "3306"
+    depends_on:
+      db:
+        condition: service_healthy
+    command: python manage.py migrate --noinput
+
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    user: "${DEV_UID:-1000}:${DEV_GID:-1000}"
+    working_dir: /workspace
+    volumes:
+      - ./:/workspace
+    environment: *django_environment
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+    command: python manage.py runserver 0.0.0.0:8000
+    ports:
+      - "127.0.0.1:${GCD_WEB_PORT:-8000}:8000"
+    healthcheck:
+      test: ["CMD-SHELL", 'python -c "from urllib.request import urlopen; urlopen(\"http://127.0.0.1:8000/\", timeout=3)"']
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+
+volumes:
+  mysql_data:

--- a/compose.yaml
+++ b/compose.yaml
@@ -13,7 +13,7 @@ services:
     volumes:
       - mysql_data:/var/lib/mysql
     healthcheck:
-      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u$$MYSQL_USER -p$$MYSQL_PASSWORD"]
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u'$$MYSQL_USER' -p'$$MYSQL_PASSWORD'"]
       interval: 5s
       timeout: 5s
       retries: 12
@@ -55,7 +55,7 @@ services:
     ports:
       - "127.0.0.1:${GCD_WEB_PORT:-8000}:8000"
     healthcheck:
-      test: ["CMD-SHELL", 'python -c "from urllib.request import urlopen; urlopen(\"http://127.0.0.1:8000/\", timeout=3)"']
+      test: ["CMD-SHELL", "python -c \"from urllib.request import urlopen; urlopen('http://127.0.0.1:8000/', timeout=3)\""]
       interval: 5s
       timeout: 5s
       retries: 12

--- a/docs/development/CORE_SETUP.md
+++ b/docs/development/CORE_SETUP.md
@@ -1,0 +1,82 @@
+# Core development environment
+
+This is the supported one-clone setup for working on `gcd-django`. It runs the
+application with Python 3.13 and MySQL 8.0. Elasticsearch, sample data, image
+fixtures, and optional service integrations are intentionally outside this
+first setup layer.
+
+## Docker (default)
+
+Install Docker Desktop, clone this repository, and run:
+
+```bash
+./bin/dev up
+```
+
+The application is available at <http://127.0.0.1:8000>. MySQL is available
+only on `127.0.0.1:3308` from the local machine. The database data lives in the
+Docker volume named `gcd-django-dev_mysql_data`.
+
+Useful commands:
+
+```bash
+./bin/dev doctor
+./bin/dev test
+./bin/dev manage createsuperuser
+./bin/dev logs web
+./bin/dev down
+```
+
+To change local ports or development-only credentials, copy `.env.example` to
+`.env` and edit literal `KEY=VALUE` entries. Shell expressions are deliberately
+not evaluated. Do not use production credentials in this file.
+
+`./bin/dev reset --yes` removes the local Docker database volume and starts a
+fresh database. It is intentionally confirmation-gated.
+
+## Native (Docker-free)
+
+Docker is not required. Install Python 3.13, MySQL 8.0 or newer, Git, and the
+system packages needed to compile the project dependencies. Create a database
+and user, then point the launcher at it. The native defaults expect a MySQL
+server exposed on local port 3308 so they work with the Docker database too.
+
+On Ubuntu 24.04, install the build prerequisites with:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y build-essential default-libmysqlclient-dev git libicu-dev pkg-config
+```
+
+On macOS with Homebrew, install them with:
+
+```bash
+brew install icu4c mysql-client pkg-config
+export PKG_CONFIG_PATH="$(brew --prefix icu4c)/lib/pkgconfig:$(brew --prefix mysql-client)/lib/pkgconfig"
+export ICU_VERSION="$(pkg-config --modversion icu-i18n)"
+```
+
+Keep the two `export` lines in the shell session used for dependency
+installation, or add them to the environment activation script for your local
+virtual environment. They allow PyICU to find Homebrew's ICU installation.
+
+```bash
+python3.13 -m venv .venv
+.venv/bin/python -m pip install --upgrade pip "setuptools<81"
+.venv/bin/python -m pip install -r requirements.txt
+
+MYSQL_PORT=3306 PYTHON=.venv/bin/python ./bin/dev --runtime native up
+```
+
+The equivalent native commands are:
+
+```bash
+MYSQL_PORT=3306 PYTHON=.venv/bin/python ./bin/dev --runtime native doctor
+MYSQL_PORT=3306 PYTHON=.venv/bin/python ./bin/dev --runtime native test
+MYSQL_PORT=3306 PYTHON=.venv/bin/python ./bin/dev --runtime native manage createsuperuser
+```
+
+Native `reset --yes` only operates on a database named `gcd_dev` or
+`gcd_django_dev`; it flushes that database and reapplies migrations. Set
+`MYSQL_DATABASE`, `MYSQL_USER`, and `MYSQL_PASSWORD` in your shell or `.env`
+when your local MySQL credentials differ from the development defaults.

--- a/docs/development/CORE_SETUP.md
+++ b/docs/development/CORE_SETUP.md
@@ -51,14 +51,14 @@ sudo apt-get install -y build-essential default-libmysqlclient-dev git libicu-de
 On macOS with Homebrew, install them with:
 
 ```bash
-brew install icu4c mysql-client pkg-config
-export PKG_CONFIG_PATH="$(brew --prefix icu4c)/lib/pkgconfig:$(brew --prefix mysql-client)/lib/pkgconfig"
-export ICU_VERSION="$(pkg-config --modversion icu-i18n)"
+brew install icu4c@78 mysql-client pkgconf
+export PKG_CONFIG_PATH="$(brew --prefix icu4c@78)/lib/pkgconfig:$(brew --prefix mysql-client)/lib/pkgconfig"
 ```
 
-Keep the two `export` lines in the shell session used for dependency
-installation, or add them to the environment activation script for your local
-virtual environment. They allow PyICU to find Homebrew's ICU installation.
+Keep the `export` line in the shell session used for dependency installation,
+or add it to the environment activation script for your local virtual
+environment. Do not set `ICU_VERSION`: PyICU uses `pkg-config` to obtain the
+required compiler and linker flags on macOS.
 
 ```bash
 python3.13 -m venv .venv


### PR DESCRIPTION
## Summary
- add the one-clone Docker Compose development stack and `./bin/dev` launcher
- document supported Docker and Docker-free Python 3.13/MySQL 8 setup paths
- add contract coverage and a Compose smoke job to the development-environment workflow

## Validation
- `./bin/dev up`, `./bin/dev doctor`, and localhost HTTP smoke check
- `./bin/dev test apps/gcd/tests/test_dev_environment_core.py`
- `./bin/dev test apps/gcd/tests/test_publisher.py -q` (43 passed)
- `bash -n bin/dev`, `docker compose config --quiet`, and `git diff --check`

The native launcher is implemented and documented. A complete native macOS dependency install was not run on this machine because its Homebrew ICU/pkg-config prerequisites are not installed; the exact prerequisites are included in the guide.