### PR TITLE
Align requests from daily creators infinite scroll JS with urls.py to avoid redirect

### DIFF
--- a/static/js/infinite_scroll.js
+++ b/static/js/infinite_scroll.js
@@ -20,9 +20,9 @@ const attachInfiniteScroll = (sentinel, scrollElement, baseUrl, addUrl, directio
 
     if (!end && bottomEntry.intersectionRatio > 0) {
       if (direction < 0){
-        var url = `${baseUrl}${addUrl}-${counter + 1}`;
+        var url = `${baseUrl}${addUrl}-${counter + 1}/`;
       } else {
-        var url = `${baseUrl}${addUrl}${counter + 1}`;
+        var url = `${baseUrl}${addUrl}${counter + 1}/`;
       }
       let req = await fetch(url);
 
@@ -43,4 +43,3 @@ const attachInfiniteScroll = (sentinel, scrollElement, baseUrl, addUrl, directio
   })
   observer.observe(sentinel);
 };
-


### PR DESCRIPTION
The infinite scroll of the daily creators section in the front page creates URLs like:
```
https://www.comics.org/daily_creators/offset/-2
```
But `apps/gcd/urls.py` expects a slash at the end (i.e. `'daily_creators/offset/(?P<offset>[-+]?\d{1,3})/$`) and this causes a redirect to the correct request for each update.