### PR TITLE
Add setuptools<81 to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,7 @@ requests<2.33
 simplejson<3.21
 tablib<3.10
 unidecode
+setuptools<81
 
 # REST-API
 djangorestframework


### PR DESCRIPTION
With recent Python versions (3.12+), setuptools is not installed by default. `docs/development/CORE_SETUP.md` does state that `setuptools<81` is needed, but adding it to `requirements.txt` might help if someone doesn't notice?