### PR TITLE
Use sortable tables for object selection

### DIFF
--- a/apps/oi/tests/test_select_views.py
+++ b/apps/oi/tests/test_select_views.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+
+
+from unittest.mock import patch
+
+import pytest
+
+from django.test import RequestFactory
+
+from apps.gcd.models.issue import IssuePublisherTable
+from apps.gcd.models.publisher import PublisherSearchTable
+from apps.gcd.models.series import SeriesPublisherTable
+from apps.gcd.models.story import StoryTable
+from apps.select.views import process_select_search
+
+
+def selector_request(params, user):
+    request = RequestFactory().get('/select_object/test/search/', params)
+    request.user = user
+    return request
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'select_type, search_param, search_fields, table_class, target',
+    [
+        ('publisher', 'search_publisher', {'publisher': 'Test'},
+         PublisherSearchTable, 'publisher'),
+        ('series', 'search_series', {'series': 'Test'},
+         SeriesPublisherTable, 'series'),
+        ('issue', 'search_issue',
+         {'publisher': 'Test', 'series': 'Test', 'number': '1'},
+         IssuePublisherTable, 'issue'),
+        ('story', 'search_story',
+         {'publisher': 'Test', 'series': 'Test', 'number': '1'},
+         StoryTable, 'story'),
+        ('cover', 'search_cover',
+         {'publisher': 'Test', 'series': 'Test', 'number': '1'},
+         StoryTable, 'story'),
+    ])
+def test_database_selector_uses_sortable_table(
+        select_type, search_param, search_fields, table_class, target,
+        any_indexer):
+    data = {select_type: True}
+    params = {'select_key': 'test', search_param: 'Search'}
+    params.update(search_fields)
+    request = selector_request(params, any_indexer)
+
+    with patch('apps.select.views.get_select_data', return_value=data), \
+            patch('apps.gcd.views.details.generic_sortable_list') as render:
+        process_select_search.__wrapped__(request, 'test')
+
+    table = render.call_args.args[2]
+    context = render.call_args.args[4]
+    assert isinstance(table, table_class)
+    assert context['select_key'] == 'test'
+    assert context['select_target'] == target
+    assert context['select_issue'] is False
+
+
+@pytest.mark.django_db
+def test_publisher_selector_renders_selection_column(any_added_publisher,
+                                                     any_indexer):
+    data = {'publisher': True}
+    request = selector_request({
+        'select_key': 'test',
+        'search_publisher': 'Search',
+        'publisher': any_added_publisher.name,
+    }, any_indexer)
+
+    with patch('apps.select.views.get_select_data', return_value=data):
+        response = process_select_search.__wrapped__(request, 'test')
+
+    body = response.content.decode()
+    assert 'Selection' in body
+    assert 'Select this publisher' in body
+    assert 'publisher_%d' % any_added_publisher.id in body
+
+
+@pytest.mark.django_db
+def test_story_selector_keeps_issue_selection(any_indexer):
+    data = {'story': True, 'issue': True}
+    request = selector_request({
+        'select_key': 'test',
+        'search_story': 'Search',
+        'publisher': 'Test',
+        'series': 'Test',
+        'number': '1',
+    }, any_indexer)
+
+    with patch('apps.select.views.get_select_data', return_value=data), \
+            patch('apps.gcd.views.details.generic_sortable_list') as render:
+        process_select_search.__wrapped__(request, 'test')
+
+    context = render.call_args.args[4]
+    assert context['select_target'] == 'story'
+    assert context['select_issue'] is True
+
+
+@pytest.mark.django_db
+def test_issue_selector_does_not_render_duplicate_issue_action(any_indexer):
+    data = {'issue': True}
+    request = selector_request({
+        'select_key': 'test',
+        'search_issue': 'Search',
+        'publisher': 'Test',
+        'series': 'Test',
+        'number': '1',
+    }, any_indexer)
+
+    with patch('apps.select.views.get_select_data', return_value=data), \
+            patch('apps.gcd.views.details.generic_sortable_list') as render:
+        process_select_search.__wrapped__(request, 'test')
+
+    assert render.call_args.args[4]['select_issue'] is False

--- a/apps/select/views.py
+++ b/apps/select/views.py
@@ -192,10 +192,10 @@ def process_select_search(request, select_key):
     else:
         select_issue = False
 
-    publisher_name = cd['publisher'] if cd['publisher'] else '?'
-    series_name = cd['series'] if cd.get('series') else ''
-    number = cd['number'] if cd.get('number') else ''
-    year = cd['year'] if cd.get('year') else ''
+    publisher_name = cd.get('publisher') or '?'
+    series_name = cd.get('series') or ''
+    number = cd.get('number') or ''
+    year = cd.get('year') or ''
 
     if 'search_story' in request.GET or 'search_cover' in request.GET:
         search = Story.objects.filter(
@@ -297,7 +297,7 @@ def process_select_search(request, select_key):
       'select_target': select_target,
       'select_issue': select_issue and select_target == 'story',
       'no_bulk_edit': True,
-      'publisher': cd['publisher'] if cd['publisher'] else '',
+      'publisher': cd.get('publisher') or '',
       'series': series_name,
       'year': year,
       'number': number

--- a/apps/select/views.py
+++ b/apps/select/views.py
@@ -32,6 +32,10 @@ from apps.gcd.models import Publisher, Series, Issue, Story, StoryType, \
 from apps.stddata.models import Country, Language
 from apps.gcd.templatetags.credits import get_native_language_name
 from apps.gcd.views import paginate_response
+from apps.gcd.models.issue import IssuePublisherTable
+from apps.gcd.models.publisher import PublisherSearchTable
+from apps.gcd.models.series import SeriesPublisherTable
+from apps.gcd.models.story import StoryTable
 from apps.indexer.views import render_error
 from apps.select.forms import get_select_cache_form, get_select_search_form
 
@@ -168,12 +172,14 @@ def process_select_search(request, select_key):
     series = data.get('series', False)
     issue = data.get('issue', False)
     story = data.get('story', False)
+    cover = data.get('cover', False)
     if 'search_series' in request.GET:
         issue = False
     search_form = get_select_search_form(search_publisher=publisher,
                                          search_series=series,
                                          search_issue=issue,
-                                         search_story=story)(request.GET)
+                                         search_story=story,
+                                         search_cover=cover)(request.GET)
     if not search_form.is_valid():
         return HttpResponseRedirect(
           urlresolvers.reverse('select_object',
@@ -186,23 +192,28 @@ def process_select_search(request, select_key):
     else:
         select_issue = False
 
+    publisher_name = cd['publisher'] if cd['publisher'] else '?'
+    series_name = cd['series'] if cd.get('series') else ''
+    number = cd['number'] if cd.get('number') else ''
+    year = cd['year'] if cd.get('year') else ''
+
     if 'search_story' in request.GET or 'search_cover' in request.GET:
         search = Story.objects.filter(
-          issue__number=cd['number'],
+          issue__number=number,
           deleted=False,
-          issue__series__name__icontains=cd['series'],
-          issue__series__publisher__name__icontains=cd['publisher'])
-        publisher = cd['publisher'] if cd['publisher'] else '?'
-        if cd['year']:
-            search = search.filter(issue__series__year_began=cd['year'])
-            heading = '%s (%s, %d series) #%s' % (cd['series'],
-                                                  publisher,
-                                                  cd['year'],
-                                                  cd['number'])
+          issue__series__name__icontains=series_name,
+          issue__series__publisher__name__icontains=cd['publisher']) \
+            .select_related('issue__series__publisher', 'type')
+        if year:
+            search = search.filter(issue__series__year_began=year)
+            heading = '%s (%s, %d series) #%s' % (series_name,
+                                                  publisher_name,
+                                                  year,
+                                                  number)
         else:
-            heading = '%s (%s, ? series) #%s' % (cd['series'],
-                                                 publisher,
-                                                 cd['number'])
+            heading = '%s (%s, ? series) #%s' % (series_name,
+                                                 publisher_name,
+                                                 number)
         if cd['sequence_number']:
             search = search.filter(sequence_number=cd['sequence_number'])
             heading += ', seq.# ' + str(cd['sequence_number'])
@@ -214,70 +225,85 @@ def process_select_search(request, select_key):
         else:
             base_name = 'stor'
             plural_suffix = 'y,ies'
-        template = 'gcd/search/content_list.html'
         heading = 'Search for: ' + heading
         search = search.order_by("issue__series__name",
                                  "issue__series__year_began",
                                  "issue__key_date",
                                  "sequence_number")
+        table_format = StoryTable
+        order_by = 'issue'
+        select_target = 'story'
     elif 'search_issue' in request.GET:
         search = Issue.objects.filter(
-          number=cd['number'],
+          number=number,
           deleted=False,
-          series__name__icontains=cd['series'],
-          series__publisher__name__icontains=cd['publisher'])
-        publisher = cd['publisher'] if cd['publisher'] else '?'
-        if cd['year']:
-            search = search.filter(series__year_began=cd['year'])
-            heading = '%s (%s, %d series) #%s' % (cd['series'], publisher,
-                                                  cd['year'], cd['number'])
+          series__name__icontains=series_name,
+          series__publisher__name__icontains=cd['publisher']) \
+            .select_related('series__publisher')
+        if year:
+            search = search.filter(series__year_began=year)
+            heading = '%s (%s, %d series) #%s' % (series_name, publisher_name,
+                                                  year, number)
         else:
-            heading = '%s (%s, ? series) #%s' % (cd['series'], publisher,
-                                                 cd['number'])
+            heading = '%s (%s, ? series) #%s' % (series_name, publisher_name,
+                                                 number)
         heading = 'matching search for: ' + heading
-        template = 'gcd/search/issue_list.html'
         base_name = 'issue'
         plural_suffix = 's'
         search = search.order_by("series__name", "series__year_began",
                                  "key_date")
+        table_format = IssuePublisherTable
+        order_by = 'issue'
+        select_target = 'issue'
     elif 'search_series' in request.GET:
         search = Series.objects.filter(
           deleted=False,
-          name__icontains=cd['series'],
-          publisher__name__icontains=cd['publisher'])
-        heading = 'Series search for: ' + cd['series']
-        if cd['year']:
-            search = search.filter(year_began=cd['year'])
-            heading = '%s (%s, %d series)' % (cd['series'], publisher,
-                                              cd['year'])
-        template = 'gcd/search/series_list.html'
+          name__icontains=series_name,
+          publisher__name__icontains=cd['publisher']) \
+            .select_related('publisher', 'country', 'language')
+        heading = 'Series search for: ' + series_name
+        if year:
+            search = search.filter(year_began=year)
+            heading = '%s (%s, %d series)' % (series_name, publisher_name,
+                                              year)
         base_name = 'series'
         plural_suffix = ''
         search = search.order_by("name")
+        table_format = SeriesPublisherTable
+        order_by = 'name'
+        select_target = 'series'
     elif 'search_publisher' in request.GET:
         search = Publisher.objects.filter(deleted=False,
-                                          name__icontains=cd['publisher'])
+                                          name__icontains=cd['publisher']) \
+            .select_related('country')
         heading = 'matching search for: ' + cd['publisher']
-        template = 'gcd/search/publisher_list.html'
         base_name = 'publisher'
         plural_suffix = 's'
         search = search.order_by("name")
+        table_format = PublisherSearchTable
+        order_by = 'name'
+        select_target = 'publisher'
 
+    from apps.gcd.views.details import generic_sortable_list
+    table = table_format(
+        search,
+        template_name='gcd/bits/tw_sortable_table.html',
+        order_by=order_by)
     context = {
       'item_name': base_name,
       'plural_suffix': plural_suffix,
-      'items': search,
       'heading': heading,
       'select_key': select_key,
-      'select_issue': select_issue,
+      'select_target': select_target,
+      'select_issue': select_issue and select_target == 'story',
       'no_bulk_edit': True,
-      'query_string': request.META['QUERY_STRING'],
       'publisher': cd['publisher'] if cd['publisher'] else '',
-      'series': cd['series'] if 'series' in cd and cd['series'] else '',
-      'year': cd['year'] if 'year' in cd and cd['year'] else '',
-      'number': cd['number'] if 'number' in cd and cd['number'] else ''
+      'series': series_name,
+      'year': year,
+      'number': number
     }
-    return paginate_response(request, search, template, context)
+    return generic_sortable_list(
+        request, search, table, 'gcd/search/tw_list_sortable.html', context)
 
 
 @permission_required('indexer.can_reserve')

--- a/templates/gcd/bits/tw_sortable_table.html
+++ b/templates/gcd/bits/tw_sortable_table.html
@@ -44,6 +44,13 @@
                 <input type="submit" name="search_select" value="Select this {{ table.context.select_target }}"></input>
                 <input type="hidden" name="object_choice" value="{{ table.context.select_target }}_{{ row.record.id }}"></input>
               </form>
+              {% if table.context.select_issue %}
+              <form action="{% url 'select_object' select_key=table.context.select_key %}" method="POST">
+              {% csrf_token %}
+                <input type="submit" name="search_select" value="Select this issue"></input>
+                <input type="hidden" name="object_choice" value="issue_{{ row.record.issue.id }}"></input>
+              </form>
+              {% endif %}
             </td>
             {% endif %}
             {% for column, cell in row.items %}


### PR DESCRIPTION
## Summary

I routed the database-backed object selector results through the existing sortable django-tables views.

- Publisher, series, issue, story, and cover searches now use the shared table presentation.
- Selection actions keep the existing object IDs and downstream handlers.
- Story selectors retain the separate issue-selection action used by reprints and awards.
- Cover-only searches use the story table while preserving the existing story selection behavior.
- Haystack mixed results and the MyComics multi-select flow remain unchanged.

## Testing

- Selector tests: 8 passed
- Existing story, issue, series, and publisher tests: 118 passed
- Python compilation and diff checks passed

Closes #675
