### PR TITLE
Honor approver collapse preference in review email

### DIFF
--- a/apps/oi/tests/test_views.py
+++ b/apps/oi/tests/test_views.py
@@ -1,0 +1,50 @@
+import pytest
+
+from django.contrib.auth.models import User
+from django.core import mail
+from django.test import override_settings
+from django.urls import reverse
+
+from apps.indexer.models import Indexer
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ('collapse_compare_view', 'url_suffix'),
+    ((None, ''), (False, ''), (True, '?collapse=1')),
+)
+@override_settings(
+    EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend',
+    SITE_URL='https://www.example.com/',
+)
+def test_submit_email_uses_approver_compare_preference(
+        client, any_country, any_indexer, any_added_publisher_rev,
+        collapse_compare_view, url_suffix):
+    approver = User.objects.create_user(
+      'approver', email='approver@example.com', password='approver')
+    if collapse_compare_view is not None:
+        Indexer.objects.create(
+          user=approver,
+          country=any_country,
+          collapse_compare_view=collapse_compare_view)
+
+    changeset = any_added_publisher_rev.changeset
+    changeset.approver = approver
+    changeset.save()
+
+    any_indexer.is_superuser = True
+    any_indexer.save()
+    client.force_login(any_indexer)
+
+    response = client.post(
+      reverse('submit', kwargs={'id': changeset.id}),
+      {'comments': ''})
+
+    assert response.status_code == 302
+    assert len(mail.outbox) == 1
+    compare_url = (
+      f'https://www.example.com/changeset/{changeset.id}/compare/'
+      f'{url_suffix}'
+    )
+    assert f'Please go to {compare_url} to compare the changes.' in (
+      mail.outbox[0].body)

--- a/apps/oi/views.py
+++ b/apps/oi/views.py
@@ -579,6 +579,13 @@ def submit(request, id):
                       comment_text
         else:
             comment = ''
+        compare_url = settings.SITE_URL.rstrip('/') + urlresolvers.reverse(
+          'compare', kwargs={'id': changeset.id})
+        if (hasattr(changeset.approver, 'indexer') and
+                changeset.approver.indexer.collapse_compare_view):
+            # The compare route currently has no query parameters. If any are
+            # added later, merge this parameter instead of appending another ?.
+            compare_url += '?collapse=1'
         email_body = """
 Hello from the %s!
 
@@ -594,8 +601,7 @@ thanks,
                      str(changeset),
                      str(changeset.indexer.indexer),
                      comment,
-                     settings.SITE_URL.rstrip('/') + urlresolvers.reverse(
-                       'compare', kwargs={'id': changeset.id}),
+                     compare_url,
                      settings.SITE_NAME,
                      settings.SITE_URL)
 


### PR DESCRIPTION
## Summary

- honor the assigned approver's collapsed compare-view preference in the “GCD change to review” email
- preserve the existing expanded link when that preference is disabled
- document that the compare route currently has no query parameters and must merge any future ones
- add regression coverage for both preference values

## Testing

- `pytest gcd-django/apps/oi/tests/test_views.py`
- `python manage.py check`
- `python -m flake8 apps/oi/views.py apps/oi/tests/test_views.py`
- `git diff --check`
- mounted runtime health check returned HTTP 200
