### PR TITLE
Eliminate N+1 queries in character-order display and editing

### DIFF
--- a/apps/gcd/models/story.py
+++ b/apps/gcd/models/story.py
@@ -1,5 +1,6 @@
 from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
+from django.db.models import Q
 from django.db.models.functions import NullIf
 from django.db.models import Value
 import django.urls as urlresolvers
@@ -15,8 +16,8 @@ from apps.stddata.models import Language
 
 from .gcddata import GcdData, GcdLink
 from .award import ReceivedAward
-from .character import CharacterNameDetail, Group, GroupNameDetail, \
-                       Universe, Multiverse
+from .character import CharacterNameDetail, CharacterRelation, Group, \
+                       GroupNameDetail, Universe, Multiverse
 from .creator import CreatorNameDetail, CreatorSignature
 from .feature import Feature, FeatureLogo, FeatureNameDetail
 from .support_tables import render_publisher
@@ -193,8 +194,52 @@ def _get_reference_universe(story):
     return reference_universe_id
 
 
+def _build_character_identity_cache(appearing_characters):
+    """Load alias and civilian identities for all appearances in one pass."""
+    appearances = list(appearing_characters.select_related(
+        'character__character', 'universe'))
+    character_ids = {
+        appearance.character.character_id for appearance in appearances
+    }
+    relation_rows = CharacterRelation.objects.filter(
+        relation_type_id=2,
+    ).filter(
+        Q(from_character_id__in=character_ids)
+        | Q(to_character_id__in=character_ids)
+    ).values_list('from_character_id', 'to_character_id')
+    civilian_ids = {}
+    alias_ids = {}
+    for from_id, to_id in relation_rows:
+        civilian_ids.setdefault(from_id, set()).add(to_id)
+        alias_ids.setdefault(to_id, set()).add(from_id)
+
+    appearances_by_universe = {}
+    for appearance in appearances:
+        appearances_by_universe.setdefault(appearance.universe_id, []).append(
+            appearance)
+
+    civilian_appearances = {}
+    has_alias = {}
+    for appearance in appearances:
+        same_universe = appearances_by_universe[appearance.universe_id]
+        character_id = appearance.character.character_id
+        same_universe_ids = {
+            item.character.character_id for item in same_universe
+        }
+        civilian_appearances[appearance.id] = [
+            item for item in same_universe
+            if item.character.character_id in
+            civilian_ids.get(character_id, set())
+        ]
+        has_alias[appearance.id] = bool(
+            alias_ids.get(character_id, set()).intersection(same_universe_ids)
+        )
+    return civilian_appearances, has_alias
+
+
 def _process_single_character(character, appearing_characters,
-                              reference_universe_id):
+                              reference_universe_id,
+                              civilian_identity_cache=None):
     universe = None
     if reference_universe_id:
         if character.universe:
@@ -202,12 +247,15 @@ def _process_single_character(character, appearing_characters,
                 universe = character.universe
         else:
             universe = Universe(name='without a universe')
-    civilian_identity = _get_civilian_identity(character,
-                                               appearing_characters)
-    if civilian_identity:
-        civilian_identity = appearing_characters.filter(
-          universe=character.universe,
-          character__character__id__in=civilian_identity)
+    if civilian_identity_cache is None:
+        civilian_identity = _get_civilian_identity(character,
+                                                   appearing_characters)
+        if civilian_identity:
+            civilian_identity = appearing_characters.filter(
+                  universe=character.universe,
+                  character__character__id__in=civilian_identity)
+    else:
+        civilian_identity = civilian_identity_cache.get(character.id, [])
     return (character, civilian_identity, universe)
 
 
@@ -221,6 +269,8 @@ def process_appearing_characters(story):
     groups = story.active_groups
 
     reference_universe_id = _get_reference_universe(story)
+    civilian_identity_cache, has_alias = _build_character_identity_cache(
+        all_appearing_characters)
 
     group_list = []
     processed_appearances_ids = []
@@ -233,7 +283,8 @@ def process_appearing_characters(story):
         for member in in_group.filter(group_name=group.group_name_id,
                                       group_universe=group.universe_id):
             character_list.append(_process_single_character(
-              member, all_appearing_characters, reference_universe_id))
+              member, all_appearing_characters, reference_universe_id,
+              civilian_identity_cache))
             processed_appearances_ids.append(member.id)
         group_list.append((group, group_universe, character_list))
     appearing_characters = all_appearing_characters.exclude(
@@ -241,17 +292,11 @@ def process_appearing_characters(story):
 
     character_list = []
     for character in appearing_characters:
-        alias_identity = set(
-          character.character.character.from_related_character
-                   .filter(relation_type__id=2).values_list('from_character',
-                                                            flat=True))\
-                   .intersection(all_appearing_characters.filter(
-                      universe=character.universe).values_list(
-                      'character__character', flat=True))
-        if alias_identity:
+        if has_alias.get(character.id, False):
             continue
         character_list.append(_process_single_character(
-          character, all_appearing_characters, reference_universe_id))
+          character, all_appearing_characters, reference_universe_id,
+          civilian_identity_cache))
     return (group_list, character_list)
 
 
@@ -269,12 +314,23 @@ def process_ordered_appearing_characters(character_order):
     else:
         field = 'characters'
     through_model = character_order._meta.get_field(field).remote_field.through
-    in_character_order = all_appearing_characters.filter(
-      **{f'{through_model.__name__.lower()}__order': character_order}
-    ).distinct()
+    through_rows = through_model.objects.filter(order=character_order)
+    if field == 'character_revisions':
+        through_rows = through_rows.values(
+            'story_character__story_character_id', 'order_code')
+        order_codes = {
+            row['story_character__story_character_id']: row['order_code']
+            for row in through_rows
+        }
+    else:
+        order_codes = dict(through_rows.values_list(
+            'story_character_id', 'order_code'))
+    in_character_order_ids = set(order_codes)
     groups = story.active_groups
 
     reference_universe_id = _get_reference_universe(story)
+    civilian_identity_cache, has_alias = _build_character_identity_cache(
+        all_appearing_characters)
 
     group_list = []
     processed_appearances_ids = []
@@ -287,21 +343,20 @@ def process_ordered_appearing_characters(character_order):
         ordered_character_list = []
         for member in in_group.filter(group_name=group.group_name_id,
                                       group_universe=group.universe_id):
-            if member in in_character_order:
+            if member.id in in_character_order_ids:
                 ordered_character_list.append((
-                  getattr(character_order,
-                          f'{through_model.__name__.lower()}_set').get(
-                    order=character_order,
-                    story_character=member).order_code, member))
+                    order_codes[member.id], member))
             else:
                 character_list.append(_process_single_character(
-                  member, all_appearing_characters, reference_universe_id))
+                  member, all_appearing_characters, reference_universe_id,
+                  civilian_identity_cache))
             processed_appearances_ids.append(member.id)
         ordered_character_list.sort(key=lambda x: x[0])
         cnt = 0
         for _, member in ordered_character_list:
             character_list.insert(cnt, _process_single_character(
-              member, all_appearing_characters, reference_universe_id))
+              member, all_appearing_characters, reference_universe_id,
+              civilian_identity_cache))
             cnt += 1
         group_list.append((group, group_universe, character_list))
     appearing_characters = all_appearing_characters.exclude(
@@ -310,29 +365,21 @@ def process_ordered_appearing_characters(character_order):
     character_list = []
     ordered_character_list = []
     for character in appearing_characters:
-        alias_identity = set(
-          character.character.character.from_related_character
-                   .filter(relation_type__id=2).values_list('from_character',
-                                                            flat=True))\
-                   .intersection(all_appearing_characters.filter(
-                      universe=character.universe).values_list(
-                      'character__character', flat=True))
-        if alias_identity:
+        if has_alias.get(character.id, False):
             continue
-        if character in in_character_order:
+        if character.id in in_character_order_ids:
             ordered_character_list.append((
-              getattr(character_order,
-                      f'{through_model.__name__.lower()}_set').get(
-                order=character_order,
-                story_character=character).order_code, character))
+                order_codes[character.id], character))
         else:
             character_list.append(_process_single_character(
-              character, all_appearing_characters, reference_universe_id))
+              character, all_appearing_characters, reference_universe_id,
+              civilian_identity_cache))
     ordered_character_list.sort(key=lambda x: x[0])
     cnt = 0
     for _, character in ordered_character_list:
         character_list.insert(cnt, _process_single_character(
-          character, all_appearing_characters, reference_universe_id))
+          character, all_appearing_characters, reference_universe_id,
+          civilian_identity_cache))
         cnt += 1
     return (group_list, character_list)
 

--- a/apps/gcd/models/story.py
+++ b/apps/gcd/models/story.py
@@ -317,9 +317,9 @@ def process_ordered_appearing_characters(character_order):
     through_rows = through_model.objects.filter(order=character_order)
     if field == 'character_revisions':
         through_rows = through_rows.values(
-            'story_character__story_character_id', 'order_code')
+            'story_character_id', 'order_code')
         order_codes = {
-            row['story_character__story_character_id']: row['order_code']
+            row['story_character_id']: row['order_code']
             for row in through_rows
         }
     else:

--- a/apps/oi/models.py
+++ b/apps/oi/models.py
@@ -55,7 +55,7 @@ from apps.gcd.models.gcddata import GcdData, GcdLink
 from apps.gcd.models.issue import issue_descriptor
 from apps.gcd.models.story import show_feature, show_feature_as_text, \
                                   show_characters, show_title, \
-                                  _get_civilian_identity, \
+                                  _build_character_identity_cache, \
                                   CharacterThroughOrder
 from apps.gcd.models.image import CropToFace
 from apps.indexer.views import ErrorWithMessage
@@ -5616,10 +5616,12 @@ class CharacterOrderRevision(Revision):
                                .order_by('id')
         # process characters to have civilians after their aliases
         character_list = _order_civilian_after_alias(story_characters)
+        ordered_character_ids = set(
+            self.character_revisions.values_list('id', flat=True))
         for character in character_list:
             character_id = character[0].id
             # add characters to the list if not already present in the order
-            if not self.character_revisions.filter(id=character_id).exists():
+            if character_id not in ordered_character_ids:
                 character_order_list.append((character[0], order))
                 order += 1
                 # we do not add civilians if their alias is present, so
@@ -5882,24 +5884,17 @@ class StoryArcRelationRevision(Revision):
 
 
 def _order_civilian_after_alias(story_characters):
+    civilian_identity_cache, has_alias = _build_character_identity_cache(
+        story_characters)
+    appearances_by_id = {item.id: item for item in story_characters}
     character_list = []
-    for character in story_characters:
-        alias_identity = set(
-            character.character.character.from_related_character
-                     .filter(relation_type__id=2)
-                     .values_list('from_character', flat=True))\
-                     .intersection(story_characters.filter(
-                                   universe=character.universe).values_list(
-                                   'character__character', flat=True))
-        if alias_identity:
+    for character in civilian_identity_cache:
+        if has_alias.get(character, False):
             continue
-        civilian_identity = _get_civilian_identity(character,
-                                                   story_characters)
-        if civilian_identity:
-            civilian_identity = story_characters.filter(
-                universe=character.universe,
-                character__character__id__in=civilian_identity)
-        character_list.append([character, civilian_identity])
+        character_list.append([
+            appearances_by_id[character],
+            civilian_identity_cache.get(character, []),
+        ])
     return character_list
 
 

--- a/apps/oi/tests/db/test_character_order_revision.py
+++ b/apps/oi/tests/db/test_character_order_revision.py
@@ -196,6 +196,19 @@ def test_display_order_uses_bounded_queries(large_character_order_world):
 
 
 @pytest.mark.django_db
+def test_revision_display_uses_revision_through_ids(large_character_order_world):
+    """Revision ordering matches StoryCharacterRevision IDs correctly."""
+    _, _, revision_with_order = large_character_order_world
+    revision = revision_with_order(
+        ('Gamma', 5), ('Alpha', 10), ('Beta', 15))
+
+    _, characters = revision.process_ordered_appearing_characters()
+
+    assert [item[0].character.name for item in characters[:3]] == [
+        'Gamma', 'Alpha', 'Beta']
+
+
+@pytest.mark.django_db
 def test_edit_order_list_uses_bounded_queries(large_character_order_world):
     """Preparing the edit list does not query once per appearing character."""
     _, _, revision_with_order = large_character_order_world

--- a/apps/oi/tests/db/test_character_order_revision.py
+++ b/apps/oi/tests/db/test_character_order_revision.py
@@ -8,7 +8,7 @@ from django.test.utils import CaptureQueriesContext
 
 from apps.gcd.models import (
     Character, CharacterNameDetail, CharacterOrder, CharacterOrderType,
-    StoryCharacter)
+    CharacterRelation, CharacterRelationType, StoryCharacter)
 from apps.gcd.models.story import CharacterThroughOrder
 from apps.oi.models import (
     CharacterOrderRevision, CharacterThroughOrderRevision, Changeset,
@@ -175,3 +175,57 @@ def test_reconciliation_uses_bounded_queries(large_character_order_world):
 
     # Two reads plus at most one batched delete, update, and insert.
     assert len(queries) <= 5
+
+
+@pytest.mark.django_db
+def test_display_order_uses_bounded_queries(large_character_order_world):
+    """Character-order display does not query once per ordered character."""
+    character_order, _, _ = large_character_order_world
+
+    with CaptureQueriesContext(connection) as queries:
+        result = character_order.process_ordered_appearing_characters()
+
+    assert [item[0].character.name for item in result[1]] == [
+        'Alpha', 'Beta',
+        *['Extra %s' % number for number in range(10)],
+        'Gamma',
+    ]
+    # The count stays bounded as the order grows; this fixture currently uses
+    # thirteen appearing characters.
+    assert len(queries) <= 20
+
+
+@pytest.mark.django_db
+def test_edit_order_list_uses_bounded_queries(large_character_order_world):
+    """Preparing the edit list does not query once per appearing character."""
+    _, _, revision_with_order = large_character_order_world
+    revision = revision_with_order(
+        ('Alpha', 10), ('Beta', 20), ('Gamma', 30),
+        *[('Extra %s' % number, 40 + number * 10)
+          for number in range(10)])
+
+    with CaptureQueriesContext(connection) as queries:
+        result = revision.story_characters()
+
+    assert result
+    assert len(queries) <= 10
+
+
+@pytest.mark.django_db
+def test_display_keeps_alias_and_civilian_order(character_order_world):
+    """Bulk identity loading preserves alias/civilian display behavior."""
+    character_order, appearances, _ = character_order_world
+    relation_type, _ = CharacterRelationType.objects.get_or_create(
+        id=2, defaults={'type': 'civilian identity',
+                        'reverse_type': 'alias'})
+    CharacterRelation.objects.create(
+        from_character=appearances['Alpha'].character.character,
+        to_character=appearances['Gamma'].character.character,
+        relation_type=relation_type,
+        notes='')
+
+    _, characters = character_order.process_ordered_appearing_characters()
+
+    assert [item[0].character.name for item in characters] == [
+        'Alpha', 'Beta']
+    assert [item.character.name for item in characters[0][1]] == ['Gamma']

--- a/apps/oi/views.py
+++ b/apps/oi/views.py
@@ -5701,34 +5701,50 @@ def reorder_characters(request, character_order_id):
     try:
         order_code_boundary = request.POST['order_code_boundary']
         request_post = request.POST.copy()
+        revision_characters = character_order_revision.character_revisions
+        revision_character_ids = set(
+            revision_characters.values_list('id', flat=True))
+        removed_character_ids = []
         for key in request.POST:
             if key.startswith('order_code_') and key != 'order_code_boundary':
                 value = request.POST[key]
                 if value and float(value) >= float(order_code_boundary):
                     request_post.pop(key)
                     character_id = int(key.split('_')[-1])
-                    revision_characters = character_order_revision\
-                        .character_revisions
-                    if revision_characters.filter(id=character_id).exists():
-                        revision_characters.remove(character_id)
+                    if character_id in revision_character_ids:
+                        removed_character_ids.append(character_id)
+                        revision_character_ids.remove(character_id)
+        if removed_character_ids:
+            revision_characters.remove(*removed_character_ids)
         request.POST = request_post
         characters = _process_reorder_form(request, character_order_revision,
                                            'order_code',
                                            'character', StoryCharacterRevision)
         order = 0
+        through_model = revision_characters.through
+        current_through = {
+            row.story_character_id: row
+            for row in through_model.objects.filter(
+                order=character_order_revision)
+        }
+        changed_through = []
+        new_through = []
         for character in characters:
-            revision_characters = character_order_revision.character_revisions
-            if not revision_characters.filter(id=character.id).exists():
-                revision_characters.add(character,
-                                        through_defaults={'order_code': order})
+            through_instance = current_through.get(character.id)
+            if through_instance is None:
+                new_through.append(through_model(
+                    order_id=character_order_revision.id,
+                    story_character_id=character.id,
+                    order_code=order,
+                ))
             else:
-                through_instance = revision_characters.through.objects.get(
-                    order=character_order_revision,
-                    story_character=character
-                )
                 through_instance.order_code = order
-                through_instance.save()
+                changed_through.append(through_instance)
             order += 1
+        if changed_through:
+            through_model.objects.bulk_update(changed_through, ['order_code'])
+        if new_through:
+            through_model.objects.bulk_create(new_through)
         if 'commit_and_changeset' in request.POST:
             return HttpResponseRedirect(urlresolvers.reverse(
               'edit', kwargs={'id': changeset.id}))


### PR DESCRIPTION
## Summary

I eliminated the per-character database queries in character-order display and editing flows.

- Bulk-load character identity and alias relationships once per display/edit operation.
- Bulk-load character-order through rows instead of calling `get()` for each appearance.
- Batch removals, updates, and inserts in the character-order editing view.
- Preserve ordering and alias/civilian display behavior.

## Testing

- `apps/oi/tests/db/test_character_order_revision.py`: 7 passed
- Story/revision compatibility suite: 71 passed
- Added query-bound regression coverage for display and edit preparation.

Closes #731
